### PR TITLE
Unify BaseReader and BaseWriter as BaseStream

### DIFF
--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -5,8 +5,7 @@ from .concurrency.asyncio import AsyncioBackend
 from .concurrency.base import (
     BaseBackgroundManager,
     BasePoolSemaphore,
-    BaseReader,
-    BaseWriter,
+    BaseStream,
     ConcurrencyBackend,
 )
 from .config import (
@@ -105,8 +104,7 @@ __all__ = [
     "TooManyRedirects",
     "WriteTimeout",
     "AsyncDispatcher",
-    "BaseReader",
-    "BaseWriter",
+    "BaseStream",
     "ConcurrencyBackend",
     "Dispatcher",
     "URL",

--- a/httpx/concurrency/asyncio.py
+++ b/httpx/concurrency/asyncio.py
@@ -1,5 +1,5 @@
 """
-The `Reader` and `Writer` classes here provide a lightweight layer over
+The `Stream` class here provides a lightweight layer over
 `asyncio.StreamReader` and `asyncio.StreamWriter`.
 
 Similarly `PoolSemaphore` is a lightweight layer over `BoundedSemaphore`.
@@ -14,18 +14,17 @@ import ssl
 import typing
 from types import TracebackType
 
+from ..config import PoolLimits, TimeoutConfig
+from ..exceptions import ConnectTimeout, PoolTimeout, ReadTimeout, WriteTimeout
 from .base import (
     BaseBackgroundManager,
     BasePoolSemaphore,
     BaseEvent,
     BaseQueue,
-    BaseReader,
-    BaseWriter,
+    BaseStream,
     ConcurrencyBackend,
     TimeoutFlag,
 )
-from ..config import PoolLimits, TimeoutConfig
-from ..exceptions import ConnectTimeout, PoolTimeout, ReadTimeout, WriteTimeout
 
 SSL_MONKEY_PATCH_APPLIED = False
 
@@ -51,11 +50,15 @@ def ssl_monkey_patch() -> None:
     MonkeyPatch.write = _fixed_write
 
 
-class Reader(BaseReader):
+class Stream(BaseStream):
     def __init__(
-        self, stream_reader: asyncio.StreamReader, timeout: TimeoutConfig
-    ) -> None:
+        self,
+        stream_reader: asyncio.StreamReader,
+        stream_writer: asyncio.StreamWriter,
+        timeout: TimeoutConfig,
+    ):
         self.stream_reader = stream_reader
+        self.stream_writer = stream_writer
         self.timeout = timeout
 
     async def read(
@@ -77,15 +80,6 @@ class Reader(BaseReader):
                     raise ReadTimeout() from None
 
         return data
-
-    def is_connection_dropped(self) -> bool:
-        return self.stream_reader.at_eof()
-
-
-class Writer(BaseWriter):
-    def __init__(self, stream_writer: asyncio.StreamWriter, timeout: TimeoutConfig):
-        self.stream_writer = stream_writer
-        self.timeout = timeout
 
     def write_no_block(self, data: bytes) -> None:
         self.stream_writer.write(data)  # pragma: nocover
@@ -113,6 +107,9 @@ class Writer(BaseWriter):
                 should_raise = flag is None or flag.raise_on_write_timeout
                 if should_raise:
                     raise WriteTimeout() from None
+
+    def is_connection_dropped(self) -> bool:
+        return self.stream_reader.at_eof()
 
     async def close(self) -> None:
         self.stream_writer.close()
@@ -172,7 +169,7 @@ class AsyncioBackend(ConcurrencyBackend):
         port: int,
         ssl_context: typing.Optional[ssl.SSLContext],
         timeout: TimeoutConfig,
-    ) -> typing.Tuple[BaseReader, BaseWriter, str]:
+    ) -> typing.Tuple[BaseStream, str]:
         try:
             stream_reader, stream_writer = await asyncio.wait_for(  # type: ignore
                 asyncio.open_connection(hostname, port, ssl=ssl_context),
@@ -189,11 +186,12 @@ class AsyncioBackend(ConcurrencyBackend):
             if ident is None:
                 ident = ssl_object.selected_npn_protocol()
 
-        reader = Reader(stream_reader=stream_reader, timeout=timeout)
-        writer = Writer(stream_writer=stream_writer, timeout=timeout)
+        stream = Stream(
+            stream_reader=stream_reader, stream_writer=stream_writer, timeout=timeout
+        )
         http_version = "HTTP/2" if ident == "h2" else "HTTP/1.1"
 
-        return reader, writer, http_version
+        return stream, http_version
 
     async def run_in_threadpool(
         self, func: typing.Callable, *args: typing.Any, **kwargs: typing.Any

--- a/httpx/concurrency/base.py
+++ b/httpx/concurrency/base.py
@@ -37,28 +37,17 @@ class TimeoutFlag:
         self.raise_on_write_timeout = True
 
 
-class BaseReader:
+class BaseStream:
     """
-    A stream reader. Abstracts away any asyncio-specific interfaces
-    into a more generic base class, that we can use with alternate
-    backend, or for stand-alone test cases.
+    A stream with read/write operations. Abstracts away any asyncio-specific
+    interfaces into a more generic base class, that we can use with alternate
+    backends, or for stand-alone test cases.
     """
 
     async def read(
         self, n: int, timeout: TimeoutConfig = None, flag: typing.Any = None
     ) -> bytes:
         raise NotImplementedError()  # pragma: no cover
-
-    def is_connection_dropped(self) -> bool:
-        raise NotImplementedError()  # pragma: no cover
-
-
-class BaseWriter:
-    """
-    A stream writer. Abstracts away any asyncio-specific interfaces
-    into a more generic base class, that we can use with alternate
-    backend, or for stand-alone test cases.
-    """
 
     def write_no_block(self, data: bytes) -> None:
         raise NotImplementedError()  # pragma: no cover
@@ -67,6 +56,9 @@ class BaseWriter:
         raise NotImplementedError()  # pragma: no cover
 
     async def close(self) -> None:
+        raise NotImplementedError()  # pragma: no cover
+
+    def is_connection_dropped(self) -> bool:
         raise NotImplementedError()  # pragma: no cover
 
 
@@ -118,7 +110,7 @@ class ConcurrencyBackend:
         port: int,
         ssl_context: typing.Optional[ssl.SSLContext],
         timeout: TimeoutConfig,
-    ) -> typing.Tuple[BaseReader, BaseWriter, str]:
+    ) -> typing.Tuple[BaseStream, str]:
         raise NotImplementedError()  # pragma: no cover
 
     def get_semaphore(self, limits: PoolLimits) -> BasePoolSemaphore:

--- a/httpx/concurrency/base.py
+++ b/httpx/concurrency/base.py
@@ -44,6 +44,9 @@ class BaseStream:
     backends, or for stand-alone test cases.
     """
 
+    def get_http_version(self) -> str:
+        raise NotImplementedError()  # pragma: no cover
+
     async def read(
         self, n: int, timeout: TimeoutConfig = None, flag: typing.Any = None
     ) -> bytes:
@@ -110,7 +113,7 @@ class ConcurrencyBackend:
         port: int,
         ssl_context: typing.Optional[ssl.SSLContext],
         timeout: TimeoutConfig,
-    ) -> typing.Tuple[BaseStream, str]:
+    ) -> BaseStream:
         raise NotImplementedError()  # pragma: no cover
 
     def get_semaphore(self, limits: PoolLimits) -> BasePoolSemaphore:

