### PR TITLE
Enable mypy to discover type hints as specified in PEP 561

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
     long_description_content_type="text/markdown",
     author="Tom Christie",
     author_email="tom@tomchristie.com",
+    package_data={"httpx": ["py.typed"]},
     packages=get_packages("httpx"),
     install_requires=[
         "certifi",


### PR DESCRIPTION
Adds the `py.typed` marker file and `package_data` entry from PEP 561 (fixes #193). 

Tested locally with `pip install --editable .`. 