### PR TITLE
Add easier debug logging for users

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -1,0 +1,47 @@
+Environment Variables
+=====================
+
+The HTTPX library can be configured via environment variables.
+Here are a list of environment variables that HTTPX recognizes
+and what function they serve:
+
+HTTPX_DEBUG
+-----------
+
+Valid values: `1`, `true`
+
+If this environment variable is set to `1` or `true` then
+logging will be turned on by default to stderr about low-level
+details of the HTTP request and responses being sent and received.
+
+This can help you debug issues and see what's exactly being sent
+over the wire and to which location.
+
+Example:
+
+```python
+# test_script.py
+
+import httpx
+client = httpx.Client()
+client.request("GET", "https://google.com")
+```
+
+```console
+user@host:~$ HTTPX_DEBUG=1 python test_script.py
+20:54:17.585 - httpx.dispatch.connection_pool - acquire_connection origin=Origin(scheme='https' host='www.google.com' port=443)
+20:54:17.585 - httpx.dispatch.connection_pool - new_connection connection=HTTPConnection(origin=Origin(scheme='https' host='www.google.com' port=443))
+20:54:17.590 - httpx.dispatch.connection - start_connect host='www.google.com' port=443 timeout=TimeoutConfig(timeout=5.0)
+20:54:17.651 - httpx.dispatch.connection - connected http_version='HTTP/2'
+20:54:17.651 - httpx.dispatch.http2 - send_headers stream_id=1 headers=[(b':method', b'GET'), (b':authority', b'www.google.com'), ...]
+20:54:17.652 - httpx.dispatch.http2 - end_stream stream_id=1
+20:54:17.681 - httpx.dispatch.http2 - receive_event stream_id=0 event=<RemoteSettingsChanged changed_settings:{...}>
+20:54:17.681 - httpx.dispatch.http2 - receive_event stream_id=0 event=<WindowUpdated stream_id:0, delta:983041>
+20:54:17.682 - httpx.dispatch.http2 - receive_event stream_id=0 event=<SettingsAcknowledged changed_settings:{}>
+20:54:17.739 - httpx.dispatch.http2 - receive_event stream_id=1 event=<ResponseReceived stream_id:1, headers:[(b':status', b'200'), ...]>
+20:54:17.741 - httpx.dispatch.http2 - receive_event stream_id=1 event=<DataReceived stream_id:1, flow_controlled_length:5224 data:>
+20:54:17.742 - httpx.dispatch.http2 - receive_event stream_id=1 event=<DataReceived stream_id:1, flow_controlled_length:59, data:>
+20:54:17.742 - httpx.dispatch.http2 - receive_event stream_id=1 event=<StreamEnded stream_id:1>
+20:54:17.742 - httpx.dispatch.http2 - receive_event stream_id=0 event=<PingReceived ping_data:0000000000000000>
+20:54:17.743 - httpx.dispatch.connection_pool - release_connection connection=HTTPConnection(origin=Origin(scheme='https' host='www.google.com' port=443))
+```

--- a/httpx/dispatch/connection_pool.py
+++ b/httpx/dispatch/connection_pool.py
@@ -12,10 +12,14 @@ from ..config import (
     VerifyTypes,
 )
 from ..models import AsyncRequest, AsyncResponse, Origin
+from ..utils import get_logger
 from .base import AsyncDispatcher
 from .connection import HTTPConnection
 
 CONNECTIONS_DICT = typing.Dict[Origin, typing.List[HTTPConnection]]
+
+
+logger = get_logger(__name__)
 
 
 class ConnectionStore:
@@ -122,6 +126,7 @@ class ConnectionPool(AsyncDispatcher):
         return response
 
     async def acquire_connection(self, origin: Origin) -> HTTPConnection:
+        logger.debug(f"acquire_connection origin={origin!r}")
         connection = self.active_connections.pop_by_origin(origin, http2_only=True)
         if connection is None:
             connection = self.keepalive_connections.pop_by_origin(origin)
