### PR TITLE
Allow string comparison for URL().__eq__

### DIFF
--- a/httpx/models.py
+++ b/httpx/models.py
@@ -204,7 +204,7 @@ class URL:
         return hash(str(self))
 
     def __eq__(self, other: typing.Any) -> bool:
-        return isinstance(other, URL) and str(self) == str(other)
+        return isinstance(other, (URL, str)) and str(self) == str(other)
 
     def __str__(self) -> str:
         return self.components.unsplit()

--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -25,6 +25,12 @@ def test_url():
     assert new.scheme == "http"
 
 
+def test_url_eq_str():
+    url = URL("https://example.org:123/path/to/somewhere?abc=123#anchor")
+    assert url == "https://example.org:123/path/to/somewhere?abc=123#anchor"
+    assert str(url) == url
+
+
 def test_url__params():
     url = URL("https://example.org:123/path/to/somewhere", params={"a": "123"})
     assert str(url) == "https://example.org:123/path/to/somewhere?a=123"


### PR DESCRIPTION
Resolves #113

This turned out to be super easy, as casting a `str` to a `str` is idempotent, so adding `str` to the isinstance check allows it to pass equality checks with `str`s.