### PR TITLE
Proof of concept for parallel requests

### DIFF
--- a/httpcore/client.py
+++ b/httpcore/client.py
@@ -24,6 +24,7 @@ from .models import (
     Response,
     URLTypes,
 )
+from .parallel import Parallel
 
 
 class Client:
@@ -43,6 +44,9 @@ class Client:
             dispatch=auth_adapter, max_redirects=max_redirects
         )
         self.adapter = EnvironmentAdapter(dispatch=redirect_adapter)
+
+    def parallel(self):
+        return Parallel(self)
 
     async def request(
         self,

--- a/httpcore/parallel.py
+++ b/httpcore/parallel.py
@@ -1,0 +1,51 @@
+import asyncio
+import typing
+from types import TracebackType
+
+
+class Parallel:
+    def __init__(self, client):
+        self.client = client
+        self.pending_responses = {}
+
+    def request_soon(self, *args, **kwargs):
+        loop = asyncio.get_event_loop()
+        task = loop.create_task(self.client.request(*args, **kwargs))
+        pending = PendingResponse(task, self.pending_responses)
+        self.pending_responses[task] = pending
+        return pending
+
+    async def next_response(self):
+        tasks = list(self.pending_responses.keys())
+        done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+        task = done.pop()
+        del self.pending_responses[task]
+        return task.result()
+
+    @property
+    def has_pending_responses(self):
+        return bool(self.pending_responses)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(
+        self,
+        exc_type: typing.Type[BaseException] = None,
+        exc_value: BaseException = None,
+        traceback: TracebackType = None,
+    ) -> None:
+        for task in self.pending_responses.keys():
+            task.cancel()
+
+
+class PendingResponse:
+    def __init__(self, task, pending_responses):
+        self.task = task
+        self.pending_responses = pending_responses
+
+    async def get_response(self):
+        try:
+            return await self.task
+        finally:
+            del self.pending_responses[self.task]


### PR DESCRIPTION
To issue a bunch of requests together...

```python
import asyncio
import httpcore

async def lets_go():
    client = httpcore.Client()
    with client.parallel() as p:
        for idx in range(10):
            p.request_soon('GET', 'http://example.com/')

        while p.has_pending_responses:
            r = await p.next_response()
            print(r)

asyncio.run(lets_go())
```

Alternatively, to issue requests in parallel and deal with each as if they'd been issued sequentially...

```python
import asyncio
import httpcore

async def lets_go():
    client = httpcore.Client()
    with client.parallel() as p:
        pending1 = p.request_soon('GET', 'http://example.com/')
        pending2 = p.request_soon('GET', 'http://example.com/')

        r = await pending1.get_response()
        print(r)
        r = await pending2.get_response()
        print(r)

asyncio.run(lets_go())
```

This gets more exciting if we follow through on #51 and go sync first.
(Since we'll be able to provide a standard sync interface, on top of an async parallelization backend)

Very much open to API rejigs on this one. Considerations with why it looks the way it does...

* Strict cancellation once you leave the parallel block.
* Exception handling just fits in with the standard flow.  (Ie. use try/catch around `next_response` or `get_response` if you want it.)