### PR TITLE
Support for streaming Multipart and files

### DIFF
--- a/http3/dispatch/http2.py
+++ b/http3/dispatch/http2.py
@@ -103,6 +103,8 @@ class HTTP2Connection:
     async def send_data(
         self, stream_id: int, data: bytes, timeout: TimeoutConfig = None
     ) -> None:
+        if data == b"":
+            return
         flow_control = self.h2_state.local_flow_control_window(stream_id)
         chunk_size = min(len(data), flow_control)
         for idx in range(0, len(data), chunk_size):

--- a/http3/interfaces.py
+++ b/http3/interfaces.py
@@ -17,6 +17,7 @@ from .models import (
     Response,
     URLTypes,
 )
+from .utils import async_streamify
 
 
 class Protocol(str, enum.Enum):
@@ -204,6 +205,7 @@ class ConcurrencyBackend:
         raise NotImplementedError()  # pragma: no cover
 
     def iterate(self, async_iterator):  # type: ignore
+        async_iterator = async_streamify(async_iterator)
         while True:
             try:
                 yield self.run(async_iterator.__anext__)

--- a/http3/models.py
+++ b/http3/models.py
@@ -604,7 +604,7 @@ class AsyncRequest(BaseRequest):
         else:
             assert hasattr(data, "__aiter__") or hasattr(data, "__iter__")
             self.is_streaming = True
-            self.content_aiter = async_streamify(data)
+            self.content = data
 
         self.prepare()
 
@@ -617,12 +617,8 @@ class AsyncRequest(BaseRequest):
         return self.content
 
     async def stream(self) -> typing.AsyncIterator[bytes]:
-        if self.is_streaming:
-            async for part in self.content_aiter:
-                yield part
-        elif self.content:
-            async for part in async_streamify(self.content):
-                yield part
+        async for part in async_streamify(self.content):
+            yield part
 
 
 class Request(BaseRequest):
@@ -655,7 +651,7 @@ class Request(BaseRequest):
         else:
             assert hasattr(data, "__iter__")
             self.is_streaming = True
-            self.content_iter = streamify(data)
+            self.content = data
 
         self.prepare()
 
@@ -665,12 +661,8 @@ class Request(BaseRequest):
         return self.content
 
     def stream(self) -> typing.Iterator[bytes]:
-        if self.is_streaming:
-            for part in self.content_iter:
-                yield part
-        elif self.content:
-            for part in streamify(self.content):
-                yield part
+        for part in streamify(self.content):
+            yield part
 
 
 class BaseResponse:

--- a/http3/multipart.py
+++ b/http3/multipart.py
@@ -2,41 +2,44 @@ import binascii
 import mimetypes
 import os
 import typing
-from io import BytesIO
 from urllib.parse import quote
+
+from .utils import get_content_length
 
 
 class Field:
     def render_headers(self) -> bytes:
         raise NotImplementedError()  # pragma: nocover
 
-    def render_data(self) -> bytes:
+    def render_data(self) -> typing.Iterable[bytes]:
         raise NotImplementedError()  # pragma: nocover
 
 
 class DataField(Field):
+    __slots__ = ("name", "value")
+
     def __init__(self, name: str, value: str) -> None:
         self.name = name
         self.value = value
 
     def render_headers(self) -> bytes:
         name = quote(self.name, encoding="utf-8").encode("ascii")
-        return b"".join(
-            [b'Content-Disposition: form-data; name="', name, b'"\r\n' b"\r\n"]
-        )
+        return b"".join([b'Content-Disposition: form-data; name="', name, b'"\r\n\r\n'])
 
-    def render_data(self) -> bytes:
-        return self.value.encode("utf-8")
+    def render_data(self) -> typing.Iterable[bytes]:
+        yield self.value.encode("utf-8")
 
 
 class FileField(Field):
+    __slots__ = ("name", "value", "filename", "content_type")
+
     def __init__(
         self, name: str, value: typing.Union[typing.IO[typing.AnyStr], tuple]
     ) -> None:
         self.name = name
         if not isinstance(value, tuple):
             self.filename = os.path.basename(getattr(value, "name", "upload"))
