### PR TITLE
Trio concurency backend PoC

### DIFF
--- a/httpx/client.py
+++ b/httpx/client.py
@@ -79,7 +79,7 @@ class BaseClient:
                 )
             else:
                 dispatch = ASGIDispatch(
-                    app=app, raise_app_exceptions=raise_app_exceptions
+                    app=app, raise_app_exceptions=raise_app_exceptions, backend=backend
                 )
 
         if dispatch is None:

--- a/httpx/concurrency.py
+++ b/httpx/concurrency.py
@@ -254,7 +254,7 @@ class AsyncioBackend(ConcurrencyBackend):
 
 
 class BackgroundManager(BaseBackgroundManager):
-    def __init__(self, coroutine: typing.Callable, args: typing.Any) -> None:
+    def __init__(self, coroutine: typing.Callable, args: typing.Sequence) -> None:
         self.coroutine = coroutine
         self.args = args
 

--- a/httpx/contrib/trio.py
+++ b/httpx/contrib/trio.py
@@ -1,0 +1,259 @@
+import functools
+import ssl
+import typing
+from types import TracebackType
+
+import trio
+import trio.abc
+
+from httpx.config import PoolLimits, TimeoutConfig
+from httpx.exceptions import ConnectTimeout, PoolTimeout, ReadTimeout, WriteTimeout
+from httpx.interfaces import (
+    BaseAsyncContextManager,
+    BaseBackgroundManager,
+    BaseBodyIterator,
+    BaseEvent,
+    BasePoolSemaphore,
+    BaseReader,
+    BaseWriter,
+    ConcurrencyBackend,
+    Protocol,
+)
+from httpx.concurrency import TimeoutFlag
+
+
+class Reader(BaseReader):
+    def __init__(
+        self, receive_stream: trio.abc.ReceiveStream, timeout: TimeoutConfig
+    ) -> None:
+        self.receive_stream = receive_stream
+        self.timeout = timeout
+        self.is_eof = False
+
+    async def read(
+        self, n: int, timeout: TimeoutConfig = None, flag: TimeoutFlag = None
+    ) -> bytes:
+        if timeout is None:
+            timeout = self.timeout
+
+        while True:
+            # Check our flag at the first possible moment, and use a fine
+            # grained retry loop if we're not yet in read-timeout mode.
+            should_raise = flag is None or flag.raise_on_read_timeout
+            read_timeout = timeout.read_timeout if should_raise else 0.01
+            with trio.move_on_after(read_timeout) as cancel_scope:
+                data = await self.receive_stream.receive_some(max_bytes=n)
+            if cancel_scope.cancelled_caught:
+                if should_raise:
+                    raise ReadTimeout() from None
+            else:
+                if data == b"":
+                    self.is_eof = True
+                return data
+
+        return data
+
+    def is_connection_dropped(self) -> bool:
+        return self.is_eof
+
+
+class Writer(BaseWriter):
+    def __init__(self, send_stream: trio.abc.SendStream, timeout: TimeoutConfig):
+        self.send_stream = send_stream
+        self.timeout = timeout
+
+    def write_no_block(self, data: bytes) -> None:
+        self.send_stream.send_all(data)  # pragma: nocover
+
+    async def write(
+        self, data: bytes, timeout: TimeoutConfig = None, flag: TimeoutFlag = None
+    ) -> None:
+        if not data:
+            return
+
+        if timeout is None:
+            timeout = self.timeout
+
+        while True:
+            with trio.move_on_after(timeout.write_timeout) as cancel_scope:
+                await self.send_stream.wait_send_all_might_not_block()
+                await self.send_stream.send_all(data)
+                break
+            if cancel_scope.cancelled_caught:
+                # We check our flag at the possible moment, in order to
+                # allow us to suppress write timeouts, if we've since
+                # switched over to read-timeout mode.
+                should_raise = flag is None or flag.raise_on_write_timeout
+                if should_raise:
+                    raise WriteTimeout() from None
+
+    async def close(self) -> None:
+        await self.send_stream.aclose()
+
+
+class PoolSemaphore(BasePoolSemaphore):
+    def __init__(self, pool_limits: PoolLimits):
+        self.pool_limits = pool_limits
+
+    @property
+    def semaphore(self) -> typing.Optional[trio.Semaphore]:
+        if not hasattr(self, "_semaphore"):
+            max_connections = self.pool_limits.hard_limit
+            if max_connections is None:
+                self._semaphore = None
+            else:
+                self._semaphore = trio.Semaphore(
+                    initial_value=1, max_value=max_connections
+                )
+        return self._semaphore
+
+    async def acquire(self) -> None:
+        if self.semaphore is None:
+            return
+
+        timeout = self.pool_limits.pool_timeout
+        with trio.move_on_after(timeout) as cancel_scope:
+            await self.semaphore.acquire()
+        if cancel_scope.cancelled_caught:
+            raise PoolTimeout()
+
+    def release(self) -> None:
+        if self.semaphore is None:
+            return
+
+        self.semaphore.release()
+
+
+class TrioBackend(ConcurrencyBackend):
+    async def connect(
+        self,
+        hostname: str,
+        port: int,
+        ssl_context: typing.Optional[ssl.SSLContext],
+        timeout: TimeoutConfig,
+    ) -> typing.Tuple[BaseReader, BaseWriter, Protocol]:
+        with trio.move_on_after(timeout.connect_timeout) as cancel_scope:
+            if ssl_context is None:
+                stream = await trio.open_tcp_stream(hostname, port)
+            else:
+                stream = await trio.open_ssl_over_tcp_stream(
+                    hostname, port, ssl_context=ssl_context
+                )
+                await stream.do_handshake()
+        if cancel_scope.cancelled_caught:
+            raise ConnectTimeout()
+
+        if ssl_context is None:
+            ident = "http/1.1"  # TODO
+        else:
+            ident = stream.selected_alpn_protocol()
+            if ident is None:
+                ident = stream.selected_npn_protocol()
+
+        reader = Reader(receive_stream=stream, timeout=timeout)
+        writer = Writer(send_stream=stream, timeout=timeout)
+        protocol = Protocol.HTTP_2 if ident == "h2" else Protocol.HTTP_11
+
+        return reader, writer, protocol
+
+    def get_semaphore(self, limits: PoolLimits) -> BasePoolSemaphore:
+        return PoolSemaphore(limits)
+
+    async def run_in_threadpool(
+        self, func: typing.Callable, *args: typing.Any, **kwargs: typing.Any
+    ) -> typing.Any:
+        if kwargs:
+            # trio.to_thread.run_async doesn't accept 'kwargs', so bind them in here
+            func = functools.partial(func, **kwargs)
+        return await trio.to_thread.run_sync(func, *args)
+
+    def run(
+        self, coroutine: typing.Callable, *args: typing.Any, **kwargs: typing.Any
+    ) -> typing.Any:
+        if kwargs:
+            coroutine = functools.partial(coroutine, **kwargs)
+        return trio.run(coroutine, *args)
+
+    async def sleep(self, seconds: float) -> None:
+        await trio.sleep(seconds)
+
+    def create_event(self) -> BaseEvent:
+        return trio.Event()  # type: ignore
+
+    def background_manager(self) -> "BackgroundManager":
+        return BackgroundManager()
+
+    def body_iterator(self) -> "BodyIterator":
+        return BodyIterator()
+
+
+class BackgroundManager(BaseBackgroundManager):
+    nursery: trio.Nursery
+
+    def __init__(self) -> None:
+        self.nursery_manager = trio.open_nursery()
+        self.convert = lambda coroutine: coroutine
+
+    def start_soon(self, coroutine: typing.Callable, *args: typing.Any) -> None:
+        self.nursery.start_soon(self.convert(coroutine), *args)
+
+    def will_wait_for_first_completed(self) -> BaseAsyncContextManager:
+        return WillWaitForFirstCompleted(self)
+
+    async def __aenter__(self) -> "BackgroundManager":
+        self.nursery = await self.nursery_manager.__aenter__()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: typing.Type[BaseException] = None,
+        exc_value: BaseException = None,
+        traceback: TracebackType = None,
+    ) -> None:
+        await self.nursery_manager.__aexit__(exc_type, exc_value, traceback)
+
+
+class BodyIterator(BaseBodyIterator):
+    def __init__(self) -> None:
+        self.send_channel, self.receive_channel = trio.open_memory_channel()
+
+    async def iterate(self) -> typing.AsyncIterator[bytes]:
+        async with self.receive_channel:
+            async for data in self.receive_channel:
+                assert isinstance(data, bytes)
+                yield data
+
+    async def put(self, data: bytes) -> None:
+        await self.send_channel.send(data)
+
+    async def done(self) -> None:
+        await self.send_channel.aclose()
+
+
+class WillWaitForFirstCompleted(BaseAsyncContextManager):
+    nursery: trio.Nursery
+
+    def __init__(self, background: BackgroundManager):
+        self.background = background
+        self.send_channel, self.receive_channel = trio.open_memory_channel(0)
+        self.initial_convert = self.background.convert
+        self.initial_nursery = self.background.nursery
+        self.nursery_manager = trio.open_nursery()
+
+    def convert(self, coroutine: typing.Callable) -> typing.Callable:
+        async def wrapped(*args: typing.Any) -> None:
+            await self.send_channel.send(await coroutine(*args))
+
+        return wrapped
+
+    async def __aenter__(self) -> None:
+        self.background.convert = self.convert
+        self.nursery = await self.nursery_manager.__aenter__()
+        self.background.nursery = self.nursery
+
+    async def __aexit__(self, *args: typing.Any) -> None:
+        await self.receive_channel.receive()
+        self.nursery.cancel_scope.cancel()
+        await self.nursery.__aexit__(*args)
+        self.background.convert = self.initial_convert
+        self.background.nursery = self.initial_nursery

