### PR TITLE
Add __truediv__ and __rtruediv__ functions to URL

### DIFF
--- a/httpx/models.py
+++ b/httpx/models.py
@@ -214,6 +214,12 @@ class URL:
         url_str = str(self)
         return f"{class_name}({url_str!r})"
 
+    def __truediv__(self, right):
+        return self.join(URL(right, allow_relative=True))
+
+    def __rtruediv__(self, left):
+        return URL(left).join(self)
+
 
 class Origin:
     """

--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -25,7 +25,7 @@ def test_url():
     assert new.scheme == "http"
 
 
-def test_url__params():
+def test_url_params():
     url = URL("https://example.org:123/path/to/somewhere", params={"a": "123"})
     assert str(url) == "https://example.org:123/path/to/somewhere?a=123"
 
@@ -42,3 +42,40 @@ def test_url_set():
     url_set = set(urls)
 
     assert all(url in urls for url in url_set)
+
+
+def test_url_div():
+    url = URL("http://www.example.com/path/to/file.ext?query#fragment")
+
+    assert str("http://example.org" / url) == str(url)
+    assert str("http://example.org/over/the/rainbow" / url) == str(url)
+
+    assert (
+        str(url / "https://secure.example.com/path")
+        == "https://secure.example.com/path"
+    )
+    assert str(url / "/changed/path") == "http://www.example.com/changed/path"
+    assert (
+        str(URL("http://example.com/base/") / "path/to/file")
+        == "http://example.com/base/path/to/file"
+    )
+    assert (
+        str(URL("http://example.com/no/trailing/slash/base") / "path/to/file")
+        == "http://example.com/no/trailing/slash/path/to/file"
+    )
+    assert (
+        str(
+            URL("http://example.com/path/?q")
+            / URL("http://localhost/app/?q")
+            / URL("to/content", allow_relative=True)
+        )
+        == "http://localhost/app/to/content"
+    )
+
+    assert (
+        str(URL("http://example.com/name/") / "\u65e5\u672c\u8a9e/\u540d\u524d")
+        == "http://example.com/name/%E6%97%A5%E6%9C%AC%E8%AA%9E/%E5%90%8D%E5%89%8D"
+    )
+
+    url = URL("s3://mybucket") / "some_folder/123_2017-10-30T18:43:11.csv.gz"
+    assert str(url) == "s3://mybucket/some_folder/123_2017-10-30T18:43:11.csv.gz"


### PR DESCRIPTION
To allow pathlib-like concatenation: https://github.com/python/cpython/blob/master/Lib/pathlib.py#L909-L913

This will allow me to stop using https://pypi.org/project/urlpath/ in favor of httpx.URL, and thus consolidate my dependencies.

Added using the pre-existing `.join` method, and stole several tests from [urlpath](https://github.com/chrono-meter/urlpath/blob/master/test/test_url.py#L43) to verify functionality.