### PR TITLE
Check disconnections on connection reacquiry

### DIFF
--- a/httpx/concurrency.py
+++ b/httpx/concurrency.py
@@ -108,6 +108,9 @@ class Reader(BaseReader):
 
         return data
 
+    def is_connection_dropped(self) -> bool:
+        return self.stream_reader.at_eof()
+
 
 class Writer(BaseWriter):
     def __init__(self, stream_writer: asyncio.StreamWriter, timeout: TimeoutConfig):

--- a/httpx/dispatch/connection.py
+++ b/httpx/dispatch/connection.py
@@ -102,3 +102,10 @@ class HTTPConnection(AsyncDispatcher):
         else:
             assert self.h11_connection is not None
             return self.h11_connection.is_closed
+
+    def is_connection_dropped(self) -> bool:
+        if self.h2_connection is not None:
+            return self.h2_connection.is_connection_dropped()
+        else:
+            assert self.h11_connection is not None
+            return self.h11_connection.is_connection_dropped()

--- a/httpx/dispatch/connection_pool.py
+++ b/httpx/dispatch/connection_pool.py
@@ -9,7 +9,7 @@ from ..config import (
     TimeoutTypes,
     VerifyTypes,
 )
-from ..exceptions import ConnectionClosedByRemote, NotConnected
+from ..exceptions import NotConnected
 from ..interfaces import AsyncDispatcher, ConcurrencyBackend
 from ..models import AsyncRequest, AsyncResponse, Origin
 from .connection import HTTPConnection
@@ -121,10 +121,7 @@ class ConnectionPool(AsyncDispatcher):
             except BaseException as exc:
                 self.active_connections.remove(connection)
                 self.max_connections.release()
-                if (
-                    isinstance(exc, (NotConnected, ConnectionClosedByRemote))
-                    and allow_connection_reuse
-                ):
+                if isinstance(exc, NotConnected) and allow_connection_reuse:
                     connection = None
                     allow_connection_reuse = False
                 else:

--- a/httpx/dispatch/connection_pool.py
+++ b/httpx/dispatch/connection_pool.py
@@ -9,7 +9,7 @@ from ..config import (
     TimeoutTypes,
     VerifyTypes,
 )
-from ..exceptions import NotConnected
+from ..exceptions import NotConnected, ConnectionClosedByRemote
 from ..interfaces import AsyncDispatcher, ConcurrencyBackend
 from ..models import AsyncRequest, AsyncResponse, Origin
 from .connection import HTTPConnection
@@ -121,7 +121,10 @@ class ConnectionPool(AsyncDispatcher):
             except BaseException as exc:
                 self.active_connections.remove(connection)
                 self.max_connections.release()
-                if isinstance(exc, NotConnected) and allow_connection_reuse:
+                if (
+                    isinstance(exc, (NotConnected, ConnectionClosedByRemote))
+                    and allow_connection_reuse
+                ):
                     connection = None
                     allow_connection_reuse = False
                 else:

--- a/httpx/dispatch/connection_pool.py
+++ b/httpx/dispatch/connection_pool.py
@@ -9,7 +9,7 @@ from ..config import (
     TimeoutTypes,
     VerifyTypes,
 )
-from ..exceptions import NotConnected, ConnectionClosedByRemote
+from ..exceptions import ConnectionClosedByRemote, NotConnected
 from ..interfaces import AsyncDispatcher, ConcurrencyBackend
 from ..models import AsyncRequest, AsyncResponse, Origin
 from .connection import HTTPConnection

--- a/httpx/dispatch/http11.py
+++ b/httpx/dispatch/http11.py
@@ -4,7 +4,7 @@ import h11
 
 from ..concurrency import TimeoutFlag
 from ..config import TimeoutConfig, TimeoutTypes
-from ..exceptions import NotConnected
+from ..exceptions import NotConnected, ConnectionClosedByRemote
 from ..interfaces import BaseReader, BaseWriter, ConcurrencyBackend
 from ..models import AsyncRequest, AsyncResponse
 
@@ -166,6 +166,9 @@ class HTTP11Connection:
                     )
                 except OSError:  # pragma: nocover
                     data = b""
+                if self.h11_state.their_state == h11.SEND_RESPONSE and data == b"":
+                    # the server closed a keep-alive connection
+                    raise ConnectionClosedByRemote
                 self.h11_state.receive_data(data)
             else:
                 break

--- a/httpx/dispatch/http11.py
+++ b/httpx/dispatch/http11.py
@@ -4,7 +4,7 @@ import h11
 
 from ..concurrency import TimeoutFlag
 from ..config import TimeoutConfig, TimeoutTypes
