### PR TITLE
Add headers to BaseClient

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -20,7 +20,7 @@
 >>> response = client.get('https://example.org')
 ```
 
-* `def __init__([auth], [cookies], [verify], [cert], [timeout], [pool_limits], [max_redirects], [app], [dispatch])`
+* `def __init__([auth], [headers], [cookies], [verify], [cert], [timeout], [pool_limits], [max_redirects], [app], [dispatch])`
 * `def .get(url, [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout])`
 * `def .options(url, [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout])`
 * `def .head(url, [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout])`

--- a/httpx/client.py
+++ b/httpx/client.py
@@ -49,6 +49,7 @@ class BaseClient:
     def __init__(
         self,
         auth: AuthTypes = None,
+        headers: HeaderTypes = None,
         cookies: CookieTypes = None,
         verify: VerifyTypes = True,
         cert: CertTypes = None,
@@ -95,6 +96,7 @@ class BaseClient:
             self.base_url = URL(base_url)
 
         self.auth = auth
+        self.headers = Headers(headers)
         self.cookies = Cookies(cookies)
         self.max_redirects = max_redirects
         self.dispatch = async_dispatch
@@ -108,6 +110,15 @@ class BaseClient:
             merged_cookies.update(cookies)
             return merged_cookies
         return cookies
+
+    def merge_headers(
+        self, headers: HeaderTypes = None
+    ) -> typing.Optional[HeaderTypes]:
+        if headers and self.headers:
+            merged_headers = Headers(self.headers)
+            merged_headers.update(headers)
+            return merged_headers
+        return headers or self.headers
 
     async def send(
         self,
@@ -527,6 +538,7 @@ class AsyncClient(BaseClient):
         timeout: TimeoutTypes = None,
     ) -> AsyncResponse:
         url = self.base_url.join(url)
+        headers = self.merge_headers(headers)
         cookies = self.merge_cookies(cookies)
         request = AsyncRequest(
             method,
@@ -608,6 +620,7 @@ class Client(BaseClient):
         timeout: TimeoutTypes = None,
     ) -> Response:
         url = self.base_url.join(url)
+        headers = self.merge_headers(headers)
         cookies = self.merge_cookies(cookies)
         request = AsyncRequest(
             method,

--- a/httpx/client.py
+++ b/httpx/client.py
@@ -114,11 +114,11 @@ class BaseClient:
     def merge_headers(
         self, headers: HeaderTypes = None
     ) -> typing.Optional[HeaderTypes]:
-        if headers and self.headers:
+        if headers or self.headers:
             merged_headers = Headers(self.headers)
             merged_headers.update(headers)
             return merged_headers
-        return headers or self.headers
+        return headers
 
     async def send(
         self,

--- a/httpx/models.py
+++ b/httpx/models.py
@@ -318,7 +318,7 @@ class QueryParams(typing.Mapping[str, str]):
         return f"{class_name}({query_string!r})"
 
 
-class Headers(typing.MutableMapping[str, str]):
+class Headers(typing.MutableMapping[str, str], MutableMapping):
     """
     HTTP headers, as a case-insensitive multi-dict.
     """

--- a/httpx/models.py
+++ b/httpx/models.py
@@ -417,8 +417,8 @@ class Headers(typing.MutableMapping[str, str]):
 
     def update(self, headers: HeaderTypes = None) -> None:  # type: ignore
         headers = Headers(headers)
-        for header, value in headers.items():
-            self.headers[header] = value
+        for header in headers:
+            self[header] = headers[header]
 
     def __getitem__(self, key: str) -> str:
         """

--- a/httpx/models.py
+++ b/httpx/models.py
@@ -318,7 +318,7 @@ class QueryParams(typing.Mapping[str, str]):
         return f"{class_name}({query_string!r})"
 
 
-class Headers(typing.MutableMapping[str, str], MutableMapping):
+class Headers(typing.MutableMapping[str, str]):
     """
     HTTP headers, as a case-insensitive multi-dict.
     """
@@ -414,6 +414,11 @@ class Headers(typing.MutableMapping[str, str], MutableMapping):
         for value in values:
             split_values.extend([item.strip() for item in value.split(",")])
         return split_values
+
+    def update(self, headers: HeaderTypes = None) -> None:  # type: ignore
+        headers = Headers(headers)
+        for header, value in headers.items():
+            self.headers[header] = value
 
     def __getitem__(self, key: str) -> str:
         """

--- a/tests/client/test_headers.py
+++ b/tests/client/test_headers.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+import json
+from httpx import (
+    __version__,
+    Client,
+    AsyncRequest,
+    AsyncResponse,
+    VerifyTypes,
+    CertTypes,
+    TimeoutTypes,
+    AsyncDispatcher,
+)
+
+
+class MockDispatch(AsyncDispatcher):
+    async def send(
+        self,
+        request: AsyncRequest,
+        verify: VerifyTypes = None,
+        cert: CertTypes = None,
+        timeout: TimeoutTypes = None,
+    ) -> AsyncResponse:
+        if request.url.path.startswith("/echo_headers"):
+            request_headers = dict(request.headers.items())
+            body = json.dumps({"headers": request_headers}).encode()
+            return AsyncResponse(200, content=body, request=request)
+
+
+def test_client_header():
+    """
+    Set a header in the Client.
+    """
+    url = "http://example.org/echo_headers"
+    headers = {"Example-Header": "example-value"}
+
+    with Client(dispatch=MockDispatch(), headers=headers) as client:
+        response = client.get(url)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "headers": {
+            "accept": "*/*",
+            "accept-encoding": "gzip, deflate, br",
+            "connection": "keep-alive",
+            "example-header": "example-value",
+            "host": "example.org",
+            "user-agent": f"python-httpx/{__version__}",
+        }
+    }
+
+
+def test_header_merge():
+    url = "http://example.org/echo_headers"
+    client_headers = {"User-Agent": "python-myclient/0.2.1"}
+    request_headers = {"X-Auth-Token": "FooBarBazToken"}
+    with Client(dispatch=MockDispatch(), headers=client_headers) as client:
+        response = client.get(url, headers=request_headers)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "headers": {
+            "accept": "*/*",
+            "accept-encoding": "gzip, deflate, br",
+            "connection": "keep-alive",
+            "host": "example.org",
+            "user-agent": "python-myclient/0.2.1",
+            "x-auth-token": "FooBarBazToken",
+        }
+    }
+
+
+def test_header_update():
+    url = "http://example.org/echo_headers"
+    with Client(dispatch=MockDispatch()) as client:
+        first_response = client.get(url)
+        client.headers.update(
+            {"User-Agent": "python-myclient/0.2.1", "Another-Header": "AThing"}
+        )
+        second_response = client.get(url)
+
+    assert first_response.status_code == 200
+    assert first_response.json() == {
+        "headers": {
+            "accept": "*/*",
+            "accept-encoding": "gzip, deflate, br",
+            "connection": "keep-alive",
+            "host": "example.org",
+            "user-agent": f"python-httpx/{__version__}",
+        }
+    }
+
+    assert second_response.status_code == 200
+    assert second_response.json() == {
+        "headers": {
+            "accept": "*/*",
+            "accept-encoding": "gzip, deflate, br",
+            "another-header": "AThing",
+            "connection": "keep-alive",
+            "host": "example.org",
+            "user-agent": "python-myclient/0.2.1",
+        }
+    }

--- a/tests/client/test_headers.py
+++ b/tests/client/test_headers.py
@@ -70,6 +70,26 @@ def test_header_merge():
     }
 
 
+def test_header_merge_conflicting_headers():
+    url = "http://example.org/echo_headers"
+    client_headers = {"X-Auth-Token": "FooBar"}
+    request_headers = {"X-Auth-Token": "BazToken"}
+    with Client(dispatch=MockDispatch(), headers=client_headers) as client:
+        response = client.get(url, headers=request_headers)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "headers": {
+            "accept": "*/*",
+            "accept-encoding": "gzip, deflate, br",
+            "connection": "keep-alive",
+            "host": "example.org",
+            "user-agent": f"python-httpx/{__version__}",
+            "x-auth-token": "BazToken",
+        }
+    }
+
+
 def test_header_update():
     url = "http://example.org/echo_headers"
     with Client(dispatch=MockDispatch()) as client:


### PR DESCRIPTION
This PR resolves #149, by adding `headers` as an arg to the `BaseClient` class, as with `cookies`, and also adds a `merge_headers` function to... merge the headers. I started by copying `merge_cookies`, but got a `NoneType is not iterable` error when trying to use it, so I changed the conditional to ensure that both the passed `headers` and `self.headers` were set, and returning one or the other in the case that they are not. This will still return `None` if neither are set.

I haven't added test cases, yet, but I did test against httpbin.org. I could check out adding something based on the existing [cookie tests](https://github.com/encode/httpx/blob/master/tests/client/test_cookies.py), but wanted to get some feedback first.

```
Python 3.7.3 (default, Jun 24 2019, 04:54:02) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.6.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from httpx import Headers, Client, AsyncClient                                                                                                                                                               

