### PR TITLE
Fail silently if invalid Content-Encoding is sent

### DIFF
--- a/httpx/models.py
+++ b/httpx/models.py
@@ -780,8 +780,11 @@ class BaseResponse:
             values = self.headers.getlist("content-encoding", split_commas=True)
             for value in values:
                 value = value.strip().lower()
-                decoder_cls = SUPPORTED_DECODERS[value]
-                decoders.append(decoder_cls())
+                try:
+                    decoder_cls = SUPPORTED_DECODERS[value]
+                    decoders.append(decoder_cls())
+                except KeyError:
+                    continue
 
             if len(decoders) == 1:
                 self._decoder = decoders[0]

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -86,3 +86,14 @@ def test_decoding_errors(header_value):
     with pytest.raises(httpx.exceptions.DecodingError):
         response = httpx.Response(200, headers=headers, content=compressed_body)
         response.content
+
+
+@pytest.mark.parametrize("header_value", (b"invalid-header", ))
+def test_invalid_header(header_value):
+    headers = [(b"Content-Encoding", header_value)]
+    body = b"test 123"
+
+    response = httpx.Response(200, headers=headers, content=body)
+    response.content
+
+    assert response.read() == body

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -88,8 +88,7 @@ def test_decoding_errors(header_value):
         response.content
 
 
-@pytest.mark.parametrize("header_value", (b"invalid-header", ))
-def test_invalid_header(header_value):
+def test_invalid_content_encoding_header(header_value):
     headers = [(b"Content-Encoding", header_value)]
     body = b"test 123"
 

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -94,6 +94,5 @@ def test_invalid_header(header_value):
     body = b"test 123"
 
     response = httpx.Response(200, headers=headers, content=body)
-    response.content
 
     assert response.read() == body


### PR DESCRIPTION
This is my proposed fix for #195 
It just discards invalid header values for Content-Encoding