--- a/httpx/dispatch/http11.py
+++ b/httpx/dispatch/http11.py
@@ -48,7 +48,8 @@ class HTTP11Connection:
         await self._send_request(request, timeout)
 
         task, args = self._send_request_data, [request.stream(), timeout]
-        async with self.backend.background_manager(task, args=args):
+        async with self.backend.background_manager() as background:
+            background.start_soon(task, *args)
             http_version, status_code, headers = await self._receive_response(timeout)
         content = self._receive_response_data(timeout)
 

--- a/httpx/dispatch/http2.py
+++ b/httpx/dispatch/http2.py
@@ -44,7 +44,8 @@ class HTTP2Connection:
         self.timeout_flags[stream_id] = TimeoutFlag()
 
         task, args = self.send_request_data, [stream_id, request.stream(), timeout]
-        async with self.backend.background_manager(task, args=args):
+        async with self.backend.background_manager() as background:
+            background.start_soon(task, *args)
             status_code, headers = await self.receive_response(stream_id, timeout)
         content = self.body_iter(stream_id, timeout)
         on_close = functools.partial(self.response_closed, stream_id=stream_id)

--- a/httpx/interfaces.py
+++ b/httpx/interfaces.py
@@ -162,14 +162,6 @@ class BaseEvent:
         raise NotImplementedError()  # pragma: no cover
 
 
