### PR TITLE
Turn concurrency.py into its own sub-package

### DIFF
--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -1,7 +1,7 @@
 from .__version__ import __description__, __title__, __version__
 from .api import delete, get, head, options, patch, post, put, request
 from .client import AsyncClient, Client
-from .concurrency import AsyncioBackend
+from .concurrency.asyncio import AsyncioBackend
 from .config import (
     USER_AGENT,
     CertTypes,

--- a/httpx/client.py
+++ b/httpx/client.py
@@ -5,7 +5,7 @@ from types import TracebackType
 import hstspreload
 
 from .auth import HTTPBasicAuth
-from .concurrency import AsyncioBackend
+from .concurrency.asyncio import AsyncioBackend
 from .config import (
     DEFAULT_MAX_REDIRECTS,
     DEFAULT_POOL_LIMITS,

--- a/httpx/concurrency/asyncio.py
+++ b/httpx/concurrency/asyncio.py
@@ -14,9 +14,9 @@ import ssl
 import typing
 from types import TracebackType
 
-from .config import PoolLimits, TimeoutConfig
-from .exceptions import ConnectTimeout, PoolTimeout, ReadTimeout, WriteTimeout
-from .interfaces import (
+from ..config import PoolLimits, TimeoutConfig
+from ..exceptions import ConnectTimeout, PoolTimeout, ReadTimeout, WriteTimeout
+from ..interfaces import (
     BaseBackgroundManager,
     BasePoolSemaphore,
     BaseReader,

--- a/httpx/dispatch/connection.py
+++ b/httpx/dispatch/connection.py
@@ -1,7 +1,7 @@
 import functools
 import typing
 
-from ..concurrency import AsyncioBackend
+from ..concurrency.asyncio import AsyncioBackend
 from ..config import (
     DEFAULT_TIMEOUT_CONFIG,
     CertTypes,

--- a/httpx/dispatch/connection_pool.py
+++ b/httpx/dispatch/connection_pool.py
@@ -1,6 +1,6 @@
 import typing
 
-from ..concurrency import AsyncioBackend
+from ..concurrency.asyncio import AsyncioBackend
 from ..config import (
     DEFAULT_POOL_LIMITS,
     DEFAULT_TIMEOUT_CONFIG,

--- a/httpx/dispatch/http11.py
+++ b/httpx/dispatch/http11.py
@@ -2,7 +2,7 @@ import typing
 
 import h11
 
-from ..concurrency import TimeoutFlag
+from ..concurrency.asyncio import TimeoutFlag
 from ..config import TimeoutConfig, TimeoutTypes
 from ..interfaces import BaseReader, BaseWriter, ConcurrencyBackend
 from ..models import AsyncRequest, AsyncResponse

--- a/httpx/dispatch/http2.py
+++ b/httpx/dispatch/http2.py
@@ -4,7 +4,7 @@ import typing
 import h2.connection
 import h2.events
 
-from ..concurrency import TimeoutFlag
+from ..concurrency.asyncio import TimeoutFlag
 from ..config import TimeoutConfig, TimeoutTypes
 from ..interfaces import BaseReader, BaseWriter, ConcurrencyBackend
 from ..models import AsyncRequest, AsyncResponse


### PR DESCRIPTION
Fixes #245 

Breaking things up from #217 for ease of review, this turns `concurrency.py` into a `concurrency` package.

Splitting `interfaces.py` into `concurrency/interfaces.py` will be tackled in a future PR.