### PR TITLE
Update IDNA encoding to 2008 spec

### DIFF
--- a/httpx/models.py
+++ b/httpx/models.py
@@ -8,6 +8,7 @@ from http.cookiejar import Cookie, CookieJar
 from urllib.parse import parse_qsl, urlencode
 
 import chardet
+import idna
 import hstspreload
 import rfc3986
 
@@ -94,7 +95,11 @@ class URL:
 
         # Handle IDNA domain names.
         if self.components.authority:
-            idna_authority = self.components.authority.encode("idna").decode("ascii")
+            # idna.encode raises InvalidCodepoint when encountering a colon, so split
+            # host and port in case the latter is specified and rejoin after encoding
+            host_port = self.components.authority.split(":")
+            host_port[0] = idna.encode(host_port[0]).decode("ascii")
+            idna_authority = ":".join(host_port)
             if idna_authority != self.components.authority:
                 self.components = self.components.copy_with(authority=idna_authority)
 

--- a/httpx/models.py
+++ b/httpx/models.py
@@ -98,7 +98,7 @@ class URL:
             # idna.encode raises InvalidCodepoint when encountering a colon, so split
             # host and port in case the latter is specified and rejoin after encoding
             host_port = self.components.authority.split(":")
-            host_port[0] = idna.encode(host_port[0]).decode("ascii")
+            host_port[0] = idna.encode(host_port[0], uts46=True).decode("ascii")
             idna_authority = ":".join(host_port)
             if idna_authority != self.components.authority:
                 self.components = self.components.copy_with(authority=idna_authority)

--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -1,4 +1,5 @@
 import pytest
+import rfc3986
 
 from httpx import URL
 from httpx.exceptions import InvalidURL
@@ -77,6 +78,17 @@ def test_url():
     new = url.copy_with(scheme="http")
     assert new == URL("http://example.org:123/path/to/somewhere?abc=123#anchor")
     assert new.scheme == "http"
+
+def test_iri():
+    iri = rfc3986.iri.IRIReference.from_string("https://example.org:123/path/to/somewhere?abc=123#anchor")
+    url = URL(iri)
+    assert url.scheme == "https"
+    assert url.host == "example.org"
+    assert url.port == 123
+    assert url.authority == "example.org:123"
+    assert url.path == "/path/to/somewhere"
+    assert url.query == "abc=123"
+    assert url.fragment == "anchor"
 
 
 def test_url_eq_str():

--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -8,6 +8,29 @@ def test_idna_url():
     url = URL("http://中国.icom.museum:80/")
     assert url == URL("http://xn--fiqs8s.icom.museum:80/")
     assert url.host == "xn--fiqs8s.icom.museum"
+    assert url.port == 80
+
+    url = URL("https://faß.de")
+    assert url == URL("https://xn--fa-hia.de") # IDNA 2008
+    assert url.host == "xn--fa-hia.de"
+    assert url.port == 443
+
+    url = URL("https://βόλος.com:443")
+    assert url == URL("https://xn--nxasmm1c.com:443") # IDNA 2008
+    assert url.host == "xn--nxasmm1c.com"
+    assert url.port == 443
+
+    url = URL("http://ශ්‍රී.com:444")
+    assert url == URL("http://xn--10cl1a0b660p.com:444") # IDNA 2008
+    assert url.host == "xn--10cl1a0b660p.com"
+    assert url.scheme == "http"
+    assert url.port == 444
+
+    url = URL("https://نامه‌ای.com:4433")
+    assert url == URL("https://xn--mgba3gch31f060k.com:4433") # IDNA 2008
+    assert url.host == "xn--mgba3gch31f060k.com"
+    assert url.scheme == "https"
+    assert url.port == 4433
 
 
 def test_url():

--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -10,6 +10,11 @@ def test_idna_url():
     assert url.host == "xn--fiqs8s.icom.museum"
     assert url.port == 80
 
+    url = URL("http://Königsgäßchen.de")
+    assert url == URL("http://xn--knigsgchen-b4a3dun.de") # IDNA 2008
+    assert url.host == "xn--knigsgchen-b4a3dun.de"
+    assert url.port == 80
+
     url = URL("https://faß.de")
     assert url == URL("https://xn--fa-hia.de") # IDNA 2008
     assert url.host == "xn--fa-hia.de"

--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -79,17 +79,6 @@ def test_url():
     assert new == URL("http://example.org:123/path/to/somewhere?abc=123#anchor")
     assert new.scheme == "http"
 