-            self.file = value  # type: typing.Union[typing.IO[str], typing.IO[bytes]]
+            self.file = value  # type: typing.Union[typing.IO[typing.AnyStr]]
             self.content_type = self.guess_content_type()
         else:
             self.filename = value[0]
@@ -58,17 +61,17 @@ class FileField(Field):
                 name,
                 b'"; filename="',
                 filename,
-                b'"\r\n',
-                b"Content-Type: ",
+                b'"\r\nContent-Type: ',
                 content_type,
-                b"\r\n",
-                b"\r\n",
+                b"\r\n\r\n",
             ]
         )
 
-    def render_data(self) -> bytes:
-        content = self.file.read()
-        return content.encode("utf-8") if isinstance(content, str) else content
+    def render_data(self) -> typing.Iterable[bytes]:
+        chunk = self.file.read(16384)
+        while chunk:
+            yield chunk.encode("utf-8") if isinstance(chunk, str) else chunk
+            chunk = self.file.read(16384)
 
 
 def iter_fields(data: dict, files: dict) -> typing.Iterator[Field]:
@@ -83,18 +86,73 @@ def iter_fields(data: dict, files: dict) -> typing.Iterator[Field]:
         yield FileField(name=name, value=value)
 
 
-def multipart_encode(data: dict, files: dict) -> typing.Tuple[bytes, str]:
-    body = BytesIO()
+class _MultipartBody(object):
+    def __init__(self, data: dict, files: dict, boundary: bytes):
+        self._data = data
+        self._files = files
+        self._file_start_offset: typing.Dict[str, int] = {}
+        self._boundary = boundary
+        self._offset: int = 0
+        self._size = None
+        self._finished = False
+
+        self._buffer = bytearray()
+        self._generator = self._create_generator()
+
+    def read(self, amount: int) -> bytes:
+        if amount == 0 or self._finished:
+            return b""
+        data = self._buffer
+        while len(data) < amount:
+            try:
+                data += next(self._generator)
+            except StopIteration:
+                break
+        self._buffer = data[amount:]
+        return bytes(data[:amount])
+
+    def seek(self, offset: int, whence: int):
+        if offset != 0 or whence not in (0, 2):  # pragma: nocover
+            raise NotImplementedError(
+                "MultipartBody only supports seek() to beginning and end"
+            )
+        if whence == 0:
+            self._reset_generator()
+        else:
+            self._finished = True
+            if self._size is None:
+                self._size = (6 + len(self._boundary)) * (
+                    len(self._data) + len(self._files) + 1
+                )
+                for field in iter_fields(self._data, {}):
+                    self._size += len(field.render_headers()) + len(field.value)
+                for field in iter_fields({}, self._files):
+                    self._size += len(field.render_headers()) + get_content_length(
+                        field.file
+                    )
+            self._offset = self._size
+            print(self._size)
+
+    def tell(self) -> int:
+        return self._offset
+
+    def _reset_generator(self):
+        self._offset = 0
+        self._finished = False
+        for name, offset in self._file_start_offset.items():
+            self._files[name].seek(offset, 0)
+        self._generator = self._create_generator()
+
+    def _create_generator(self):
+        for field in iter_fields(self._data, self._files):
+            yield b"--%s\r\n" % self._boundary
+            yield field.render_headers()
+            yield from field.render_data()
+            yield b"\r\n"
+        yield b"--%s--\r\n" % self._boundary
+
+
+def multipart_encode(data: dict, files: dict) -> typing.Tuple[_MultipartBody, str]:
     boundary = binascii.hexlify(os.urandom(16))
-
-    for field in iter_fields(data, files):
-        body.write(b"--%s\r\n" % boundary)
-        body.write(field.render_headers())
-        body.write(field.render_data())
-        body.write(b"\r\n")
-
-    body.write(b"--%s--\r\n" % boundary)
-
-    content_type = "multipart/form-data; boundary=%s" % boundary.decode("ascii")
-
-    return body.getvalue(), content_type
+    content_type = f"multipart/form-data; boundary={boundary.decode('ascii')}"
+    return _MultipartBody(data, files, boundary), content_type

