### PR TITLE
[WIP] Middlewares

### DIFF
--- a/httpx/client.py
+++ b/httpx/client.py
@@ -107,6 +107,7 @@ class BaseClient:
         self.max_redirects = max_redirects
         self.dispatch = async_dispatch
         self.concurrency_backend = backend
+        self.additional_middlewares = additional_middlewares or []
 
     def merge_cookies(
         self, cookies: CookieTypes = None
@@ -157,6 +158,8 @@ class BaseClient:
             middlewares.append(HTTPBasicAuthMiddleware(username=auth[0], password=auth[1]))
         elif isinstance(auth, HTTPBasicAuth):
             middlewares.append(HTTPBasicAuthMiddleware(username=auth.username, password=auth.password))
+
+        middlewares.extend(self.additional_middlewares)
 
         while True:
             for middleware in middlewares:

--- a/httpx/client.py
+++ b/httpx/client.py
@@ -24,6 +24,11 @@ from .exceptions import (
     TooManyRedirects,
 )
 from .interfaces import AsyncDispatcher, ConcurrencyBackend, Dispatcher
+from .middlewares import (
+    BaseMiddleware,
+    RedirectMiddleware,
+    HTTPBasicAuthMiddleware,
+)
 from .models import (
     URL,
     AsyncRequest,
@@ -61,6 +66,7 @@ class BaseClient:
         app: typing.Callable = None,
         raise_app_exceptions: bool = True,
         backend: ConcurrencyBackend = None,
+        additional_middlewares: list = None,  # TODO: is this the best way to inject mws?
     ):
         if backend is None:
             backend = AsyncioBackend()
@@ -131,29 +137,43 @@ class BaseClient:
         cert: CertTypes = None,
         timeout: TimeoutTypes = None,
     ) -> AsyncResponse:
-        if auth is None:
-            auth = self.auth
-
         url = request.url
-
         if url.scheme not in ("http", "https"):
             raise InvalidURL('URL scheme must be "http" or "https".')
 
+        middlewares: typing.List[BaseMiddleware] = [
+            # TODO: RedirectMW uses a combination of parameters to the client
+            # but also to send, which makes this awkward instantiation
+            RedirectMiddleware(
+                allow_redirects=allow_redirects,
+                max_redirects=self.max_redirects,
+                base_cookies=self.cookies,
+            ),
+        ]
+
         if auth is None and (url.username or url.password):
-            auth = HTTPBasicAuth(username=url.username, password=url.password)
+            middlewares.append(HTTPBasicAuthMiddleware(username=url.username, password=url.password))
+        elif isinstance(auth, tuple):
+            middlewares.append(HTTPBasicAuthMiddleware(username=auth[0], password=auth[1]))
+        elif isinstance(auth, HTTPBasicAuth):
+            middlewares.append(HTTPBasicAuthMiddleware(username=auth.username, password=auth.password))
 
-        if auth is not None:
-            if isinstance(auth, tuple):
-                auth = HTTPBasicAuth(username=auth[0], password=auth[1])
-            request = auth(request)
+        while True:
+            for middleware in middlewares:
+                request = middleware.process_request(request)
 
-        response = await self.send_handling_redirects(
-            request,
-            verify=verify,
-            cert=cert,
-            timeout=timeout,
-            allow_redirects=allow_redirects,
-        )
+            response = await self.dispatch.send(
+                request, verify=verify, cert=cert, timeout=timeout
+            )
+
+            for middleware in middlewares:
+                result = middleware.process_response(request, response)
+                if isinstance(result, AsyncRequest):
+                    request = result
+                    break  # do not process more middlewares as one has an action to take
+
+            if isinstance(result, AsyncResponse):
+                break  # we have a response after all middlewares have processed the result
 
         if not stream:
             try:
@@ -162,140 +182,6 @@ class BaseClient:
                 await response.close()
 
         return response
