### PR TITLE
Centralize tooling configuration

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,3 +1,0 @@
-[settings]
-known_first_party = httpx
-known_third_party = brotli,certifi,chardet,cryptography,h11,h2,hstspreload,nox,pytest,rfc3986,setuptools,trustme,uvicorn

--- a/noxfile.py
+++ b/noxfile.py
@@ -9,18 +9,7 @@ def lint(session):
 
     session.run("autoflake", "--in-place", "--recursive", *source_files)
     session.run("seed-isort-config", "--application-directories=httpx")
-    session.run(
-        "isort",
-        "--project=httpx",
-        "--multi-line=3",
-        "--trailing-comma",
-        "--force-grid-wrap=0",
-        "--combine-as",
-        "--line-width=88",
-        "--recursive",
-        "--apply",
-        *source_files,
-    )
+    session.run("isort", "--project=httpx", "--recursive", "--apply", *source_files)
     session.run("black", "--target-version=py36", *source_files)
 
     check(session)
@@ -33,10 +22,8 @@ def check(session):
     )
 
     session.run("black", "--check", "--target-version=py36", *source_files)
-    session.run(
-        "flake8", "--max-line-length=88", "--ignore=W503,E203,B305", *source_files
-    )
-    session.run("mypy", "httpx", "--ignore-missing-imports", "--disallow-untyped-defs")
+    session.run("flake8", *source_files)
+    session.run("mypy", "httpx")
 
 
 @nox.session(reuse_venv=True)
@@ -50,13 +37,4 @@ def docs(session):
 def test(session):
     session.install("-r", "test-requirements.txt")
 
-    session.run(
-        "coverage",
-        "run",
-        "--omit='*'",
-        "-m",
-        "pytest",
-        "--cov=httpx",
-        "--cov=tests",
-        "--cov-report=term-missing",
-    )
+    session.run("coverage", "run", "-m", "pytest")

--- a/noxfile.py
+++ b/noxfile.py
@@ -37,4 +37,4 @@ def docs(session):
 def test(session):
     session.install("-r", "test-requirements.txt")
 
-    session.run("coverage", "run", "-m", "pytest")
+    session.run("python", "-m", "pytest")

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ line_length = 88
 multi_line_output = 3
 
 [tool:pytest]
-adopts = --cov=httpx --cov=tests --cov-report=term-missing
+addopts = --cov=httpx --cov=tests --cov-report=term-missing
 
 [tool:coverage:run]
 omit = *

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,22 @@
+[flake8]
+ignore = W503, E203, B305
+max-line-length = 88
+
+[mypy]
+disallow_untyped_defs = True
+ignore_missing_imports = True
+
+[tool:isort]
+combine_as_imports = True
+force_grid_wrap = 0
+include_trailing_comma = True
+known_first_party = httpx
+known_third_party = brotli,certifi,chardet,cryptography,h11,h2,hstspreload,nox,pytest,rfc3986,setuptools,trustme,uvicorn
+line_length = 88
+multi_line_output = 3
+
+[tool:pytest]
+adopts = --cov=httpx --cov=tests --cov-report=term-missing
+
+[tool:coverage:run]
+omit = *

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,3 @@ multi_line_output = 3
 
 [tool:pytest]
 addopts = --cov=httpx --cov=tests --cov-report=term-missing
-
-[tool:coverage:run]
-omit = *


### PR DESCRIPTION
This centralizes all the tooling configurations that will be used by
flake8, mypy, isort, pytest, and coverage tools.

It prevents the config file bloating at the project and also makes the
editor linters to automatic detects the project coding standards.

It also removes the .isort.cfg file and the configurations hardcoded at
the noxfile to prevent duplication.