### PR TITLE
Switch hosts in HSTS preload list to HTTPS

### DIFF
--- a/httpx/models.py
+++ b/httpx/models.py
@@ -8,6 +8,7 @@ from http.cookiejar import Cookie, CookieJar
 from urllib.parse import parse_qsl, urlencode
 
 import chardet
+import hstspreload
 import rfc3986
 
 from .config import USER_AGENT
@@ -112,6 +113,14 @@ class URL:
                 raise InvalidURL("No scheme included in URL.")
             if not self.host:
                 raise InvalidURL("No host included in URL.")
+
+        # If the URL is HTTP but the host is on the HSTS preload list switch to HTTPS.
+        if (
+            self.scheme == "http"
+            and self.host
+            and hstspreload.in_hsts_preload(self.host)
+        ):
+            self.components = self.components.copy_with(scheme="https")
 
     @property
     def scheme(self) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ certifi
 chardet==3.*
 h11==0.8.*
 h2==3.*
+hstspreload
 idna==2.*
 rfc3986==1.*
 

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         "chardet==3.*",
         "h11==0.8.*",
         "h2==3.*",
+        "hstspreload",
         "idna==2.*",
         "rfc3986==1.*",
     ],

--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -1,6 +1,7 @@
+import pytest
+
 from httpx import URL
 from httpx.exceptions import InvalidURL
-import pytest
 
 
 def test_idna_url():
@@ -46,10 +47,14 @@ def test_url_join():
     Some basic URL joining tests.
     """
     url = URL("https://example.org:123/path/to/somewhere")
-    assert url.join('/somewhere-else') == "https://example.org:123/somewhere-else"
-    assert url.join('somewhere-else') == "https://example.org:123/path/to/somewhere-else"
-    assert url.join('../somewhere-else') == "https://example.org:123/path/somewhere-else"
-    assert url.join('../../somewhere-else') == "https://example.org:123/somewhere-else"
+    assert url.join("/somewhere-else") == "https://example.org:123/somewhere-else"
+    assert (
+        url.join("somewhere-else") == "https://example.org:123/path/to/somewhere-else"
+    )
+    assert (
+        url.join("../somewhere-else") == "https://example.org:123/path/somewhere-else"
+    )
+    assert url.join("../../somewhere-else") == "https://example.org:123/somewhere-else"
 
 
 def test_url_join_rfc3986():
@@ -119,3 +124,11 @@ def test_url_set():
     url_set = set(urls)
 
     assert all(url in urls for url in url_set)
+
+
+def test_hsts_preload_converted_to_https():
+    url = URL("http://www.paypal.com")
+
+    assert url.is_ssl
+    assert url.scheme == "https"
+    assert url == "https://www.paypal.com"


### PR DESCRIPTION
This does the switch on the URL level as a part of normalization. Adds a new dependency that is under my control currently and potentially will be under the python-http org.