-
-    async def send_handling_redirects(
-        self,
-        request: AsyncRequest,
-        *,
-        cert: CertTypes = None,
-        verify: VerifyTypes = None,
-        timeout: TimeoutTypes = None,
-        allow_redirects: bool = True,
-        history: typing.List[AsyncResponse] = None,
-    ) -> AsyncResponse:
-        if history is None:
-            history = []
-
-        while True:
-            # We perform these checks here, so that calls to `response.next()`
-            # will raise redirect errors if appropriate.
-            if len(history) > self.max_redirects:
-                raise TooManyRedirects()
-            if request.url in [response.url for response in history]:
-                raise RedirectLoop()
-
-            response = await self.dispatch.send(
-                request, verify=verify, cert=cert, timeout=timeout
-            )
-            should_close_response = True
-            try:
-                assert isinstance(response, AsyncResponse)
-                response.history = list(history)
-                self.cookies.extract_cookies(response)
-                history = history + [response]
-
-                if allow_redirects and response.is_redirect:
-                    request = self.build_redirect_request(request, response)
-                else:
-                    should_close_response = False
-                    break
-            finally:
-                if should_close_response:
-                    await response.close()
-
-        if response.is_redirect:
-
-            async def send_next() -> AsyncResponse:
-                nonlocal request, response, verify, cert
-                nonlocal allow_redirects, timeout, history
-                request = self.build_redirect_request(request, response)
-                response = await self.send_handling_redirects(
-                    request,
-                    allow_redirects=allow_redirects,
-                    verify=verify,
-                    cert=cert,
-                    timeout=timeout,
-                    history=history,
-                )
-                return response
-
-            response.next = send_next  # type: ignore
-
-        return response
-
-    def build_redirect_request(
-        self, request: AsyncRequest, response: AsyncResponse
-    ) -> AsyncRequest:
-        method = self.redirect_method(request, response)
-        url = self.redirect_url(request, response)
-        headers = self.redirect_headers(request, url)
-        content = self.redirect_content(request, method)
-        cookies = self.merge_cookies(request.cookies)
-        return AsyncRequest(
-            method=method, url=url, headers=headers, data=content, cookies=cookies
-        )
-
-    def redirect_method(self, request: AsyncRequest, response: AsyncResponse) -> str:
-        """
-        When being redirected we may want to change the method of the request
-        based on certain specs or browser behavior.
-        """
-        method = request.method
-
-        # https://tools.ietf.org/html/rfc7231#section-6.4.4
-        if response.status_code == codes.SEE_OTHER and method != "HEAD":
-            method = "GET"
-
-        # Do what the browsers do, despite standards...
-        # Turn 302s into GETs.
-        if response.status_code == codes.FOUND and method != "HEAD":
-            method = "GET"
-
-        # If a POST is responded to with a 301, turn it into a GET.
-        # This bizarre behaviour is explained in 'requests' issue 1704.
-        if response.status_code == codes.MOVED_PERMANENTLY and method == "POST":
-            method = "GET"
-
-        return method
-
-    def redirect_url(self, request: AsyncRequest, response: AsyncResponse) -> URL:
-        """
-        Return the URL for the redirect to follow.
-        """
-        location = response.headers["Location"]
-
-        url = URL(location, allow_relative=True)
-
-        # Facilitate relative 'Location' headers, as allowed by RFC 7231.
-        # (e.g. '/path/to/resource' instead of 'http://domain.tld/path/to/resource')
-        if url.is_relative_url:
-            url = request.url.join(url)
-
-        # Attach previous fragment if needed (RFC 7231 7.1.2)
-        if request.url.fragment and not url.fragment:
-            url = url.copy_with(fragment=request.url.fragment)
-
-        return url
-
-    def redirect_headers(self, request: AsyncRequest, url: URL) -> Headers:
-        """
-        Strip Authorization headers when responses are redirected away from
-        the origin.
-        """
-        headers = Headers(request.headers)
-        if url.origin != request.url.origin:
-            del headers["Authorization"]
-        return headers
-
-    def redirect_content(self, request: AsyncRequest, method: str) -> bytes:
-        """
-        Return the body that should be used for the redirect request.
-        """
-        if method != request.method and method == "GET":
-            return b""
-        if request.is_streaming:
-            raise RedirectBodyUnavailable()
-        return request.content
 
 
 class AsyncClient(BaseClient):

