### PR TITLE
Require values for headers

### DIFF
--- a/httpx/utils.py
+++ b/httpx/utils.py
@@ -15,6 +15,8 @@ def normalize_header_value(value: typing.AnyStr, encoding: str = None) -> bytes:
     """
     Coerce str/bytes into a strictly byte-wise HTTP header value.
     """
+    if value is None:
+        raise ValueError("NoneType header values are not allowed")
     if isinstance(value, bytes):
         return value
     return value.encode(encoding or "ascii")

--- a/tests/models/test_headers.py
+++ b/tests/models/test_headers.py
@@ -1,3 +1,5 @@
+import pytest
+
 import httpx
 
 
@@ -151,3 +153,8 @@ def test_multiple_headers():
 
     h = httpx.Headers([("vary", "a, b"), ("vary", "c")])
     h.getlist("Vary") == ["a", "b", "c"]
+
+
+def test_none_header_value_disallowed():
+    with pytest.raises(ValueError, match=r"NoneType.*not allowed"):
+        none_headers = httpx.Headers({"key": None})


### PR DESCRIPTION
Not sure if this is too literal an interpretation of "require values within the `headers` parameter" from https://github.com/encode/httpx/issues/152#issuecomment-515816059, but thought it might be useful to enforce.

Error message is just something I came up with.

Feel free to close this as not useful, if we'll simply rely on the `AttributeError: 'NoneType' object has no attribute 'encode'` that's currently raised three lines down.