### PR TITLE
Removed deprecated TLS versions

### DIFF
--- a/httpx/config.py
+++ b/httpx/config.py
@@ -147,6 +147,8 @@ class SSLConfig:
         context = ssl.SSLContext(ssl.PROTOCOL_TLS)
         context.options |= ssl.OP_NO_SSLv2
         context.options |= ssl.OP_NO_SSLv3
+        context.options |= ssl.OP_NO_TLSv1
+        context.options |= ssl.OP_NO_TLSv1_1
         context.options |= ssl.OP_NO_COMPRESSION
         context.set_ciphers(DEFAULT_CIPHERS)
 


### PR DESCRIPTION
So I just added the two deprecated version to the SSL context, As we support python 3.6 this should be good but this way of building the sslContext seems to be deprecated in 3.7

https://docs.python.org/3/library/ssl.html#ssl.OP_NO_TLSv1
https://docs.python.org/3/library/ssl.html#ssl.SSLContext.minimum_version