### PR TITLE
Expand disallow_redirects test assert

### DIFF
--- a/tests/client/test_redirects.py
+++ b/tests/client/test_redirects.py
@@ -135,11 +135,13 @@ async def test_disallow_redirects():
     )
     assert response.status_code == codes.SEE_OTHER
     assert response.url == URL("https://example.org/redirect_303")
+    assert response.is_redirect is True
     assert len(response.history) == 0
 
     response = await response.next()
     assert response.status_code == codes.OK
     assert response.url == URL("https://example.org/")
+    assert response.is_redirect is False
     assert len(response.history) == 1
 
 


### PR DESCRIPTION
The `response.is_redirect` is already implicitly tested to be _True_ in the other test case that disallows redirects (https://github.com/encode/httpx/blob/master/tests/client/test_redirects.py#L220) but I thought it would be good to have it explicit in the first simpler test case.