### PR TITLE
Enforce that sync client uses asyncio-based backend

### DIFF
--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -158,3 +158,19 @@ def test_merge_url():
 
     assert url.scheme == "https"
     assert url.is_ssl
+
+
+class DerivedFromAsyncioBackend(httpx.AsyncioBackend):
+    pass
+
+
+class AnyBackend:
+    pass
+
+
+def test_client_backend_must_be_asyncio_based():
+    httpx.Client(backend=httpx.AsyncioBackend())
+    httpx.Client(backend=DerivedFromAsyncioBackend())
+
+    with pytest.raises(ValueError):
+        httpx.Client(backend=AnyBackend())


### PR DESCRIPTION
As suggested in #214 (https://github.com/encode/httpx/pull/214#issuecomment-522241493).

We still need the `backend` argument on `Client` for some of the tests (e.g. the HTTP2 mock backend in `test_http2.py`), so I figured a simple inheritance check would be enough, esp. since the `backend` argument is not documented.