In [2]: headers = Headers({"X-Auth-Token": "FooBarBazToken", "Fake-Agent": "python-myclient/0.2.1"}) 
   ...: session = Client(base_url="https://httpbin.org", headers=headers)                                                                                                                                        

In [3]: async_session = AsyncClient(base_url="https://httpbin.org", headers=headers)                                                                                                                                 

In [4]: sync_headers = session.get("/headers")                                                                                                                                                                       

In [5]: async_headers = await async_session.get("/headers")                                                                                                                                                          

In [6]: sync_headers.json()                                                                                                                                                                                          
Out[6]: 
{'headers': {'Accept': '*/*',
  'Accept-Encoding': 'gzip, deflate',
  'Fake-Agent': 'python-myclient/0.2.1',
  'Host': 'httpbin.org',
  'User-Agent': 'python-httpx/0.6.8',
  'X-Auth-Token': 'FooBarBazToken'}}

In [7]: async_headers.json()                                                                                                                                                                                         
Out[7]: 
{'headers': {'Accept': '*/*',
  'Accept-Encoding': 'gzip, deflate',
  'Fake-Agent': 'python-myclient/0.2.1',
  'Host': 'httpbin.org',
  'User-Agent': 'python-httpx/0.6.8',
  'X-Auth-Token': 'FooBarBazToken'}}