--- a/httpx/middlewares/__init__.py
+++ b/httpx/middlewares/__init__.py
@@ -2,9 +2,4 @@ from .base import BaseMiddleware
 from .redirect import RedirectMiddleware
 from .auth import HTTPBasicAuthMiddleware
 
-__all__ = [
-    "BaseMiddleware",
-    "RedirectMiddleware",
-    "HTTPBasicAuthMiddleware",
-    "HTTPDigestAuthMiddleware",
-]
+__all__ = ["BaseMiddleware", "RedirectMiddleware", "HTTPBasicAuthMiddleware"]

--- a/httpx/middlewares/__init__.py
+++ b/httpx/middlewares/__init__.py
@@ -1,0 +1,10 @@
+from .base import BaseMiddleware
+from .redirect import RedirectMiddleware
+from .auth import HTTPBasicAuthMiddleware
+
+__all__ = [
+    "BaseMiddleware",
+    "RedirectMiddleware",
+    "HTTPBasicAuthMiddleware",
+    "HTTPDigestAuthMiddleware",
+]

--- a/httpx/middlewares/auth.py
+++ b/httpx/middlewares/auth.py
@@ -1,0 +1,34 @@
+import hashlib
+import os
+import time
+import typing
+from base64 import b64encode
+from urllib.parse import urlparse
+
+from ..models import AsyncRequest, AsyncResponse, StatusCode
+from .base import BaseMiddleware
+
+
+class HTTPBasicAuthMiddleware(BaseMiddleware):
+    def __init__(
+        self, username: typing.Union[str, bytes], password: typing.Union[str, bytes]
+    ):
+        self.username = username
+        self.password = password
+
+    def process_request(self, request: AsyncRequest) -> AsyncRequest:
+        request.headers["Authorization"] = self.build_auth_header()
+        return request
+
+    def build_auth_header(self) -> str:
+        username, password = self.username, self.password
+
+        if isinstance(username, str):
+            username = username.encode("latin1")
+
+        if isinstance(password, str):
+            password = password.encode("latin1")
+
+        userpass = b":".join((username, password))
+        token = b64encode(userpass).decode().strip()
+        return f"Basic {token}"

--- a/httpx/middlewares/base.py
+++ b/httpx/middlewares/base.py
@@ -1,0 +1,13 @@
+import typing
+
+from ..models import AsyncRequest, AsyncResponse
+
+
+class BaseMiddleware:
+    def process_request(self, request: AsyncRequest) -> AsyncRequest:
+        return request
+
+    def process_response(
+        self, request: AsyncRequest, response: AsyncResponse
+    ) -> typing.Union[AsyncRequest, AsyncResponse]:
+        return response

