### PR TITLE
Fixed multipart header params encoding

### DIFF
--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -127,17 +127,17 @@ def test_multipart_encode():
 
 class TestHeaderParamHTML5Formatting:
     def test_unicode(self):
-        param = multipart.format_header_param_html5("filename", "n\u00e4me")
+        param = multipart._format_param("filename", "n\u00e4me")
         assert param == 'filename="n\u00e4me"'
 
     def test_ascii(self):
-        param = multipart.format_header_param_html5("filename", b"name")
+        param = multipart._format_param("filename", b"name")
         assert param == 'filename="name"'
 
     def test_unicode_escape(self):
-        param = multipart.format_header_param_html5("filename", "hello\\world\u0022")
+        param = multipart._format_param("filename", "hello\\world\u0022")
         assert param == 'filename="hello\\\\world%22"'
 
     def test_unicode_with_control_character(self):
-        param = multipart.format_header_param_html5("filename", "hello\x1A\x1B\x1C")
+        param = multipart._format_param("filename", "hello\x1A\x1B\x1C")
         assert param == 'filename="hello%1A\x1B%1C"'

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -128,16 +128,16 @@ def test_multipart_encode():
 class TestHeaderParamHTML5Formatting:
     def test_unicode(self):
         param = multipart._format_param("filename", "n\u00e4me")
-        assert param == 'filename="n\u00e4me"'
+        assert param == b'filename="n\u00e4me"'
 
     def test_ascii(self):
         param = multipart._format_param("filename", b"name")
-        assert param == 'filename="name"'
+        assert param == b'filename="name"'
 
     def test_unicode_escape(self):
         param = multipart._format_param("filename", "hello\\world\u0022")
-        assert param == 'filename="hello\\\\world%22"'
+        assert param == b'filename="hello\\\\world%22"'
 
     def test_unicode_with_control_character(self):
         param = multipart._format_param("filename", "hello\x1A\x1B\x1C")
-        assert param == 'filename="hello%1A\x1B%1C"'
+        assert param == b'filename="hello%1A\x1B%1C"'

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -123,3 +123,21 @@ def test_multipart_encode():
             "--{0}--\r\n"
             "".format(boundary).encode("ascii")
         )
+
+
+class TestHeaderParamHTML5Formatting:
+    def test_unicode(self):
+        param = multipart.format_header_param_html5("filename", "n\u00e4me")
+        assert param == 'filename="n\u00e4me"'
+
+    def test_ascii(self):
+        param = multipart.format_header_param_html5("filename", b"name")
+        assert param == 'filename="name"'
+
+    def test_unicode_escape(self):
+        param = multipart.format_header_param_html5("filename", "hello\\world\u0022")
+        assert param == 'filename="hello\\\\world%22"'
+
+    def test_unicode_with_control_character(self):
+        param = multipart.format_header_param_html5("filename", "hello\x1A\x1B\x1C")
+        assert param == 'filename="hello%1A\x1B%1C"'

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -128,7 +128,7 @@ def test_multipart_encode():
 class TestHeaderParamHTML5Formatting:
     def test_unicode(self):
         param = multipart._format_param("filename", "n\u00e4me")
-        assert param == b'filename="n\u00e4me"'
+        assert param == b'filename="n\xc3\xa4me"'
 
     def test_ascii(self):
         param = multipart._format_param("filename", b"name")


### PR DESCRIPTION
This resolves #164. Fixed using non-ASCII letters in `multipart/form-data` request.