@@ -141,12 +146,16 @@ class ConnectionPool(AsyncDispatcher):
                 backend=self.backend,
                 release_func=self.release_connection,
             )
+            logger.debug(f"new_connection connection={connection!r}")
+        else:
+            logger.debug(f"reuse_connection connection={connection!r}")
 
         self.active_connections.add(connection)
 
         return connection
 
     async def release_connection(self, connection: HTTPConnection) -> None:
+        logger.debug(f"release_connection connection={connection!r}")
         if connection.is_closed:
             self.active_connections.remove(connection)
             self.max_connections.release()

--- a/httpx/models.py
+++ b/httpx/models.py
@@ -243,6 +243,12 @@ class Origin:
     def __hash__(self) -> int:
         return hash((self.scheme, self.host, self.port))
 
+    def __repr__(self) -> str:
+        class_name = self.__class__.__name__
+        return (
+            f"{class_name}(scheme={self.scheme!r} host={self.host!r} port={self.port})"
+        )
+
 
 class QueryParams(typing.Mapping[str, str]):
     """

--- a/httpx/utils.py
+++ b/httpx/utils.py
@@ -1,7 +1,9 @@
 import codecs
+import logging
 import netrc
 import os
 import re
+import sys
 import typing
 from pathlib import Path
 
@@ -140,3 +142,31 @@ def parse_header_links(value: str) -> typing.List[typing.Dict[str, str]]:
             link[key.strip(replace_chars)] = value.strip(replace_chars)
         links.append(link)
     return links
+
+
+_LOGGER_INITIALIZED = False
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Gets a `logging.Logger` instance and optionally
+    sets up debug logging if the user requests it via
+    the `HTTPX_DEBUG=1` environment variable.
+    """
+    global _LOGGER_INITIALIZED
+
+    # If the user wants debug logging on we set it up for them.
+    if not _LOGGER_INITIALIZED:
+        _LOGGER_INITIALIZED = True
+        if os.environ.get("HTTPX_DEBUG", "").lower() in ("1", "true"):
+            logger = logging.getLogger("httpx")
+            logger.setLevel(logging.DEBUG)
+            handler = logging.StreamHandler(sys.stderr)
+            handler.setFormatter(
+                logging.Formatter(
+                    fmt="%(asctime)s.%(msecs)03d - %(name)s - %(message)s",
+                    datefmt="%H:%M:%S",
+                )
+            )
+            logger.addHandler(handler)
+
+    return logging.getLogger(name)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
     - Introduction: 'index.md'
     - QuickStart: 'quickstart.md'
     - Advanced Usage: 'advanced.md'
+    - Environment Variables: 'environment_variables.md'
     - Parallel Requests: 'parallel.md'
     - Async Client: 'async.md'
     - Requests Compatibility: 'compatibility.md'

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ combine_as_imports = True
 force_grid_wrap = 0
 include_trailing_comma = True
 known_first_party = httpx
-known_third_party = brotli,certifi,chardet,cryptography,h11,h2,hstspreload,nox,pytest,rfc3986,setuptools,trustme,uvicorn
+known_third_party = brotli,certifi,chardet,cryptography,h11,h2,hstspreload,nox,pytest,rfc3986,setuptools,tests,trustme,uvicorn
 line_length = 88
 multi_line_output = 3
 

--- a/tests/dispatch/utils.py
+++ b/tests/dispatch/utils.py
@@ -4,9 +4,9 @@ import typing
 import h2.config
 import h2.connection
 import h2.events
+from tests.concurrency import sleep
 
 from httpx import AsyncioBackend, BaseStream, Request, TimeoutConfig
-from tests.concurrency import sleep
 
 
 class MockHTTP2Backend:


### PR DESCRIPTION
This builds on #240 and adds it to all request-making dispatchers. It can be added to ASGI and WSGI dispatchers as well but I'm less familiar with what information would be useful for debugging those use-cases.

This also adds a new environment variable `HTTPX_DEBUG` which can be turned on to automatically display these debug logs.

A new section `Environment Variables` has been added to the documentation with the intent of future expansion for all environment variables that HTTPX will react to.