-from ..exceptions import NotConnected, ConnectionClosedByRemote
+from ..exceptions import ConnectionClosedByRemote, NotConnected
 from ..interfaces import BaseReader, BaseWriter, ConcurrencyBackend
 from ..models import AsyncRequest, AsyncResponse
 

--- a/httpx/dispatch/http11.py
+++ b/httpx/dispatch/http11.py
@@ -157,6 +157,8 @@ class HTTP11Connection:
         """
         Read a single `h11` event, reading more data from the network if needed.
         """
+        if self.reader.is_connection_dropped():
+            raise NotConnected
         while True:
             event = self.h11_state.next_event()
             if event is h11.NEED_DATA:
@@ -166,9 +168,6 @@ class HTTP11Connection:
                     )
                 except OSError:  # pragma: nocover
                     data = b""
-                if self.h11_state.their_state == h11.SEND_RESPONSE and data == b"":
-                    # the server closed a keep-alive connection
-                    raise NotConnected
                 self.h11_state.receive_data(data)
             else:
                 break

--- a/httpx/dispatch/http11.py
+++ b/httpx/dispatch/http11.py
@@ -4,7 +4,7 @@ import h11
 
 from ..concurrency import TimeoutFlag
 from ..config import TimeoutConfig, TimeoutTypes
-from ..exceptions import ConnectionClosedByRemote, NotConnected
+from ..exceptions import NotConnected
 from ..interfaces import BaseReader, BaseWriter, ConcurrencyBackend
 from ..models import AsyncRequest, AsyncResponse
 
@@ -168,7 +168,7 @@ class HTTP11Connection:
                     data = b""
                 if self.h11_state.their_state == h11.SEND_RESPONSE and data == b"":
                     # the server closed a keep-alive connection
-                    raise ConnectionClosedByRemote
+                    raise NotConnected
                 self.h11_state.receive_data(data)
             else:
                 break

--- a/httpx/dispatch/http11.py
+++ b/httpx/dispatch/http11.py
@@ -117,6 +117,8 @@ class HTTP11Connection:
         Send a single `h11` event to the network, waiting for the data to
         drain before returning.
         """
+        if self.reader.is_connection_dropped():
+            raise NotConnected
         bytes_to_send = self.h11_state.send(event)
         await self.writer.write(bytes_to_send, timeout)
 

--- a/httpx/dispatch/http2.py
+++ b/httpx/dispatch/http2.py
@@ -6,7 +6,6 @@ import h2.events
 
 from ..concurrency import TimeoutFlag
 from ..config import TimeoutConfig, TimeoutTypes
-from ..exceptions import NotConnected
 from ..interfaces import BaseReader, BaseWriter, ConcurrencyBackend
 from ..models import AsyncRequest, AsyncResponse
 
@@ -39,10 +38,7 @@ class HTTP2Connection:
         if not self.initialized:
             self.initiate_connection()
 
-        try:
-            stream_id = await self.send_headers(request, timeout)
-        except ConnectionResetError:
-            raise NotConnected() from None
+        stream_id = await self.send_headers(request, timeout)
 
         self.events[stream_id] = []
         self.timeout_flags[stream_id] = TimeoutFlag()
@@ -176,3 +172,6 @@ class HTTP2Connection:
     @property
     def is_closed(self) -> bool:
         return False
+
+    def is_connection_dropped(self) -> bool:
+        return self.reader.is_connection_dropped()

--- a/httpx/exceptions.py
+++ b/httpx/exceptions.py
@@ -34,13 +34,6 @@ class PoolTimeout(Timeout):
 # HTTP exceptions...
 
 
-class NotConnected(Exception):
-    """
-    A connection was lost at the point of starting a request,
-    prior to any writes succeeding.
-    """
-
-
 class HttpError(Exception):
     """
     An HTTP error occurred.

--- a/httpx/exceptions.py
+++ b/httpx/exceptions.py
@@ -120,6 +120,12 @@ class ResponseClosed(StreamException):
     """
 
 
+class ConnectionClosedByRemote(StreamException):
+    """
+    The remote server closed the connection, typically after a timeout.
+    """
+
+
 # Other cases...
 
 

--- a/httpx/exceptions.py
+++ b/httpx/exceptions.py
@@ -120,12 +120,6 @@ class ResponseClosed(StreamException):
     """
 
 
-class ConnectionClosedByRemote(StreamException):
-    """
-    The remote server closed the connection, typically after a timeout.
-    """
-
-
 # Other cases...
 
 

--- a/httpx/interfaces.py
+++ b/httpx/interfaces.py
@@ -130,6 +130,9 @@ class BaseReader:
     ) -> bytes:
         raise NotImplementedError()  # pragma: no cover
 
