### PR TITLE
Skip coverage on breaks right before returns for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,6 @@ matrix:
     - python: 3.8-dev
       env: NOX_SESSION=test-3.8
 
-  allow_failures:
-    - python: 3.8-dev
-
 install:
   - pip install --upgrade nox
 

--- a/httpx/config.py
+++ b/httpx/config.py
@@ -148,7 +148,7 @@ class SSLConfig:
 
         if ssl.HAS_ALPN:
             context.set_alpn_protocols(["h2", "http/1.1"])
-        if ssl.HAS_NPN:
+        if ssl.HAS_NPN:  # pragma: no cover
             context.set_npn_protocols(["h2", "http/1.1"])
 
         return context

--- a/httpx/dispatch/http11.py
+++ b/httpx/dispatch/http11.py
@@ -129,7 +129,7 @@ class HTTP11Connection:
                 continue
             else:
                 assert isinstance(event, h11.Response)
-                break
+                break  # pragma: no cover
         http_version = "HTTP/%s" % event.http_version.decode("latin-1", errors="ignore")
         return http_version, event.status_code, event.headers
 
@@ -145,7 +145,7 @@ class HTTP11Connection:
                 yield bytes(event.data)
             else:
                 assert isinstance(event, h11.EndOfMessage)
-                break
+                break  # pragma: no cover
 
     async def _receive_event(self, timeout: TimeoutConfig = None) -> H11Event:
         """
@@ -162,7 +162,8 @@ class HTTP11Connection:
                     data = b""
                 self.h11_state.receive_data(data)
             else:
-                break
+                assert event is not h11.NEED_DATA
+                break  # pragma: no cover
         return event
 
     async def response_closed(self) -> None:


### PR DESCRIPTION
This is a work-around for this bug: nedbat/coveragepy#772 which makes `break` statements not show up in the opcodes if they immediately precede a `return` statement due to peep-hole optimizations. This allows us to say we want 3.8 to always pass on CI. :)

Maybe in the future we should rely on Codecov to aggregate our code coverage so we don't need to do this but that has it's own set of issues.