### PR TITLE
Add RequestDataIter for normalizing streams, iterators

### DIFF
--- a/http3/client.py
+++ b/http3/client.py
@@ -284,7 +284,9 @@ class BaseClient:
         """
         if method != request.method and method == "GET":
             return b""
-        return request.content.rewind()
+        if request.content.seekable:
+            request.content.seek(0, 0)
+        return request.content.data()
 
 
 class AsyncClient(BaseClient):

--- a/http3/client.py
+++ b/http3/client.py
@@ -276,15 +276,15 @@ class BaseClient:
             del headers["Authorization"]
         return headers
 
-    def redirect_content(self, request: AsyncRequest, method: str) -> bytes:
+    def redirect_content(
+        self, request: AsyncRequest, method: str
+    ) -> typing.Union[bytes, typing.IO[typing.AnyStr]]:
         """
         Return the body that should be used for the redirect request.
         """
         if method != request.method and method == "GET":
             return b""
-        if request.is_streaming:
-            raise RedirectBodyUnavailable()
-        return request.content
+        return request.content.rewind()
 
 
 class AsyncClient(BaseClient):

--- a/http3/exceptions.py
+++ b/http3/exceptions.py
@@ -76,8 +76,8 @@ class TooManyRedirects(RedirectError):
 
 class RedirectBodyUnavailable(RedirectError):
     """
-    Got a redirect response, but the request body was streaming, and is
-    no longer available.
+    Got a redirect response, but the request body was streaming or
+    could not be rewound, and is no longer available.
     """
 
 

--- a/http3/models.py
+++ b/http3/models.py
@@ -32,11 +32,11 @@ from .exceptions import (
 from .multipart import multipart_encode
 from .status_codes import StatusCode
 from .utils import (
+    get_content_length,
     guess_json_utf,
     is_known_encoding,
     normalize_header_key,
     normalize_header_value,
-get_content_length
 )
 
 URLTypes = typing.Union["URL", str]
@@ -565,7 +565,9 @@ class BaseRequest:
             else:
                 content_length = get_content_length(content)
                 if content_length:
-                    auto_headers.append((b"content-length", str(content_length).encode()))
+                    auto_headers.append(
+                        (b"content-length", str(content_length).encode())
+                    )
         if not has_accept_encoding:
             auto_headers.append((b"accept-encoding", ACCEPT_ENCODING.encode()))
         if not has_connection:

--- a/http3/models.py
+++ b/http3/models.py
@@ -59,7 +59,12 @@ AuthTypes = typing.Union[
 ]
 
 AsyncRequestData = typing.Union[
-    dict, str, bytes, typing.Iterator[typing.AnyStr], typing.AsyncIterator[typing.AnyStr], typing.IO[typing.AnyStr]
+    dict,
+    str,
+    bytes,
+    typing.Iterator[typing.AnyStr],
+    typing.AsyncIterator[typing.AnyStr],
+    typing.IO[typing.AnyStr],
 ]
 
 RequestData = typing.Union[

--- a/http3/utils.py
+++ b/http3/utils.py
@@ -64,3 +64,14 @@ def guess_json_utf(data: bytes) -> typing.Optional[str]:
             return "utf-32-le"
         # Did not detect a valid UTF-32 ascii-range character
     return None
+
+
+def get_content_length(value: typing.Union[bytes, typing.IO[typing.AnyStr]]) -> int:
+    if isinstance(value, bytes):
+        return len(value)
+    else:
+        start = value.tell()
+        value.seek(0, 2)
+        end = value.tell()
+        value.seek(start, 0)
+        return end - start

--- a/tests/dispatch/test_http2.py
+++ b/tests/dispatch/test_http2.py
@@ -12,7 +12,7 @@ def app(request):
         {
             "method": request.method,
             "path": request.url.path,
-            "body": request.content.decode(),
+            "body": request.read().decode(),
         }
     ).encode()
     headers = {"Content-Length": str(len(content))}

--- a/tests/models/test_requests.py
+++ b/tests/models/test_requests.py
@@ -22,14 +22,14 @@ def test_url_encoded_data():
     for RequestClass in (http3.Request, http3.AsyncRequest):
         request = RequestClass("POST", "http://example.org", data={"test": "123"})
         assert request.headers["Content-Type"] == "application/x-www-form-urlencoded"
-        assert request.content.chunk() == b"test=123"
+        assert request.content._wrapped.read() == b"test=123"
 
 
 def test_json_encoded_data():
     for RequestClass in (http3.Request, http3.AsyncRequest):
         request = RequestClass("POST", "http://example.org", json={"test": 123})
         assert request.headers["Content-Type"] == "application/json"
-        assert request.content.chunk() == b'{"test": 123}'
+        assert request.content._wrapped.read() == b'{"test": 123}'
 
 
 def test_transfer_encoding_header():

--- a/tests/models/test_requests.py
+++ b/tests/models/test_requests.py
@@ -22,14 +22,14 @@ def test_url_encoded_data():
     for RequestClass in (http3.Request, http3.AsyncRequest):
         request = RequestClass("POST", "http://example.org", data={"test": "123"})
         assert request.headers["Content-Type"] == "application/x-www-form-urlencoded"
-        assert request.content == b"test=123"
+        assert request.content.chunk() == b"test=123"
 
 
 def test_json_encoded_data():
     for RequestClass in (http3.Request, http3.AsyncRequest):
         request = RequestClass("POST", "http://example.org", json={"test": 123})
         assert request.headers["Content-Type"] == "application/json"
-        assert request.content == b'{"test": 123}'
+        assert request.content.chunk() == b'{"test": 123}'
 
 
 def test_transfer_encoding_header():


### PR DESCRIPTION
Makes it so you can pass iterators, async iterators, open files and file-like objects, and raw strings as `data`. Do we need `Request.is_streaming` anymore?