### PR TITLE
Add missing async test cases

### DIFF
--- a/tests/dispatch/test_http2.py
+++ b/tests/dispatch/test_http2.py
@@ -1,6 +1,8 @@
 import json
 
-from httpx import Client, Response
+import pytest
+
+from httpx import AsyncClient, Client, Response
 
 from .utils import MockHTTP2Backend
 
@@ -27,11 +29,37 @@ def test_http2_get_request():
     assert json.loads(response.content) == {"method": "GET", "path": "/", "body": ""}
 
 
+@pytest.mark.asyncio
+async def test_async_http2_get_request():
+    backend = MockHTTP2Backend(app=app)
+
+    async with AsyncClient(backend=backend) as client:
+        response = await client.get("http://example.org")
+
+    assert response.status_code == 200
+    assert json.loads(response.content) == {"method": "GET", "path": "/", "body": ""}
+
+
 def test_http2_post_request():
     backend = MockHTTP2Backend(app=app)
 
     with Client(backend=backend) as client:
         response = client.post("http://example.org", data=b"<data>")
+
+    assert response.status_code == 200
+    assert json.loads(response.content) == {
+        "method": "POST",
+        "path": "/",
+        "body": "<data>",
+    }
+
+
+@pytest.mark.asyncio
+async def test_async_http2_post_request():
+    backend = MockHTTP2Backend(app=app)
+
+    async with AsyncClient(backend=backend) as client:
+        response = await client.post("http://example.org", data=b"<data>")
 
     assert response.status_code == 200
     assert json.loads(response.content) == {
@@ -59,6 +87,25 @@ def test_http2_multiple_requests():
     assert json.loads(response_3.content) == {"method": "GET", "path": "/3", "body": ""}
 
 
+@pytest.mark.asyncio
+async def test_async_http2_multiple_requests():
+    backend = MockHTTP2Backend(app=app)
+
+    async with AsyncClient(backend=backend) as client:
+        response_1 = await client.get("http://example.org/1")
+        response_2 = await client.get("http://example.org/2")
+        response_3 = await client.get("http://example.org/3")
+
+    assert response_1.status_code == 200
+    assert json.loads(response_1.content) == {"method": "GET", "path": "/1", "body": ""}
+
+    assert response_2.status_code == 200
+    assert json.loads(response_2.content) == {"method": "GET", "path": "/2", "body": ""}
+
+    assert response_3.status_code == 200
+    assert json.loads(response_3.content) == {"method": "GET", "path": "/3", "body": ""}
+
+
 def test_http2_reconnect():
     """
     If a connection has been dropped between requests, then we should
@@ -70,6 +117,26 @@ def test_http2_reconnect():
         response_1 = client.get("http://example.org/1")
         backend.server.close_connection = True
         response_2 = client.get("http://example.org/2")
+
+    assert response_1.status_code == 200
+    assert json.loads(response_1.content) == {"method": "GET", "path": "/1", "body": ""}
+
+    assert response_2.status_code == 200
+    assert json.loads(response_2.content) == {"method": "GET", "path": "/2", "body": ""}
+
+
+@pytest.mark.asyncio
+async def test_async_http2_reconnect():
+    """
+    If a connection has been dropped between requests, then we should
+    be seemlessly reconnected.
+    """
+    backend = MockHTTP2Backend(app=app)
+
+    async with AsyncClient(backend=backend) as client:
+        response_1 = await client.get("http://example.org/1")
+        backend.server.close_connection = True
+        response_2 = await client.get("http://example.org/2")
 
     assert response_1.status_code == 200
     assert json.loads(response_1.content) == {"method": "GET", "path": "/1", "body": ""}

--- a/tests/dispatch/test_threaded.py
+++ b/tests/dispatch/test_threaded.py
@@ -1,6 +1,9 @@
 import json
 
+import pytest
+
 from httpx import (
+    AsyncClient,
     CertTypes,
     Client,
     Dispatcher,
@@ -39,12 +42,26 @@ class MockDispatch(Dispatcher):
 
 def test_threaded_dispatch():
     """
-    Use a syncronous 'Dispatcher' class with the client.
+    Use a synchronous 'Dispatcher' class with the client.
     Calls to the dispatcher will end up running within a thread pool.
     """
     url = "https://example.org/"
     with Client(dispatch=MockDispatch()) as client:
         response = client.get(url)
+
+    assert response.status_code == 200
+    assert response.json() == {"hello": "world"}
+
+
+@pytest.mark.asyncio
+async def test_async_threaded_dispatch():
+    """
+    Use a synchronous 'Dispatcher' class with the async client.
+    Calls to the dispatcher will end up running within a thread pool.
+    """
+    url = "https://example.org/"
+    async with AsyncClient(dispatch=MockDispatch()) as client:
+        response = await client.get(url)
 
     assert response.status_code == 200
     assert response.json() == {"hello": "world"}

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -46,9 +46,25 @@ def test_asgi():
     assert response.text == "Hello, World!"
 
 
+@pytest.mark.asyncio
+async def test_asgi_async():
+    client = httpx.AsyncClient(app=hello_world)
+    response = await client.get("http://www.example.org/")
+    assert response.status_code == 200
+    assert response.text == "Hello, World!"
+
+
 def test_asgi_upload():
     client = httpx.Client(app=echo_body)
     response = client.post("http://www.example.org/", data=b"example")
+    assert response.status_code == 200
+    assert response.text == "example"
+
+
+@pytest.mark.asyncio
+async def test_asgi_upload_async():
+    client = httpx.AsyncClient(app=echo_body)
+    response = await client.post("http://www.example.org/", data=b"example")
     assert response.status_code == 200
     assert response.text == "example"
 
@@ -59,7 +75,21 @@ def test_asgi_exc():
         client.get("http://www.example.org/")
 
 
+@pytest.mark.asyncio
+async def test_asgi_exc_async():
+    client = httpx.AsyncClient(app=raise_exc)
+    with pytest.raises(ValueError):
+        await client.get("http://www.example.org/")
+
+
 def test_asgi_exc_after_response():
     client = httpx.Client(app=raise_exc_after_response)
     with pytest.raises(ValueError):
         client.get("http://www.example.org/")
+
+
+@pytest.mark.asyncio
+async def test_asgi_exc_after_response_async():
+    client = httpx.AsyncClient(app=raise_exc_after_response)
+    with pytest.raises(ValueError):
+        await client.get("http://www.example.org/")


### PR DESCRIPTION
There were a few test cases that didn't have an async equivalent, so I added those (mostly by copy-paste-asyncify-ing, but I think it ends up being fine from a maintainability perspective).

Besides expanding functional coverage, these will be useful to test alternative backends that can't shouldn't be with the sync `Client`. For example, this will allow us to test HTTP/2 with the trio backend.