+    def is_connection_dropped(self) -> bool:
+        raise NotImplementedError()  # pragma: no cover
+
 
 class BaseWriter:
     """

--- a/tests/dispatch/test_connection_pools.py
+++ b/tests/dispatch/test_connection_pools.py
@@ -131,3 +131,21 @@ async def test_premature_response_close(server):
         await response.close()
         assert len(http.active_connections) == 0
         assert len(http.keepalive_connections) == 0
+
+
+@pytest.mark.asyncio
+async def test_keepalive_connection_closed_by_server_is_reestablished(server):
+    """
+    Upon keep-alive connection closed by remote a new connection should be reestablished.
+    """
+    async with httpx.ConnectionPool() as http:
+        response = await http.request("GET", "http://127.0.0.1:8000/")
+        await response.read()
+
+        await server.shutdown()  # shutdown the server to close the keep-alive connection
+        await server.startup()
+
+        response = await http.request("GET", "http://127.0.0.1:8000/")
+        await response.read()
+        assert len(http.active_connections) == 0
+        assert len(http.keepalive_connections) == 1

--- a/tests/dispatch/test_http2.py
+++ b/tests/dispatch/test_http2.py
@@ -76,3 +76,22 @@ def test_http2_reconnect():
 
     assert response_2.status_code == 200
     assert json.loads(response_2.content) == {"method": "GET", "path": "/2", "body": ""}
+
+
+def test_http2_reconnect_after_remote_closed_connection():
+    """
+    If a connection has been closed between requests, then we should
+    be seemlessly reconnected.
+    """
+    backend = MockHTTP2Backend(app=app)
+
+    with Client(backend=backend) as client:
+        response_1 = client.get("http://example.org/1")
+        backend.server.close_connection = True
+        response_2 = client.get("http://example.org/2")
+
+    assert response_1.status_code == 200
+    assert json.loads(response_1.content) == {"method": "GET", "path": "/1", "body": ""}
+
+    assert response_2.status_code == 200
+    assert json.loads(response_2.content) == {"method": "GET", "path": "/2", "body": ""}

--- a/tests/dispatch/test_http2.py
+++ b/tests/dispatch/test_http2.py
@@ -68,25 +68,6 @@ def test_http2_reconnect():
 
     with Client(backend=backend) as client:
         response_1 = client.get("http://example.org/1")
-        backend.server.raise_disconnect = True
-        response_2 = client.get("http://example.org/2")
-
-    assert response_1.status_code == 200
-    assert json.loads(response_1.content) == {"method": "GET", "path": "/1", "body": ""}
-
-    assert response_2.status_code == 200
-    assert json.loads(response_2.content) == {"method": "GET", "path": "/2", "body": ""}
-
-
-def test_http2_reconnect_after_remote_closed_connection():
-    """
-    If a connection has been closed between requests, then we should
-    be seemlessly reconnected.
-    """
-    backend = MockHTTP2Backend(app=app)
-
-    with Client(backend=backend) as client:
-        response_1 = client.get("http://example.org/1")
         backend.server.close_connection = True
         response_2 = client.get("http://example.org/2")
 

--- a/tests/dispatch/utils.py
+++ b/tests/dispatch/utils.py
@@ -44,6 +44,7 @@ class MockHTTP2Server(BaseReader, BaseWriter):
         self.buffer = b""
         self.requests = {}
         self.raise_disconnect = False
+        self.close_connection = False
 
     # BaseReader interface
 
@@ -73,6 +74,9 @@ class MockHTTP2Server(BaseReader, BaseWriter):
 
     async def close(self) -> None:
         pass
+
+    def is_connection_dropped(self) -> bool:
+        return self.close_connection
 
     # Server implementation
 

--- a/tests/dispatch/utils.py
+++ b/tests/dispatch/utils.py
@@ -43,7 +43,6 @@ class MockHTTP2Server(BaseReader, BaseWriter):
         self.app = app
         self.buffer = b""
         self.requests = {}
-        self.raise_disconnect = False
         self.close_connection = False
 
     # BaseReader interface
@@ -56,9 +55,6 @@ class MockHTTP2Server(BaseReader, BaseWriter):
     # BaseWriter interface
 
     def write_no_block(self, data: bytes) -> None:
-        if self.raise_disconnect:
-            self.raise_disconnect = False
-            raise ConnectionResetError()
         events = self.conn.receive_data(data)
         self.buffer += self.conn.data_to_send()
         for event in events:

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -10,11 +10,11 @@ from httpx import (
     CertTypes,
     Client,
     Dispatcher,
-    multipart,
     Request,
     Response,
     TimeoutTypes,
     VerifyTypes,
+    multipart,
 )
 
 


### PR DESCRIPTION
Check for connection aliveness on re-acquiry from connection pool.

Superseeds #143

Great work on this @yeraydiazdiaz! There was a last little bit of extra cleanup on the connection pool handling that we can do now, which it made sense for me to pick up. I think we're good to go on this one now.