--- a/httpx/dispatch/connection.py
+++ b/httpx/dispatch/connection.py
@@ -79,17 +79,17 @@ class HTTPConnection(AsyncDispatcher):
         else:
             on_release = functools.partial(self.release_func, self)
 
-        reader, writer, http_version = await self.backend.connect(
+        stream, http_version = await self.backend.connect(
             host, port, ssl_context, timeout
         )
         if http_version == "HTTP/2":
             self.h2_connection = HTTP2Connection(
-                reader, writer, self.backend, on_release=on_release
+                stream, self.backend, on_release=on_release
             )
         else:
             assert http_version == "HTTP/1.1"
             self.h11_connection = HTTP11Connection(
-                reader, writer, self.backend, on_release=on_release
+                stream, self.backend, on_release=on_release
             )
 
     async def get_ssl_context(self, ssl: SSLConfig) -> typing.Optional[ssl.SSLContext]:

--- a/httpx/dispatch/connection.py
+++ b/httpx/dispatch/connection.py
@@ -79,9 +79,9 @@ class HTTPConnection(AsyncDispatcher):
         else:
             on_release = functools.partial(self.release_func, self)
 
-        stream, http_version = await self.backend.connect(
-            host, port, ssl_context, timeout
-        )
+        stream = await self.backend.connect(host, port, ssl_context, timeout)
+        http_version = stream.get_http_version()
+
         if http_version == "HTTP/2":
             self.h2_connection = HTTP2Connection(
                 stream, self.backend, on_release=on_release
@@ -96,7 +96,7 @@ class HTTPConnection(AsyncDispatcher):
         if not self.origin.is_ssl:
             return None
 
-        # Run the SSL loading in a threadpool, since it may makes disk accesses.
+        # Run the SSL loading in a threadpool, since it may make disk accesses.
         return await self.backend.run_in_threadpool(
             ssl.load_ssl_context, self.http_versions
         )

--- a/httpx/dispatch/http2.py
+++ b/httpx/dispatch/http2.py
@@ -4,7 +4,7 @@ import typing
 import h2.connection
 import h2.events
 
-from ..concurrency.base import BaseReader, BaseWriter, ConcurrencyBackend, TimeoutFlag
+from ..concurrency.base import BaseStream, ConcurrencyBackend, TimeoutFlag
 from ..config import TimeoutConfig, TimeoutTypes
 from ..models import AsyncRequest, AsyncResponse
 
@@ -14,13 +14,11 @@ class HTTP2Connection:
 
     def __init__(
         self,
-        reader: BaseReader,
-        writer: BaseWriter,
+        stream: BaseStream,
         backend: ConcurrencyBackend,
         on_release: typing.Callable = None,
     ):
-        self.reader = reader
-        self.writer = writer
+        self.stream = stream
         self.backend = backend
         self.on_release = on_release
         self.h2_state = h2.connection.H2Connection()
@@ -58,12 +56,12 @@ class HTTP2Connection:
         )
 
     async def close(self) -> None:
-        await self.writer.close()
+        await self.stream.close()
 
     def initiate_connection(self) -> None:
         self.h2_state.initiate_connection()
         data_to_send = self.h2_state.data_to_send()
-        self.writer.write_no_block(data_to_send)
+        self.stream.write_no_block(data_to_send)
         self.initialized = True
 
     async def send_headers(
@@ -78,7 +76,7 @@ class HTTP2Connection:
         ] + [(k, v) for k, v in request.headers.raw if k != b"host"]
         self.h2_state.send_headers(stream_id, headers)
         data_to_send = self.h2_state.data_to_send()
-        await self.writer.write(data_to_send, timeout)
+        await self.stream.write(data_to_send, timeout)
         return stream_id
 
     async def send_request_data(
@@ -104,12 +102,12 @@ class HTTP2Connection:
             chunk = data[idx : idx + chunk_size]
             self.h2_state.send_data(stream_id, chunk)
             data_to_send = self.h2_state.data_to_send()
-            await self.writer.write(data_to_send, timeout)
+            await self.stream.write(data_to_send, timeout)
 
     async def end_stream(self, stream_id: int, timeout: TimeoutConfig = None) -> None:
         self.h2_state.end_stream(stream_id)
         data_to_send = self.h2_state.data_to_send()
-        await self.writer.write(data_to_send, timeout)
+        await self.stream.write(data_to_send, timeout)
 
     async def receive_response(
         self, stream_id: int, timeout: TimeoutConfig = None
@@ -150,14 +148,14 @@ class HTTP2Connection:
     ) -> h2.events.Event:
         while not self.events[stream_id]:
             flag = self.timeout_flags[stream_id]
-            data = await self.reader.read(self.READ_NUM_BYTES, timeout, flag=flag)
+            data = await self.stream.read(self.READ_NUM_BYTES, timeout, flag=flag)
             events = self.h2_state.receive_data(data)
             for event in events:
                 if getattr(event, "stream_id", 0):
                     self.events[event.stream_id].append(event)
 
             data_to_send = self.h2_state.data_to_send()
-            await self.writer.write(data_to_send, timeout)
+            await self.stream.write(data_to_send, timeout)
 
         return self.events[stream_id].pop(0)
 
@@ -173,4 +171,4 @@ class HTTP2Connection:
         return False
 
     def is_connection_dropped(self) -> bool:
-        return self.reader.is_connection_dropped()
+        return self.stream.is_connection_dropped()

--- a/tests/dispatch/utils.py
+++ b/tests/dispatch/utils.py
@@ -20,9 +20,9 @@ class MockHTTP2Backend(AsyncioBackend):
         port: int,
         ssl_context: typing.Optional[ssl.SSLContext],
         timeout: TimeoutConfig,
-    ) -> typing.Tuple[BaseStream, str]:
+    ) -> BaseStream:
         self.server = MockHTTP2Server(self.app)