-class BaseQueue:
-    async def get(self) -> typing.Any:
-        raise NotImplementedError()  # pragma: no cover
-
-    async def put(self, value: typing.Any) -> None:
-        raise NotImplementedError()  # pragma: no cover
-
-
 class BasePoolSemaphore:
     """
     A semaphore for use with connection pooling.
@@ -226,9 +218,6 @@ class ConcurrencyBackend:
     def create_event(self) -> BaseEvent:
         raise NotImplementedError()  # pragma: no cover
 
-    def create_queue(self, max_size: int) -> BaseQueue:
-        raise NotImplementedError()  # pragma: no cover
-
     def iterate(self, async_iterator):  # type: ignore
         while True:
             try:
@@ -237,6 +226,45 @@ class ConcurrencyBackend:
                 break
 
     def background_manager(self) -> "BaseBackgroundManager":
+        raise NotImplementedError()  # pragma: no cover
+
+    def body_iterator(self) -> "BaseBodyIterator":
+        raise NotImplementedError()  # pragma: no cover
+
+
+class BaseBodyIterator:
+    """
+    Provides a byte-iterator interface that the client can use to
+    ingest the response content from.
+    """
+
+    def __init__(self, backend: ConcurrencyBackend) -> None:
+        self.backend = backend
+
+    def iterate(self) -> typing.AsyncIterator[bytes]:
+        """
+        A byte-iterator, used by the client to consume the response body.
+        """
+        raise NotImplementedError()  # pragma: no cover
+
+    async def drain(self) -> None:
+        """
+        Drain any remaining body, in order to allow any blocked `put()` calls
+        to complete.
+        """
+        async for chunk in self.iterate():
+            pass  # pragma: no cover
+
+    async def put(self, data: bytes) -> None:
+        """
+        Used by the server to add data to the response body.
+        """
+        raise NotImplementedError()  # pragma: no cover
+
+    async def done(self) -> None:
+        """
+        Used by the server to signal the end of the response body.
+        """
         raise NotImplementedError()  # pragma: no cover
 
 

--- a/httpx/interfaces.py
+++ b/httpx/interfaces.py
@@ -265,14 +265,8 @@ class BaseBodyIterator:
         raise NotImplementedError()  # pragma: no cover
 
 
-class BaseBackgroundManager:
-    def start_soon(self, coroutine: typing.Callable, *args: typing.Any) -> None:
-        raise NotImplementedError()  # pragma: no cover
-
-    def will_wait_for_first_completed(self) -> typing.AsyncContextManager:
-        raise NotImplementedError()  # pragma: no cover
-
-    async def __aenter__(self) -> "BaseBackgroundManager":
+class BaseAsyncContextManager:
+    async def __aenter__(self: typing.T) -> typing.T:
         raise NotImplementedError()  # pragma: no cover
 
     async def __aexit__(
@@ -281,6 +275,14 @@ class BaseBackgroundManager:
         exc_value: BaseException = None,
         traceback: TracebackType = None,
     ) -> None:
+        raise NotImplementedError()  # pragma: no cover
+
+
+class BaseBackgroundManager(BaseAsyncContextManager):
+    def start_soon(self, coroutine: typing.Callable, *args: typing.Any) -> None:
+        raise NotImplementedError()  # pragma: no cover
+
+    def will_wait_for_first_completed(self) -> BaseAsyncContextManager:
         raise NotImplementedError()  # pragma: no cover
 
     async def close(self) -> None:

--- a/httpx/interfaces.py
+++ b/httpx/interfaces.py
@@ -151,6 +151,25 @@ class BaseWriter:
         raise NotImplementedError()  # pragma: no cover
 
 
+class BaseEvent:
+    def set(self) -> None:
+        raise NotImplementedError()  # pragma: no cover
+
+    def is_set(self) -> bool:
+        raise NotImplementedError()  # pragma: no cover
+
+    async def wait(self) -> None:
+        raise NotImplementedError()  # pragma: no cover
+
+
+class BaseQueue:
+    async def get(self) -> typing.Any:
+        raise NotImplementedError()  # pragma: no cover
+
+    async def put(self, value: typing.Any) -> None:
+        raise NotImplementedError()  # pragma: no cover
+
+
 class BasePoolSemaphore:
     """
     A semaphore for use with connection pooling.
@@ -204,6 +223,12 @@ class ConcurrencyBackend:
     ) -> typing.Any:
         raise NotImplementedError()  # pragma: no cover
 
+    def create_event(self) -> BaseEvent:
+        raise NotImplementedError()  # pragma: no cover
+
+    def create_queue(self, max_size: int) -> BaseQueue:
+        raise NotImplementedError()  # pragma: no cover
+
     def iterate(self, async_iterator):  # type: ignore
         while True:
             try:
@@ -211,13 +236,17 @@ class ConcurrencyBackend:
             except StopAsyncIteration:
                 break
 
-    def background_manager(
-        self, coroutine: typing.Callable, args: typing.Any
-    ) -> "BaseBackgroundManager":
+    def background_manager(self) -> "BaseBackgroundManager":
         raise NotImplementedError()  # pragma: no cover
 
 
 class BaseBackgroundManager:
+    def start_soon(self, coroutine: typing.Callable, *args: typing.Any) -> None:
+        raise NotImplementedError()  # pragma: no cover
+
+    def will_wait_for_first_completed(self) -> typing.AsyncContextManager:
+        raise NotImplementedError()  # pragma: no cover
+
     async def __aenter__(self) -> "BaseBackgroundManager":
         raise NotImplementedError()  # pragma: no cover
 
@@ -228,3 +257,6 @@ class BaseBackgroundManager:
         traceback: TracebackType = None,
     ) -> None:
         raise NotImplementedError()  # pragma: no cover
