### PR TITLE
modified README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The [Developer Interface](https://www.encode.io/httpx/api/) provides a comprehen
 
 ## Contribute
 
-If you want to contribute with HTTPX check out the [Contributing Guide](https://www.encode.io/httpx/contributing/) to learn how to start.
+If you want to contribute with HTTPX check out the [Contributing Guide](https://github.com/duttashi/httpx/blob/develop/docs/contributing.md) to learn how to start.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The [Developer Interface](https://www.encode.io/httpx/api/) provides a comprehen
 
 ## Contribute
 
-If you want to contribute with HTTPX check out the [Contributing Guide](https://github.com/duttashi/httpx/blob/develop/docs/contributing.md) to learn how to start.
+If you want to contribute with HTTPX check out the [Contributing Guide](https://github.com/encode/httpx/blob/master/docs/contributing.md) to learn how to start.
 
 ## Dependencies
 


### PR DESCRIPTION
- updated the url pointing to `contributing guide`. The existing url leads to an error 404 page not found