-def test_iri():
-    iri = rfc3986.iri.IRIReference.from_string("https://example.org:123/path/to/somewhere?abc=123#anchor")
-    url = URL(iri)
-    assert url.scheme == "https"
-    assert url.host == "example.org"
-    assert url.port == 123
-    assert url.authority == "example.org:123"
-    assert url.path == "/path/to/somewhere"
-    assert url.query == "abc=123"
-    assert url.fragment == "anchor"
-
 
 def test_url_eq_str():
     url = URL("https://example.org:123/path/to/somewhere?abc=123#anchor")

--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -4,38 +4,61 @@ from httpx import URL
 from httpx.exceptions import InvalidURL
 
 
-def test_idna_url():
-    url = URL("http://中国.icom.museum:80/")
-    assert url == URL("http://xn--fiqs8s.icom.museum:80/")
-    assert url.host == "xn--fiqs8s.icom.museum"
-    assert url.port == 80
-
-    url = URL("http://Königsgäßchen.de")
-    assert url == URL("http://xn--knigsgchen-b4a3dun.de") # IDNA 2008
-    assert url.host == "xn--knigsgchen-b4a3dun.de"
-    assert url.port == 80
-
-    url = URL("https://faß.de")
-    assert url == URL("https://xn--fa-hia.de") # IDNA 2008
-    assert url.host == "xn--fa-hia.de"
-    assert url.port == 443
-
-    url = URL("https://βόλος.com:443")
-    assert url == URL("https://xn--nxasmm1c.com:443") # IDNA 2008
-    assert url.host == "xn--nxasmm1c.com"
-    assert url.port == 443
-
-    url = URL("http://ශ්‍රී.com:444")
-    assert url == URL("http://xn--10cl1a0b660p.com:444") # IDNA 2008
-    assert url.host == "xn--10cl1a0b660p.com"
-    assert url.scheme == "http"
-    assert url.port == 444
-
-    url = URL("https://نامه‌ای.com:4433")
-    assert url == URL("https://xn--mgba3gch31f060k.com:4433") # IDNA 2008
-    assert url.host == "xn--mgba3gch31f060k.com"
-    assert url.scheme == "https"
-    assert url.port == 4433
+@pytest.mark.parametrize(
+    "given,idna,host,scheme,port",
+    [
+        (
+            "http://中国.icom.museum:80/",
+            "http://xn--fiqs8s.icom.museum:80/",
+            "xn--fiqs8s.icom.museum",
+            "http",
+            80,
+        ),
+        (
+            "http://Königsgäßchen.de",
+            "http://xn--knigsgchen-b4a3dun.de",
+            "xn--knigsgchen-b4a3dun.de",
+            "http",
+            80,
+        ),
+        ("https://faß.de", "https://xn--fa-hia.de", "xn--fa-hia.de", "https", 443),
+        (
+            "https://βόλος.com:443",
+            "https://xn--nxasmm1c.com:443",
+            "xn--nxasmm1c.com",
+            "https",
+            443,
+        ),
+        (
+            "http://ශ්‍රී.com:444",
+            "http://xn--10cl1a0b660p.com:444",
+            "xn--10cl1a0b660p.com",
+            "http",
+            444,
+        ),
+        (
+            "https://نامه‌ای.com:4433",
+            "https://xn--mgba3gch31f060k.com:4433",
+            "xn--mgba3gch31f060k.com",
+            "https",
+            4433,
+        ),
+    ],
+    ids=[
+        "http_with_port",
+        "unicode_tr46_compat",
+        "https_without_port",
+        "https_with_port",
+        "http_with_custom_port",
+        "https_with_custom_port",
+    ],
+)
+def test_idna_url(given, idna, host, scheme, port):
+    url = URL(given)
+    assert url == URL(idna)
+    assert url.host == host
+    assert url.scheme == scheme
+    assert url.port == port
 
 
 def test_url():


### PR DESCRIPTION
Resolves #150 and adds tests based on deviations from 2003 spec: https://unicode.org/reports/tr46/#Deviations

This also enables Unicode® Technical Standard #46 to normalize capital letters and such, and a test based on the example given in the [module documentation](https://github.com/kjd/idna#compatibility-mapping-uts-46).

Since the idna encode() function chokes on colons, I've split and rejoined the authority string and added to the tests to make sure the port stays as expected.