### PR TITLE
executor for io/cpu bound projects

### DIFF
--- a/httpx/concurrency/base.py
+++ b/httpx/concurrency/base.py
@@ -136,7 +136,9 @@ class ConcurrencyBackend:
 
         while True:
             try:
-                yield await self.run_in_threadpool(next_wrapper, iterator)
+                yield await self.run_in_threadpool(
+                    next_wrapper, iterator, is_iterate=True
+                )
             except IterationComplete:
                 break
 


### PR DESCRIPTION
Hi, I was wondering that how to use `ProcessPoolExecutor, ThreadPoolExecutor` in HTTPX. Does this approach can follow httpx's philosophy, or should users handle it in their codes?  