In [8]: headers = Headers({"X-Auth-Token": "FooBarBazToken", "User-Agent": "python-myclient/0.2.1"}) 
   ...: session_two = Client(base_url="https://httpbin.org", headers=headers)                                                                                                                                    

In [9]: async_session_two = AsyncClient(base_url="https://httpbin.org", headers=headers)                                                                                                                             

In [10]: sync_headers_two = session.get("/headers")                                                                                                                                                                  

In [11]: async_headers_two = await async_session.get("/headers")                                                                                                                                                     

In [12]: sync_headers_two.json()                                                                                                                                                                                     
Out[12]: 
{'headers': {'Accept': '*/*',
  'Accept-Encoding': 'gzip, deflate',
  'Fake-Agent': 'python-myclient/0.2.1',
  'Host': 'httpbin.org',
  'User-Agent': 'python-httpx/0.6.8',
  'X-Auth-Token': 'FooBarBazToken'}}

In [13]: async_headers_two.json()                                                                                                                                                                                    
Out[13]: 
{'headers': {'Accept': '*/*',
  'Accept-Encoding': 'gzip, deflate',
  'Fake-Agent': 'python-myclient/0.2.1',
  'Host': 'httpbin.org',
  'User-Agent': 'python-httpx/0.6.8',
  'X-Auth-Token': 'FooBarBazToken'}}

In [14]: async_session.headers.update({"Another-Header": "IsAThing"})                                                                                                                                                

In [14]: async_headers_three = await async_session.get("/headers")                                                                                                                                                   

In [15]: async_headers_three.json()                                                                                                                                                                                  
Out[15]: 
{'headers': {'Accept': '*/*',
  'Accept-Encoding': 'gzip, deflate',
  'Another-Header': 'IsAThing',
  'Fake-Agent': 'python-myclient/0.2.1',
  'Host': 'httpbin.org',
  'User-Agent': 'python-httpx/0.6.8',
  'X-Auth-Token': 'FooBarBazToken'}}

```