### PR TITLE
Additional HTTP Status Codes 418, 451

### DIFF
--- a/httpx/status_codes.py
+++ b/httpx/status_codes.py
@@ -13,6 +13,8 @@ class StatusCode(IntEnum):
         * RFC 2295: Transparent Content Negotiation in HTTP
         * RFC 2774: An HTTP Extension Framework
         * RFC 7540: Hypertext Transfer Protocol Version 2 (HTTP/2)
+        * RFC 2324: Hyper Text Coffee Pot Control Protocol (HTCPCP/1.0)
+        * RFC 7725: An HTTP Status Code to Report Legal Obstacles
     """
 
     def __new__(cls, value: int, phrase: str = "") -> "StatusCode":
@@ -101,6 +103,7 @@ class StatusCode(IntEnum):
     UNSUPPORTED_MEDIA_TYPE = 415, "Unsupported Media Type"
     REQUESTED_RANGE_NOT_SATISFIABLE = 416, "Requested Range Not Satisfiable"
     EXPECTATION_FAILED = 417, "Expectation Failed"
+    I_AM_A_TEAPOT = 418, "I'm a teapot"
     MISDIRECTED_REQUEST = 421, "Misdirected Request"
     UNPROCESSABLE_ENTITY = 422, "Unprocessable Entity"
     LOCKED = 423, "Locked"
@@ -109,6 +112,7 @@ class StatusCode(IntEnum):
     PRECONDITION_REQUIRED = 428, "Precondition Required"
     TOO_MANY_REQUESTS = 429, "Too Many Requests"
     REQUEST_HEADER_FIELDS_TOO_LARGE = 431, "Request Header Fields Too Large"
+    UNAVAILABLE_FOR_LEGAL_REASONS = 451, "Unavailable For Legal Reasons"
 
     # server errors
     INTERNAL_SERVER_ERROR = 500, "Internal Server Error"

--- a/httpx/status_codes.py
+++ b/httpx/status_codes.py
@@ -103,7 +103,7 @@ class StatusCode(IntEnum):
     UNSUPPORTED_MEDIA_TYPE = 415, "Unsupported Media Type"
     REQUESTED_RANGE_NOT_SATISFIABLE = 416, "Requested Range Not Satisfiable"
     EXPECTATION_FAILED = 417, "Expectation Failed"
-    I_AM_A_TEAPOT = 418, "I'm a teapot"
+    IM_A_TEAPOT = 418, "I'm a teapot"
     MISDIRECTED_REQUEST = 421, "Misdirected Request"
     UNPROCESSABLE_ENTITY = 422, "Unprocessable Entity"
     LOCKED = 423, "Locked"


### PR DESCRIPTION
The status codes 418 and 451 are defined in RFCs 2324 and 7725, and are both fun and practical. I've used 418 as a testing status during development, and 451 is a reasonable inclusion given GDPR and other privacy and legal-related reasons content may be unavailable.

For reference, [Golang][1] and [Symphony][2] implement both, and other languages and frameworks such as [Ruby][3] and [Starlette][4] implement at least one (451).

Both are also documented in the [MDN developer docs][5], so may I should make a PR to Starlette next to add support for 418. :smiley: 

[1]: https://golang.org/src/net/http/status.go
[2]: https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpFoundation/Response.php
[3]: https://ruby-doc.org/stdlib-2.6.3/libdoc/net/http/rdoc/Net/HTTP.html#class-Net::HTTP-label-HTTP+Response+Classes
[4]: https://github.com/encode/starlette/blob/master/starlette/status.py#L49
[5]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status