### PR TITLE
Install package locally in test-requirements.txt

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,10 +1,4 @@
-certifi
-chardet==3.*
-h11==0.8.*
-h2==3.*
-hstspreload
-idna==2.*
-rfc3986==1.*
+-e .
 
 # Optional
 brotlipy==0.7.*


### PR DESCRIPTION
`setup.py` already defines the base requirements for `httpx`,  so we can install the package itself for development instead of re-listing those requirements in `test-requirements.txt`. :-)