+
+    async def close(self) -> None:
+        await self.__aexit__(None, None, None)

--- a/httpx/interfaces.py
+++ b/httpx/interfaces.py
@@ -238,9 +238,6 @@ class BaseBodyIterator:
     ingest the response content from.
     """
 
-    def __init__(self, backend: ConcurrencyBackend) -> None:
-        self.backend = backend
-
     def iterate(self) -> typing.AsyncIterator[bytes]:
         """
         A byte-iterator, used by the client to consume the response body.

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         "hstspreload",
         "idna==2.*",
         "rfc3986==1.*",
+        "async_generator==1.*;python_version<'3.7'"
     ],
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "hstspreload",
         "idna==2.*",
         "rfc3986==1.*",
-        "async_generator==1.*;python_version<'3.7'"
+        "async_generator==1.*;python_version<'3.7'",
     ],
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setup(
         "hstspreload",
         "idna==2.*",
         "rfc3986==1.*",
-        "async_generator==1.*;python_version<'3.7'",
     ],
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -11,6 +11,8 @@ isort
 mypy
 pytest
 pytest-asyncio
+trio
+pytest-trio
 pytest-cov
 trustme
 uvicorn

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,10 +1,4 @@
-certifi
-chardet==3.*
-h11==0.8.*
-h2==3.*
-hstspreload
-idna==2.*
-rfc3986==1.*
+-e .
 
 # Optional
 brotlipy==0.7.*

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -1,27 +1,8 @@
-import functools
-
 import pytest
 
 import httpx
 
 
-def threadpool(func):
-    """
-    Async tests should run in a separate thread to the uvicorn server to prevent event
-    loop clashes (e.g. asyncio for uvicorn, trio for tests).
-    """
-
-    @functools.wraps(func)
-    async def wrapped(backend, *args, **kwargs):
-        backend_for_thread = type(backend)()
-        await backend.run_in_threadpool(
-            backend_for_thread.run, func, backend_for_thread, *args, **kwargs
-        )
-
-    return wrapped
-
-
-@threadpool
 @pytest.mark.usefixtures("server")
 async def test_get(backend):
     url = "http://127.0.0.1:8000/"
@@ -34,7 +15,6 @@ async def test_get(backend):
     assert repr(response) == "<Response [200 OK]>"
 
 
-@threadpool
 @pytest.mark.usefixtures("server")
 async def test_post(backend):
     url = "http://127.0.0.1:8000/"
@@ -43,7 +23,6 @@ async def test_post(backend):
     assert response.status_code == 200
 
 
-@threadpool
 @pytest.mark.usefixtures("server")
 async def test_post_json(backend):
     url = "http://127.0.0.1:8000/"
@@ -52,7 +31,6 @@ async def test_post_json(backend):
     assert response.status_code == 200
 
 
-@threadpool
 @pytest.mark.usefixtures("server")
 async def test_stream_response(backend):
     async with httpx.AsyncClient(backend=backend) as client:
@@ -63,7 +41,6 @@ async def test_stream_response(backend):
     assert response.content == b"Hello, world!"
 
 
-@threadpool
 @pytest.mark.usefixtures("server")
 async def test_access_content_stream_response(backend):
     async with httpx.AsyncClient(backend=backend) as client:
@@ -73,7 +50,6 @@ async def test_access_content_stream_response(backend):
         response.content
 
 
-@threadpool
 @pytest.mark.usefixtures("server")
 async def test_stream_request(backend):
     async def hello_world():
@@ -87,7 +63,6 @@ async def test_stream_request(backend):
     assert response.status_code == 200
 
 
-@threadpool
 @pytest.mark.usefixtures("server")
 async def test_raise_for_status(backend):
     async with httpx.AsyncClient(backend=backend) as client:
@@ -104,7 +79,6 @@ async def test_raise_for_status(backend):
                 assert response.raise_for_status() is None
 
 
-@threadpool
 @pytest.mark.usefixtures("server")
 async def test_options(backend):
     url = "http://127.0.0.1:8000/"
@@ -114,7 +88,6 @@ async def test_options(backend):
     assert response.text == "Hello, world!"
 
 
-@threadpool
 @pytest.mark.usefixtures("server")
 async def test_head(backend):
     url = "http://127.0.0.1:8000/"
@@ -124,7 +97,6 @@ async def test_head(backend):
     assert response.text == ""
 
 
-@threadpool
 @pytest.mark.usefixtures("server")
 async def test_put(backend):
     url = "http://127.0.0.1:8000/"
@@ -133,7 +105,6 @@ async def test_put(backend):
     assert response.status_code == 200
 
 
-@threadpool
 @pytest.mark.usefixtures("server")
 async def test_patch(backend):
     url = "http://127.0.0.1:8000/"
@@ -142,7 +113,6 @@ async def test_patch(backend):
     assert response.status_code == 200
 
 
-@threadpool
 @pytest.mark.usefixtures("server")
 async def test_delete(backend):
     url = "http://127.0.0.1:8000/"
@@ -152,7 +122,6 @@ async def test_delete(backend):
     assert response.text == "Hello, world!"
 
 
-@threadpool
 @pytest.mark.usefixtures("server")
 async def test_100_continue(backend):
     url = "http://127.0.0.1:8000/echo_body"

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -3,10 +3,9 @@ import pytest
 import httpx
 
 
-@pytest.mark.asyncio
-async def test_get(server):
+async def test_get(backend, server):
     url = "http://127.0.0.1:8000/"
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(backend=backend) as client:
         response = await client.get(url)
     assert response.status_code == 200
     assert response.text == "Hello, world!"
@@ -15,25 +14,22 @@ async def test_get(server):
     assert repr(response) == "<Response [200 OK]>"
 
 
