### PR TITLE
Rely on codecov for 100% project coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,5 @@ script:
 after_script:
   - if [ -f .coverage ]; then
       python -m pip install codecov;
-      codecov;
+      codecov --required;
     fi

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+    status:
+        patch:
+            default:
+                target: '100'
+        project:
+            default:
+                target: '100'

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,4 +16,4 @@ line_length = 88
 multi_line_output = 3
 
 [tool:pytest]
-addopts = --cov=httpx --cov=tests --cov-report=term-missing --cov-fail-under=100
+addopts = --cov=httpx --cov=tests --cov-report=term-missing


### PR DESCRIPTION
As can be seen in #263 we can't have all code be covered by Python 3.6 and I don't want to mark that large chunk of code as `no cover`.