--- a/http3/utils.py
+++ b/http3/utils.py
@@ -29,3 +29,71 @@ def is_known_encoding(encoding: str) -> bool:
     except LookupError:
         return False
     return True
+
+
+def get_content_length(
+    value: typing.Union[typing.AnyStr, typing.IO[typing.AnyStr]]
+) -> int:
+    """
+    Returns the size of str, bytes or a file-like object using tell() and seek()
+    """
+    if hasattr(value, "tell") and hasattr(value, "seek"):
+        start = value.tell()
+        value.seek(0, 2)
+        end = value.tell()
+        value.seek(start, 0)
+        return end - start
+    return len(value)
+
+
+async def async_streamify(
+    value: typing.Union[
+        typing.AnyStr, typing.IO[typing.AnyStr], typing.Iterable[typing.AnyStr]
+    ]
+) -> typing.AsyncIterable[bytes]:
+    """
+    Turns raw data, a file-like object, or an iterable into an iterable of bytes.
+    """
+    if isinstance(value, bytes):
+        yield value
+    elif isinstance(value, str):
+        yield value.encode("utf-8")
+    elif hasattr(value, "read"):
+        chunk = value.read(16384)
+        while chunk:
+            yield chunk if isinstance(chunk, bytes) else chunk.encode("utf-8")
+            chunk = value.read(16384)
+    elif hasattr(value, "__anext__"):
+        while True:
+            try:
+                yield await value.__anext__()
+            except StopAsyncIteration:
+                break
+    elif hasattr(value, "__aiter__"):
+        async for chunk in value:
+            yield chunk if isinstance(chunk, bytes) else chunk.encode("utf-8")
+    else:
+        for chunk in value:
+            yield chunk if isinstance(chunk, bytes) else chunk.encode("utf-8")
+
+
+def streamify(
+    value: typing.Union[
+        typing.AnyStr, typing.IO[typing.AnyStr], typing.Iterable[typing.AnyStr]
+    ]
+) -> typing.Iterable[bytes]:
+    """
+    Turns raw data, a file-like object, or an iterable into an iterable of bytes.
+    """
+    if isinstance(value, bytes):
+        yield value
+    elif isinstance(value, str):
+        yield value.encode("utf-8")
+    elif hasattr(value, "read"):
+        chunk = value.read(16384)
+        while chunk:
+            yield chunk if isinstance(chunk, bytes) else chunk.encode("utf-8")
+            chunk = value.read(16384)
+    else:
+        for chunk in value:
+            yield chunk if isinstance(chunk, bytes) else chunk.encode("utf-8")

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -1,3 +1,5 @@
+import io
+
 import pytest
 
 import http3
@@ -61,6 +63,17 @@ async def test_stream_request(server):
             "POST", "http://127.0.0.1:8000/", data=hello_world()
         )
     assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_file_as_data(server):
+    async with http3.AsyncClient() as client:
+        response = await client.request(
+            "POST", "http://127.0.0.1:8000/echo_body", data=io.BytesIO(b"Hello")
+        )
+
+        assert response.status_code == 200
+        assert response.content == b"Hello"
 
 
 @pytest.mark.asyncio

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1,5 +1,6 @@
 import asyncio
 import functools
+import io
 
 import pytest
 
@@ -74,6 +75,17 @@ def test_stream_iterator(server):
     for chunk in response.stream():
         body += chunk
     assert body == b"Hello, world!"
+
+
+@threadpool
+def test_file_as_data(server):
+    with http3.Client() as client:
+        response = client.request(
+            "POST", "http://127.0.0.1:8000/echo_body", data=io.BytesIO(b"Hello")
+        )
+
+        assert response.status_code == 200
+        assert response.content == b"Hello"
 
 
 @threadpool


### PR DESCRIPTION
Here's my first extremely rough stab at allowing us to support passing a file-like object to `data=` parameter in addition to not loading multipart `files` parameters completely into memory before sending.

You're going to have to be rough on me for the first few reviews because I've only looked at the codebase for ~3 hours. Lots to learn! :sweat_smile:

Fixes #114 