-@pytest.mark.asyncio
-async def test_post(server):
+async def test_post(backend, server):
     url = "http://127.0.0.1:8000/"
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(backend=backend) as client:
         response = await client.post(url, data=b"Hello, world!")
     assert response.status_code == 200
 
 
-@pytest.mark.asyncio
-async def test_post_json(server):
+async def test_post_json(backend, server):
     url = "http://127.0.0.1:8000/"
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(backend=backend) as client:
         response = await client.post(url, json={"text": "Hello, world!"})
     assert response.status_code == 200
 
 
-@pytest.mark.asyncio
-async def test_stream_response(server):
-    async with httpx.AsyncClient() as client:
+async def test_stream_response(backend, server):
+    async with httpx.AsyncClient(backend=backend) as client:
         response = await client.request("GET", "http://127.0.0.1:8000/", stream=True)
     assert response.status_code == 200
     body = await response.read()
@@ -41,31 +37,28 @@ async def test_stream_response(server):
     assert response.content == b"Hello, world!"
 
 
-@pytest.mark.asyncio
-async def test_access_content_stream_response(server):
-    async with httpx.AsyncClient() as client:
+async def test_access_content_stream_response(backend, server):
+    async with httpx.AsyncClient(backend=backend) as client:
         response = await client.request("GET", "http://127.0.0.1:8000/", stream=True)
     assert response.status_code == 200
     with pytest.raises(httpx.ResponseNotRead):
         response.content
 
 
-@pytest.mark.asyncio
-async def test_stream_request(server):
+async def test_stream_request(backend, server):
     async def hello_world():
         yield b"Hello, "
         yield b"world!"
 
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(backend=backend) as client:
         response = await client.request(
             "POST", "http://127.0.0.1:8000/", data=hello_world()
         )
     assert response.status_code == 200
 
 
