### PR TITLE
Add BaseEvent interface

### DIFF
--- a/httpx/concurrency/asyncio.py
+++ b/httpx/concurrency/asyncio.py
@@ -17,6 +17,7 @@ from types import TracebackType
 from .base import (
     BaseBackgroundManager,
     BasePoolSemaphore,
+    BaseEvent,
     BaseQueue,
     BaseReader,
     BaseWriter,
@@ -218,6 +219,9 @@ class AsyncioBackend(ConcurrencyBackend):
 
     def create_queue(self, max_size: int) -> BaseQueue:
         return typing.cast(BaseQueue, asyncio.Queue(maxsize=max_size))
+
+    def create_event(self) -> BaseEvent:
+        return typing.cast(BaseEvent, asyncio.Event())
 
     def background_manager(
         self, coroutine: typing.Callable, args: typing.Any

--- a/httpx/concurrency/base.py
+++ b/httpx/concurrency/base.py
@@ -82,6 +82,21 @@ class BaseQueue:
         raise NotImplementedError()  # pragma: no cover
 
 
+class BaseEvent:
+    """
+    An event object. Abstracts away any asyncio-specific interfaces.
+    """
+
+    def set(self) -> None:
+        raise NotImplementedError()  # pragma: no cover
+
+    def is_set(self) -> bool:
+        raise NotImplementedError()  # pragma: no cover
+
+    async def wait(self) -> None:
+        raise NotImplementedError()  # pragma: no cover
+
+
 class BasePoolSemaphore:
     """
     A semaphore for use with connection pooling.
@@ -143,6 +158,9 @@ class ConcurrencyBackend:
                 break
 
     def create_queue(self, max_size: int) -> BaseQueue:
+        raise NotImplementedError()  # pragma: no cover
+
+    def create_event(self) -> BaseEvent:
         raise NotImplementedError()  # pragma: no cover
 
     def background_manager(

--- a/httpx/dispatch/asgi.py
+++ b/httpx/dispatch/asgi.py
@@ -82,7 +82,7 @@ class ASGIDispatch(AsyncDispatcher):
         app_exc = None
         status_code = None
         headers = None
-        response_started_or_failed = asyncio.Event()
+        response_started_or_failed = self.backend.create_event()
         response_body = BodyIterator(self.backend)
         request_stream = request.stream()
 


### PR DESCRIPTION
Add a `BaseEvent` interface to abstract away `asyncio.Event()`, esp. in `ASGIDispatch`.

Refs #247 