-        return self.server, "HTTP/2"
+        return self.server
 
 
 class MockHTTP2Server(BaseStream):
@@ -35,6 +35,9 @@ class MockHTTP2Server(BaseStream):
         self.close_connection = False
 
     # Stream interface
+
+    def get_http_version(self) -> str:
+        return "HTTP/2"
 
     async def read(self, n, timeout, flag=None) -> bytes:
         await asyncio.sleep(0)

--- a/tests/dispatch/utils.py
+++ b/tests/dispatch/utils.py
@@ -6,7 +6,7 @@ import h2.config
 import h2.connection
 import h2.events
 
-from httpx import AsyncioBackend, BaseReader, BaseWriter, Request, TimeoutConfig
+from httpx import AsyncioBackend, BaseStream, Request, TimeoutConfig
 
 
 class MockHTTP2Backend(AsyncioBackend):
@@ -20,16 +20,12 @@ class MockHTTP2Backend(AsyncioBackend):
         port: int,
         ssl_context: typing.Optional[ssl.SSLContext],
         timeout: TimeoutConfig,
-    ) -> typing.Tuple[BaseReader, BaseWriter, str]:
+    ) -> typing.Tuple[BaseStream, str]:
         self.server = MockHTTP2Server(self.app)
-        return self.server, self.server, "HTTP/2"
+        return self.server, "HTTP/2"
 
 
-class MockHTTP2Server(BaseReader, BaseWriter):
-    """
-    This class exposes Reader and Writer style interfaces.
-    """
-
+class MockHTTP2Server(BaseStream):
     def __init__(self, app):
         config = h2.config.H2Configuration(client_side=False)
         self.conn = h2.connection.H2Connection(config=config)
@@ -38,14 +34,12 @@ class MockHTTP2Server(BaseReader, BaseWriter):
         self.requests = {}
         self.close_connection = False
 
-    # BaseReader interface
+    # Stream interface
 
     async def read(self, n, timeout, flag=None) -> bytes:
         await asyncio.sleep(0)
         send, self.buffer = self.buffer[:n], self.buffer[n:]
         return send
-
-    # BaseWriter interface
 
     def write_no_block(self, data: bytes) -> None:
         events = self.conn.receive_data(data)


### PR DESCRIPTION
Based on a suggestion from @tomchristie in https://github.com/encode/httpx/pull/217#issuecomment-522571545, simplifies the stream interface by merging `BaseReader` and `BaseWriter` into a unified stream interface.