-@pytest.mark.asyncio
-async def test_raise_for_status(server):
-    async with httpx.AsyncClient() as client:
+async def test_raise_for_status(backend, server):
+    async with httpx.AsyncClient(backend=backend) as client:
         for status_code in (200, 400, 404, 500, 505):
             response = await client.request(
                 "GET", f"http://127.0.0.1:8000/status/{status_code}"
@@ -79,56 +72,50 @@ async def test_raise_for_status(server):
                 assert response.raise_for_status() is None
 
 
-@pytest.mark.asyncio
-async def test_options(server):
+async def test_options(backend, server):
     url = "http://127.0.0.1:8000/"
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(backend=backend) as client:
         response = await client.options(url)
     assert response.status_code == 200
     assert response.text == "Hello, world!"
 
 
-@pytest.mark.asyncio
-async def test_head(server):
+async def test_head(backend, server):
     url = "http://127.0.0.1:8000/"
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(backend=backend) as client:
         response = await client.head(url)
     assert response.status_code == 200
     assert response.text == ""
 
 
-@pytest.mark.asyncio
-async def test_put(server):
+async def test_put(backend, server):
     url = "http://127.0.0.1:8000/"
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(backend=backend) as client:
         response = await client.put(url, data=b"Hello, world!")
     assert response.status_code == 200
 
 
-@pytest.mark.asyncio
-async def test_patch(server):
+async def test_patch(backend, server):
     url = "http://127.0.0.1:8000/"
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(backend=backend) as client:
         response = await client.patch(url, data=b"Hello, world!")
     assert response.status_code == 200
 
 
-@pytest.mark.asyncio
-async def test_delete(server):
+async def test_delete(backend, server):
     url = "http://127.0.0.1:8000/"
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(backend=backend) as client:
         response = await client.delete(url)
     assert response.status_code == 200
     assert response.text == "Hello, world!"
 
 
-@pytest.mark.asyncio
-async def test_100_continue(server):
+async def test_100_continue(backend, server):
     url = "http://127.0.0.1:8000/echo_body"
     headers = {"Expect": "100-continue"}
     data = b"Echo request body"
 
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(backend=backend) as client:
         response = await client.post(url, headers=headers, data=data)
 
     assert response.status_code == 200

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -1,8 +1,27 @@
+import functools
+
 import pytest
 
 import httpx
 
 
+def threadpool(func):
+    """
+    Async tests should run in a separate thread to the uvicorn server to prevent event
+    loop clashes (e.g. asyncio for uvicorn, trio for tests).
+    """
+
+    @functools.wraps(func)
+    async def wrapped(backend, *args, **kwargs):
+        backend_for_thread = type(backend)()
+        await backend.run_in_threadpool(
+            backend_for_thread.run, func, backend_for_thread, *args, **kwargs
+        )
+
+    return wrapped
+
+
+@threadpool
 @pytest.mark.usefixtures("server")
 async def test_get(backend):
     url = "http://127.0.0.1:8000/"
@@ -15,6 +34,7 @@ async def test_get(backend):
     assert repr(response) == "<Response [200 OK]>"
 
 
+@threadpool
 @pytest.mark.usefixtures("server")
 async def test_post(backend):
     url = "http://127.0.0.1:8000/"
@@ -23,6 +43,7 @@ async def test_post(backend):
     assert response.status_code == 200
 
 
+@threadpool
 @pytest.mark.usefixtures("server")
 async def test_post_json(backend):
     url = "http://127.0.0.1:8000/"
@@ -31,6 +52,7 @@ async def test_post_json(backend):
     assert response.status_code == 200
 
 
+@threadpool
 @pytest.mark.usefixtures("server")
 async def test_stream_response(backend):
     async with httpx.AsyncClient(backend=backend) as client:
@@ -41,6 +63,7 @@ async def test_stream_response(backend):
     assert response.content == b"Hello, world!"
 
 
+@threadpool
 @pytest.mark.usefixtures("server")
 async def test_access_content_stream_response(backend):
     async with httpx.AsyncClient(backend=backend) as client:
@@ -50,6 +73,7 @@ async def test_access_content_stream_response(backend):
         response.content
 
 
+@threadpool
 @pytest.mark.usefixtures("server")
 async def test_stream_request(backend):
     async def hello_world():
@@ -63,6 +87,7 @@ async def test_stream_request(backend):
     assert response.status_code == 200
 
 
+@threadpool
 @pytest.mark.usefixtures("server")
 async def test_raise_for_status(backend):
     async with httpx.AsyncClient(backend=backend) as client:
@@ -79,6 +104,7 @@ async def test_raise_for_status(backend):
                 assert response.raise_for_status() is None
 
 
+@threadpool
 @pytest.mark.usefixtures("server")
 async def test_options(backend):
     url = "http://127.0.0.1:8000/"
@@ -88,6 +114,7 @@ async def test_options(backend):
     assert response.text == "Hello, world!"
 
 
+@threadpool
 @pytest.mark.usefixtures("server")
 async def test_head(backend):
     url = "http://127.0.0.1:8000/"
@@ -97,6 +124,7 @@ async def test_head(backend):
     assert response.text == ""
 
 
+@threadpool
 @pytest.mark.usefixtures("server")
 async def test_put(backend):
     url = "http://127.0.0.1:8000/"
@@ -105,6 +133,7 @@ async def test_put(backend):
     assert response.status_code == 200
 
 
+@threadpool
 @pytest.mark.usefixtures("server")
 async def test_patch(backend):
     url = "http://127.0.0.1:8000/"
@@ -113,6 +142,7 @@ async def test_patch(backend):
     assert response.status_code == 200
 
 
+@threadpool
 @pytest.mark.usefixtures("server")
 async def test_delete(backend):
     url = "http://127.0.0.1:8000/"
@@ -122,6 +152,7 @@ async def test_delete(backend):
     assert response.text == "Hello, world!"
 
 
+@threadpool
 @pytest.mark.usefixtures("server")
 async def test_100_continue(backend):
     url = "http://127.0.0.1:8000/echo_body"

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -3,7 +3,8 @@ import pytest
 import httpx
 
 
-async def test_get(backend, server):
+@pytest.mark.usefixtures("server")
+async def test_get(backend):
     url = "http://127.0.0.1:8000/"
     async with httpx.AsyncClient(backend=backend) as client:
         response = await client.get(url)
@@ -14,21 +15,24 @@ async def test_get(backend, server):
     assert repr(response) == "<Response [200 OK]>"
 
 
-async def test_post(backend, server):
+@pytest.mark.usefixtures("server")
+async def test_post(backend):
     url = "http://127.0.0.1:8000/"
     async with httpx.AsyncClient(backend=backend) as client:
         response = await client.post(url, data=b"Hello, world!")
     assert response.status_code == 200
 
 
-async def test_post_json(backend, server):
+@pytest.mark.usefixtures("server")
+async def test_post_json(backend):
     url = "http://127.0.0.1:8000/"
     async with httpx.AsyncClient(backend=backend) as client:
         response = await client.post(url, json={"text": "Hello, world!"})
     assert response.status_code == 200
 
 
-async def test_stream_response(backend, server):
+@pytest.mark.usefixtures("server")
+async def test_stream_response(backend):
     async with httpx.AsyncClient(backend=backend) as client:
         response = await client.request("GET", "http://127.0.0.1:8000/", stream=True)
     assert response.status_code == 200
@@ -37,7 +41,8 @@ async def test_stream_response(backend, server):
     assert response.content == b"Hello, world!"
 
 
-async def test_access_content_stream_response(backend, server):
+@pytest.mark.usefixtures("server")
+async def test_access_content_stream_response(backend):
     async with httpx.AsyncClient(backend=backend) as client:
         response = await client.request("GET", "http://127.0.0.1:8000/", stream=True)
     assert response.status_code == 200
@@ -45,7 +50,8 @@ async def test_access_content_stream_response(backend, server):
         response.content
 
 
-async def test_stream_request(backend, server):
+@pytest.mark.usefixtures("server")
+async def test_stream_request(backend):
     async def hello_world():
         yield b"Hello, "
         yield b"world!"
@@ -57,7 +63,8 @@ async def test_stream_request(backend, server):
     assert response.status_code == 200
 
 
-async def test_raise_for_status(backend, server):
+@pytest.mark.usefixtures("server")
+async def test_raise_for_status(backend):
     async with httpx.AsyncClient(backend=backend) as client:
         for status_code in (200, 400, 404, 500, 505):
             response = await client.request(
@@ -72,7 +79,8 @@ async def test_raise_for_status(backend, server):
                 assert response.raise_for_status() is None
 
 
-async def test_options(backend, server):
+@pytest.mark.usefixtures("server")
+async def test_options(backend):
     url = "http://127.0.0.1:8000/"
     async with httpx.AsyncClient(backend=backend) as client:
         response = await client.options(url)
@@ -80,7 +88,8 @@ async def test_options(backend, server):
     assert response.text == "Hello, world!"
 
 
-async def test_head(backend, server):
+@pytest.mark.usefixtures("server")
+async def test_head(backend):
     url = "http://127.0.0.1:8000/"
     async with httpx.AsyncClient(backend=backend) as client:
         response = await client.head(url)
@@ -88,21 +97,24 @@ async def test_head(backend, server):
     assert response.text == ""
 
 
-async def test_put(backend, server):
+@pytest.mark.usefixtures("server")
+async def test_put(backend):
     url = "http://127.0.0.1:8000/"
     async with httpx.AsyncClient(backend=backend) as client:
         response = await client.put(url, data=b"Hello, world!")
     assert response.status_code == 200
 
 
-async def test_patch(backend, server):
+@pytest.mark.usefixtures("server")
+async def test_patch(backend):
     url = "http://127.0.0.1:8000/"
     async with httpx.AsyncClient(backend=backend) as client:
         response = await client.patch(url, data=b"Hello, world!")
     assert response.status_code == 200
 
 
-async def test_delete(backend, server):
+@pytest.mark.usefixtures("server")
+async def test_delete(backend):
     url = "http://127.0.0.1:8000/"
     async with httpx.AsyncClient(backend=backend) as client:
         response = await client.delete(url)
@@ -110,7 +122,8 @@ async def test_delete(backend, server):
     assert response.text == "Hello, world!"
 
 
-async def test_100_continue(backend, server):
+@pytest.mark.usefixtures("server")
+async def test_100_continue(backend):
     url = "http://127.0.0.1:8000/echo_body"
     headers = {"Expect": "100-continue"}
     data = b"Echo request body"

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -19,7 +19,8 @@ def threadpool(func):
 
 
 @threadpool
-def test_get(backend, server):
+@pytest.mark.usefixtures("server")
+def test_get(backend):
     url = "http://127.0.0.1:8000/"
     with httpx.Client(backend=backend) as http:
         response = http.get(url)
@@ -36,7 +37,8 @@ def test_get(backend, server):
 
 
 @threadpool
-def test_post(backend, server):
+@pytest.mark.usefixtures("server")
+def test_post(backend):
     with httpx.Client(backend=backend) as http:
         response = http.post("http://127.0.0.1:8000/", data=b"Hello, world!")
     assert response.status_code == 200
@@ -44,7 +46,8 @@ def test_post(backend, server):
 
 
 @threadpool
-def test_post_json(backend, server):
+@pytest.mark.usefixtures("server")
+def test_post_json(backend):
     with httpx.Client(backend=backend) as http:
         response = http.post("http://127.0.0.1:8000/", json={"text": "Hello, world!"})
     assert response.status_code == 200
@@ -52,7 +55,8 @@ def test_post_json(backend, server):
 
 
 @threadpool
-def test_stream_response(backend, server):
+@pytest.mark.usefixtures("server")
+def test_stream_response(backend):
     with httpx.Client(backend=backend) as http:
         response = http.get("http://127.0.0.1:8000/", stream=True)
     assert response.status_code == 200
@@ -61,7 +65,8 @@ def test_stream_response(backend, server):
 
 
 @threadpool
-def test_stream_iterator(backend, server):
+@pytest.mark.usefixtures("server")
+def test_stream_iterator(backend):
     with httpx.Client(backend=backend) as http:
         response = http.get("http://127.0.0.1:8000/", stream=True)
     assert response.status_code == 200
@@ -72,7 +77,8 @@ def test_stream_iterator(backend, server):
 
 
 @threadpool
-def test_raw_iterator(backend, server):
+@pytest.mark.usefixtures("server")
+def test_raw_iterator(backend):
     with httpx.Client(backend=backend) as http:
         response = http.get("http://127.0.0.1:8000/", stream=True)
     assert response.status_code == 200
@@ -84,7 +90,8 @@ def test_raw_iterator(backend, server):
 
 
 @threadpool
-def test_raise_for_status(backend, server):
+@pytest.mark.usefixtures("server")
+def test_raise_for_status(backend):
     with httpx.Client(backend=backend) as client:
         for status_code in (200, 400, 404, 500, 505):
             response = client.request(
@@ -99,7 +106,8 @@ def test_raise_for_status(backend, server):
 
 
 @threadpool
-def test_options(backend, server):
+@pytest.mark.usefixtures("server")
+def test_options(backend):
     with httpx.Client(backend=backend) as http:
         response = http.options("http://127.0.0.1:8000/")
     assert response.status_code == 200
@@ -107,7 +115,8 @@ def test_options(backend, server):
 
 
 @threadpool
-def test_head(backend, server):
+@pytest.mark.usefixtures("server")
+def test_head(backend):
     with httpx.Client(backend=backend) as http:
         response = http.head("http://127.0.0.1:8000/")
     assert response.status_code == 200
@@ -115,7 +124,8 @@ def test_head(backend, server):
 
 
 @threadpool
-def test_put(backend, server):
+@pytest.mark.usefixtures("server")
+def test_put(backend):
     with httpx.Client(backend=backend) as http:
         response = http.put("http://127.0.0.1:8000/", data=b"Hello, world!")
     assert response.status_code == 200
@@ -123,7 +133,8 @@ def test_put(backend, server):
 
 
 @threadpool
-def test_patch(backend, server):
+@pytest.mark.usefixtures("server")
+def test_patch(backend):
     with httpx.Client(backend=backend) as http:
         response = http.patch("http://127.0.0.1:8000/", data=b"Hello, world!")
     assert response.status_code == 200
@@ -131,7 +142,8 @@ def test_patch(backend, server):
 
 
 @threadpool
-def test_delete(backend, server):
+@pytest.mark.usefixtures("server")
+def test_delete(backend):
     with httpx.Client(backend=backend) as http:
         response = http.delete("http://127.0.0.1:8000/")
     assert response.status_code == 200
@@ -139,7 +151,8 @@ def test_delete(backend, server):
 
 
 @threadpool
-def test_base_url(backend, server):
+@pytest.mark.usefixtures("server")
+def test_base_url(backend):
     base_url = "http://127.0.0.1:8000/"
     with httpx.Client(base_url=base_url, backend=backend) as http:
         response = http.get("/")

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1,24 +1,8 @@
-import functools
-
 import pytest
 
 import httpx
 
 
-def threadpool(func):
-    """
-    Our sync tests should run in seperate thread to the uvicorn server.
-    """
-
-    @functools.wraps(func)
-    async def wrapped(backend, *args, **kwargs):
-        backend_for_thread = type(backend)()
-        await backend.run_in_threadpool(func, backend_for_thread, *args, **kwargs)
-
-    return wrapped
-
-
-@threadpool
 @pytest.mark.usefixtures("server")
 def test_get(backend):
     url = "http://127.0.0.1:8000/"
@@ -36,7 +20,6 @@ def test_get(backend):
     assert repr(response) == "<Response [200 OK]>"
 
 
-@threadpool
 @pytest.mark.usefixtures("server")
 def test_post(backend):
     with httpx.Client(backend=backend) as http:
@@ -45,7 +28,6 @@ def test_post(backend):
     assert response.reason_phrase == "OK"
 
 
-@threadpool
 @pytest.mark.usefixtures("server")
 def test_post_json(backend):
     with httpx.Client(backend=backend) as http:
@@ -54,7 +36,6 @@ def test_post_json(backend):
     assert response.reason_phrase == "OK"
 
 
-@threadpool
 @pytest.mark.usefixtures("server")
 def test_stream_response(backend):
     with httpx.Client(backend=backend) as http:
@@ -64,7 +45,6 @@ def test_stream_response(backend):
     assert content == b"Hello, world!"
 
 
-@threadpool
 @pytest.mark.usefixtures("server")
 def test_stream_iterator(backend):
     with httpx.Client(backend=backend) as http:
@@ -76,7 +56,6 @@ def test_stream_iterator(backend):
     assert body == b"Hello, world!"
 
 
-@threadpool
 @pytest.mark.usefixtures("server")
 def test_raw_iterator(backend):
     with httpx.Client(backend=backend) as http:
@@ -89,7 +68,6 @@ def test_raw_iterator(backend):
     response.close()  # TODO: should Response be available as context managers?
 
 
-@threadpool
 @pytest.mark.usefixtures("server")
 def test_raise_for_status(backend):
     with httpx.Client(backend=backend) as client:
@@ -105,7 +83,6 @@ def test_raise_for_status(backend):
                 assert response.raise_for_status() is None
 
 
-@threadpool
 @pytest.mark.usefixtures("server")
 def test_options(backend):
     with httpx.Client(backend=backend) as http:
@@ -114,7 +91,6 @@ def test_options(backend):
     assert response.reason_phrase == "OK"
 
 
-@threadpool
 @pytest.mark.usefixtures("server")
 def test_head(backend):
     with httpx.Client(backend=backend) as http:
@@ -123,7 +99,6 @@ def test_head(backend):
     assert response.reason_phrase == "OK"
 
 
-@threadpool
 @pytest.mark.usefixtures("server")
 def test_put(backend):
     with httpx.Client(backend=backend) as http:
@@ -132,7 +107,6 @@ def test_put(backend):
     assert response.reason_phrase == "OK"
 
 
-@threadpool
 @pytest.mark.usefixtures("server")
 def test_patch(backend):
     with httpx.Client(backend=backend) as http:
@@ -141,7 +115,6 @@ def test_patch(backend):
     assert response.reason_phrase == "OK"
 
 
-@threadpool
 @pytest.mark.usefixtures("server")
 def test_delete(backend):
     with httpx.Client(backend=backend) as http:
@@ -150,7 +123,6 @@ def test_delete(backend):
     assert response.reason_phrase == "OK"
 
 
-@threadpool
 @pytest.mark.usefixtures("server")
 def test_base_url(backend):
     base_url = "http://127.0.0.1:8000/"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,18 @@ from cryptography.hazmat.primitives.serialization import (
 from uvicorn.config import Config
 from uvicorn.main import Server
 
+from httpx.concurrency import AsyncioBackend
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(AsyncioBackend, marks=pytest.mark.asyncio)  # type: ignore
+    ]
+)
+def backend(request):
+    backend_cls = request.param
+    return backend_cls()
+
 
 async def app(scope, receive, send):
     assert scope["type"] == "http"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,11 +13,7 @@ from uvicorn.main import Server
 from httpx.concurrency import AsyncioBackend
 
 
-@pytest.fixture(
-    params=[
-        pytest.param(AsyncioBackend, marks=pytest.mark.asyncio)  # type: ignore
-    ]
-)
+@pytest.fixture(params=[pytest.param(AsyncioBackend, marks=pytest.mark.asyncio)])
 def backend(request):
     backend_cls = request.param
     return backend_cls()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,10 +12,22 @@ from uvicorn.main import Server
 
 from httpx.concurrency import AsyncioBackend
 
+try:
+    from httpx.contrib.trio import TrioBackend
+except ImportError:
+    TrioBackend = None  # type: ignore
 
-@pytest.fixture(params=[pytest.param(AsyncioBackend, marks=pytest.mark.asyncio)])
+
+@pytest.fixture(
+    params=[
+        pytest.param(AsyncioBackend, marks=pytest.mark.asyncio),
+        pytest.param(TrioBackend, marks=pytest.mark.trio),
+    ]
+)
 def backend(request):
     backend_cls = request.param
+    if backend_cls is None:
+        pytest.skip()
     return backend_cls()
 
 


### PR DESCRIPTION
Refs #120 

For now I basically copy-pasted the asyncio backend from `concurrency` module and replaced asyncio-specific parts with the trio equivalent. Did the same thing for the async client tests to get a quick idea of how things were going.

Tests are read timing out for now, I'll try and look as to why that is the case tomorrow. :-)