--- a/httpx/middlewares/redirect.py
+++ b/httpx/middlewares/redirect.py
@@ -1,0 +1,131 @@
+import typing
+
+from ..models import AsyncRequest, AsyncResponse, AuthTypes, URL, Headers, Cookies
+from ..config import (
+    DEFAULT_MAX_REDIRECTS,
+    DEFAULT_POOL_LIMITS,
+    DEFAULT_TIMEOUT_CONFIG,
+    CertTypes,
+    PoolLimits,
+    TimeoutTypes,
+    VerifyTypes,
+)
+from ..exceptions import RedirectLoop, RedirectBodyUnavailable, TooManyRedirects
+from ..status_codes import codes
+from .base import BaseMiddleware
+
+
+class RedirectMiddleware(BaseMiddleware):
+    def __init__(
+        self,
+        allow_redirects,
+        *,
+        base_cookies: typing.Optional[Cookies] = None,
+        max_redirects: typing.Optional[int] = None,
+    ):
+        self.allow_redirects = allow_redirects
+        self.base_cookies = Cookies(base_cookies)
+        self.max_redirects = max_redirects or DEFAULT_MAX_REDIRECTS
+        self.history = []  # type: list
+
+    def process_request(self, request: AsyncRequest) -> AsyncRequest:
+        # We perform these checks here, so that calls to `response.next()`
+        # will raise redirect errors if appropriate.
+        if len(self.history) > self.max_redirects:
+            raise TooManyRedirects()
+        if request.url in [response.url for response in self.history]:
+            raise RedirectLoop()
+
+        return request
+
+    def process_response(
+        self, request: AsyncRequest, response: AsyncResponse
+    ) -> typing.Union[AsyncRequest, AsyncResponse]:
+        if not response.is_redirect:
+            response.history = list(self.history)
+            return response
+
+        self.history.append(response)
+        next_request = self.build_redirect_request(request, response)
+        if not self.allow_redirects:
+            # FIXME: this breaks the request.next functionality
+            # maybe we could make it a descriptor that performs the request?
+            response.next = next_request
+            return response
+        else:
+            return next_request
+
+    def build_redirect_request(
+        self, request: AsyncRequest, response: AsyncResponse
+    ) -> AsyncRequest:
+        method = self.redirect_method(request, response)
+        url = self.redirect_url(request, response)
+        headers = self.redirect_headers(request, url)  # TODO: merge headers?
+        content = self.redirect_content(request, method)
+        cookies = Cookies(self.base_cookies)
+        cookies.update(request.cookies)
+        return AsyncRequest(
+            method=method, url=url, headers=headers, data=content, cookies=cookies
+        )
+
+    def redirect_method(self, request: AsyncRequest, response: AsyncResponse) -> str:
+        """
+        When being redirected we may want to change the method of the request
+        based on certain specs or browser behavior.
+        """
+        method = request.method
+
+        # https://tools.ietf.org/html/rfc7231#section-6.4.4
+        if response.status_code == codes.SEE_OTHER and method != "HEAD":
+            method = "GET"
+
+        # Do what the browsers do, despite standards...
+        # Turn 302s into GETs.
+        if response.status_code == codes.FOUND and method != "HEAD":
+            method = "GET"
+
+        # If a POST is responded to with a 301, turn it into a GET.
+        # This bizarre behaviour is explained in 'requests' issue 1704.
+        if response.status_code == codes.MOVED_PERMANENTLY and method == "POST":
+            method = "GET"
+
+        return method
+
+    def redirect_url(self, request: AsyncRequest, response: AsyncResponse) -> URL:
+        """
+        Return the URL for the redirect to follow.
+        """
+        location = response.headers["Location"]
+
+        url = URL(location, allow_relative=True)
+
+        # Facilitate relative 'Location' headers, as allowed by RFC 7231.
+        # (e.g. '/path/to/resource' instead of 'http://domain.tld/path/to/resource')
+        if url.is_relative_url:
+            url = request.url.join(url)
+
+        # Attach previous fragment if needed (RFC 7231 7.1.2)
+        if request.url.fragment and not url.fragment:
+            url = url.copy_with(fragment=request.url.fragment)
+
+        return url
+
+    def redirect_headers(self, request: AsyncRequest, url: URL) -> Headers:
+        """
+        Strip Authorization headers when responses are redirected away from
+        the origin.
+        """
+        headers = Headers(request.headers)
+        if url.origin != request.url.origin:
+            del headers["Authorization"]
+        return headers
+
+    def redirect_content(self, request: AsyncRequest, method: str) -> bytes:
+        """
+        Return the body that should be used for the redirect request.
+        """
+        if method != request.method and method == "GET":
+            return b""
+        if request.is_streaming:
+            raise RedirectBodyUnavailable()
+        return request.content


### PR DESCRIPTION
Split from #136 [as requested](https://github.com/encode/httpx/pull/136#issuecomment-516207173). Also from that PR with some changes:

A stab at refactoring redirects and auth into middlewares. Quick tests using httpbin seems to work for redirects and basic auth, a digest auth is also working but not included in this PR.

The main idea is:
1. `client.send` sets up the pipeline
2. The request is processed by each middleware in turn
3. The resulting request is dispatched
4. The response is processed by each middleware, which can return a modified response or a new request
5. If a new request is returned go back to 2 otherwise return the response

I've inlined some comments in the problematic areas but main ones are:
- `response.next` was assembled as a callable inside the loop, which by refactoring into the middleware makes it much harder so I temporarily left it broken.
- The manual assembling of the middlewares and how to expose an API for the user assemble new middleware pipelines and how much control do we allow.

Hopefully with this PR is a bit clearer and we can discuss design options 🙂 