### PR TITLE
Fix typos in docstrings

### DIFF
--- a/httpx/concurrency.py
+++ b/httpx/concurrency.py
@@ -30,7 +30,7 @@ SSL_MONKEY_PATCH_APPLIED = False
 
 def ssl_monkey_patch() -> None:
     """
-    Monky-patch for https://bugs.python.org/issue36709
+    Monkey-patch for https://bugs.python.org/issue36709
 
     This prevents console errors when outstanding HTTPS connections
     still exist at the point of exiting.

--- a/httpx/interfaces.py
+++ b/httpx/interfaces.py
@@ -120,7 +120,7 @@ class Dispatcher:
 
 class BaseReader:
     """
-    A stream reader. Abstracts away any asyncio-specfic interfaces
+    A stream reader. Abstracts away any asyncio-specific interfaces
     into a more generic base class, that we can use with alternate
     backend, or for stand-alone test cases.
     """

--- a/httpx/status_codes.py
+++ b/httpx/status_codes.py
@@ -51,11 +51,11 @@ class StatusCode(IntEnum):
 
     @classmethod
     def is_client_error(cls, value: int) -> bool:
-        return value >= 400 and value <= 499
+        return 400 <= value <= 499
 
     @classmethod
     def is_server_error(cls, value: int) -> bool:
-        return value >= 500 and value <= 599
+        return 500 <= value <= 599
 
     # informational
     CONTINUE = 100, "Continue"

--- a/tests/dispatch/test_connection_pools.py
+++ b/tests/dispatch/test_connection_pools.py
@@ -23,7 +23,7 @@ async def test_keepalive_connections(server):
 @pytest.mark.asyncio
 async def test_differing_connection_keys(server):
     """
-    Connnections to differing connection keys should result in multiple connections.
+    Connections to differing connection keys should result in multiple connections.
     """
     async with httpx.ConnectionPool() as http:
         response = await http.request("GET", "http://127.0.0.1:8000/")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,7 +8,7 @@ import httpx
 
 def threadpool(func):
     """
-    Our sync tests should run in seperate thread to the uvicorn server.
+    Our sync tests should run in separate thread to the uvicorn server.
     """
 
     @functools.wraps(func)


### PR DESCRIPTION
I have fixed some of the typos inside the docstrings, that I found while reading through the source code. 
Also, I changed the comparator inside the `StatusCode` to use chained comparators (suggested by Pycharm), which I can drop it, to only make the PR about typos. :grinning: 