### PR TITLE
Add `build_request` for `Client`

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -63,8 +63,7 @@ Using a Client instance to make build requests
 ```python
 >>> client = httpx.Client()
 >>> r = client.build_request("GET", "https://example.com")
->>> r
-<AsyncRequest('GET', 'https://example.com')>
+>>> req.url.full_path = "*"
 >>> client.send(r)
 <Response [200 OK]>
 ```

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -68,16 +68,6 @@ Using a Client instance to make build requests
 >>> client.send(r)
 <Response [200 OK]>
 ```
-And async client
-```python
->>> import httpx
->>> client = httpx.AsyncClient()
->>> r = client.build_request("GET", "https://example.com")
->>> r
-<AsyncRequest('GET', 'https://example.com')>
->>> client.send(r)
-<coroutine object AsyncClient.send at 0x7fbc588f7560>
-```
 
 ## .netrc Support
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -59,11 +59,13 @@ client = httpx.Client(dispatch=dispatch)
 
 ## Build Request
 
-Using a Client instance to make build requests
+You can use `Client.build_request()` to build a request and
+make modifications before sending the request.
+
 ```python
 >>> client = httpx.Client()
->>> r = client.build_request("GET", "https://example.com")
->>> req.url.full_path = "*"
+>>> r = client.build_request("OPTIONS", "https://example.com")
+>>> req.url.full_path = "*"  # Build an 'OPTIONS *' request for CORS
 >>> client.send(r)
 <Response [200 OK]>
 ```

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -57,6 +57,28 @@ dispatch = httpx.WSGIDispatch(app=app, remote_addr="1.2.3.4")
 client = httpx.Client(dispatch=dispatch)
 ```
 
+## Build Request
+
+Using a Client instance to make build requests
+```python
+>>> client = httpx.Client()
+>>> r = client.build_request("GET", "https://example.com")
+>>> r
+<AsyncRequest('GET', 'https://example.com')>
+>>> client.send(r)
+<Response [200 OK]>
+```
+And async client
+```python
+>>> import httpx
+>>> client = httpx.AsyncClient()
+>>> r = client.build_request("GET", "https://example.com")
+>>> r
+<AsyncRequest('GET', 'https://example.com')>
+>>> client.send(r)
+<coroutine object AsyncClient.send at 0x7fbc588f7560>
+```
+
 ## .netrc Support
 
 HTTPX supports .netrc file. In `trust_env=True` cases, if auth parameter is

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -64,7 +64,7 @@ make modifications before sending the request.
 
 ```python
 >>> client = httpx.Client()
->>> r = client.build_request("OPTIONS", "https://example.com")
+>>> req = client.build_request("OPTIONS", "https://example.com")
 >>> req.url.full_path = "*"  # Build an 'OPTIONS *' request for CORS
 >>> client.send(r)
 <Response [200 OK]>

--- a/docs/api.md
+++ b/docs/api.md
@@ -42,30 +42,6 @@
 * `def .build_request(method, url, [data], [files], [json], [params], [headers], [cookies])`
 * `def .close()`
 
-## `AsyncClient`
-
-*An HTTP client, with connection pooling, HTTP/2, redirects, cookie persistence, etc.*
-
-```python
->>> client = httpx.AsyncClient()
->>> response = client.get('https://example.org')
-```
-
-* `def __init__([auth], [headers], [cookies], [verify], [cert], [timeout], [pool_limits], [max_redirects], [app], [dispatch])`
-* `.headers` - **Headers**
-* `.cookies` - **Cookies**
-* `async def .get(url, [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout])`
-* `async def .options(url, [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout])`
-* `async def .head(url, [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout])`
-* `async def .post(url, [data], [json], [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout])`
-* `async def .put(url, [data], [json], [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout])`
-* `async def .patch(url, [data], [json], [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout])`
-* `async def .delete(url, [data], [json], [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout])`
-* `async def .request(method, url, [data], [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout])`
-* `async def .send(request, [stream], [allow_redirects], [verify], [cert], [timeout])`
-* `async def .build_request(method, url, [data], [files], [json], [params], [headers], [cookies])`
-* `async def .close()`
-
 ## `Response`
 
 *An HTTP response.*

--- a/docs/api.md
+++ b/docs/api.md
@@ -16,6 +16,7 @@
 * `patch(url, [data], [json], [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout])`
 * `delete(url, [data], [json], [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout])`
 * `request(method, url, [data], [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout])`
+* `build_request(method, url, [data], [files], [json], [params], [headers], [cookies])`
 
 ## `Client`
 
@@ -38,7 +39,32 @@
 * `def .delete(url, [data], [json], [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout])`
 * `def .request(method, url, [data], [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout])`
 * `def .send(request, [stream], [allow_redirects], [verify], [cert], [timeout])`
+* `def .build_request(method, url, [data], [files], [json], [params], [headers], [cookies])`
 * `def .close()`
+
+## `AsyncClient`
+
+*An HTTP client, with connection pooling, HTTP/2, redirects, cookie persistence, etc.*
+
+```python
+>>> client = httpx.AsyncClient()
+>>> response = client.get('https://example.org')
+```
+
+* `def __init__([auth], [headers], [cookies], [verify], [cert], [timeout], [pool_limits], [max_redirects], [app], [dispatch])`
+* `.headers` - **Headers**
+* `.cookies` - **Cookies**
+* `async def .get(url, [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout])`
+* `async def .options(url, [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout])`
+* `async def .head(url, [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout])`
+* `async def .post(url, [data], [json], [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout])`
+* `async def .put(url, [data], [json], [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout])`
+* `async def .patch(url, [data], [json], [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout])`
+* `async def .delete(url, [data], [json], [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout])`
+* `async def .request(method, url, [data], [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout])`
+* `async def .send(request, [stream], [allow_redirects], [verify], [cert], [timeout])`
+* `async def .build_request(method, url, [data], [files], [json], [params], [headers], [cookies])`
+* `async def .close()`
 
 ## `Response`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -38,8 +38,8 @@
 * `def .patch(url, [data], [json], [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout])`
 * `def .delete(url, [data], [json], [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout])`
 * `def .request(method, url, [data], [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout])`
-* `def .send(request, [stream], [allow_redirects], [verify], [cert], [timeout])`
 * `def .build_request(method, url, [data], [files], [json], [params], [headers], [cookies])`
+* `def .send(request, [stream], [allow_redirects], [verify], [cert], [timeout])`
 * `def .close()`
 
 ## `Response`

--- a/httpx/client.py
+++ b/httpx/client.py
@@ -153,7 +153,7 @@ class BaseClient:
             return merged_headers
         return headers
 
-    async def _send(
+    async def _get_response(
         self,
         request: AsyncRequest,
         *,
@@ -553,7 +553,7 @@ class AsyncClient(BaseClient):
         timeout: TimeoutTypes = None,
         trust_env: bool = None,
     ) -> AsyncResponse:
-        return await self._send(
+        return await self._get_response(
             request=request,
             stream=stream,
             auth=auth,
@@ -677,7 +677,7 @@ class Client(BaseClient):
     ) -> Response:
         concurrency_backend = self.concurrency_backend
 
-        coroutine = self._send
+        coroutine = self._get_response
         args = [request]
         kwargs = {
             "stream": True,

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -15,15 +15,20 @@ async def test_get(server, backend):
 
 
 async def test_build_request(server, backend):
-    url = server.url
+    url = server.url.copy_with(path="/echo_headers")
+    headers = {
+        'Custom-header': 'value'
+    }
     async with httpx.AsyncClient(backend=backend) as client:
         request = client.build_request("GET", url)
+        request.headers.update(headers)
         response = await client.send(request)
+
     assert response.status_code == 200
-    assert response.text == "Hello, world!"
-    assert response.http_version == "HTTP/1.1"
-    assert response.headers
-    assert repr(response) == "<Response [200 OK]>"
+    assert response.url == url
+
+    for header_name, value in headers.items():
+        assert f'{header_name}: {value}' in response.content.decode()
 
 
 @pytest.mark.asyncio

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -25,10 +25,7 @@ async def test_build_request(server, backend):
     assert response.status_code == 200
     assert response.url == url
 
-    response_data = response.json()
-    for header_name, value in headers.items():
-        assert header_name in response_data
-        assert response_data[header_name] == value
+    assert response.json()["Custom-header"] == "value"
 
 
 @pytest.mark.asyncio

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -25,8 +25,10 @@ async def test_build_request(server, backend):
     assert response.status_code == 200
     assert response.url == url
 
+    response_data = response.json()
     for header_name, value in headers.items():
-        assert f"{header_name}: {value}" in response.content.decode()
+        assert header_name in response_data
+        assert response_data[header_name] == value
 
 
 @pytest.mark.asyncio

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -14,6 +14,18 @@ async def test_get(server, backend):
     assert repr(response) == "<Response [200 OK]>"
 
 
+async def test_build_request(server, backend):
+    url = server.url
+    async with httpx.AsyncClient(backend=backend) as client:
+        request = client.build_request("GET", url)
+        response = await client.send(request)
+    assert response.status_code == 200
+    assert response.text == "Hello, world!"
+    assert response.http_version == "HTTP/1.1"
+    assert response.headers
+    assert repr(response) == "<Response [200 OK]>"
+
+
 @pytest.mark.asyncio
 async def test_get_no_backend(server):
     """

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -16,9 +16,7 @@ async def test_get(server, backend):
 
 async def test_build_request(server, backend):
     url = server.url.copy_with(path="/echo_headers")
-    headers = {
-        'Custom-header': 'value'
-    }
+    headers = {"Custom-header": "value"}
     async with httpx.AsyncClient(backend=backend) as client:
         request = client.build_request("GET", url)
         request.headers.update(headers)
@@ -28,7 +26,7 @@ async def test_build_request(server, backend):
     assert response.url == url
 
     for header_name, value in headers.items():
-        assert f'{header_name}: {value}' in response.content.decode()
+        assert f"{header_name}: {value}" in response.content.decode()
 
 
 @pytest.mark.asyncio

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -19,6 +19,23 @@ def test_get(server):
     assert repr(response) == "<Response [200 OK]>"
 
 
+def test_build_request(server):
+    url = server.url
+    with httpx.Client() as http:
+        request = http.build_request("GET", url)
+        response = http.send(request)
+    assert response.status_code == 200
+    assert response.url == url
+    assert response.content == b"Hello, world!"
+    assert response.text == "Hello, world!"
+    assert response.http_version == "HTTP/1.1"
+    assert response.encoding == "iso-8859-1"
+    assert response.request.url == url
+    assert response.headers
+    assert response.is_redirect is False
+    assert repr(response) == "<Response [200 OK]>"
+
+
 def test_post(server):
     with httpx.Client() as http:
         response = http.post(server.url, data=b"Hello, world!")

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -31,8 +31,10 @@ def test_build_request(server):
     assert response.status_code == 200
     assert response.url == url
 
+    response_data = response.json()
     for header_name, value in headers.items():
-        assert f"{header_name}: {value}" in response.content.decode()
+        assert header_name in response_data
+        assert response_data[header_name] == value
 
 
 def test_post(server):

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -20,20 +20,22 @@ def test_get(server):
 
 
 def test_build_request(server):
-    url = server.url
+    url = server.url.copy_with(path="/echo_headers")
+    headers = {
+        'Custom-header': 'value'
+    }
+
     with httpx.Client() as http:
         request = http.build_request("GET", url)
+        request.headers.update(headers)
         response = http.send(request)
+
     assert response.status_code == 200
     assert response.url == url
-    assert response.content == b"Hello, world!"
-    assert response.text == "Hello, world!"
-    assert response.http_version == "HTTP/1.1"
-    assert response.encoding == "iso-8859-1"
-    assert response.request.url == url
-    assert response.headers
-    assert response.is_redirect is False
-    assert repr(response) == "<Response [200 OK]>"
+
+    for header_name, value in headers.items():
+        assert f'{header_name}: {value}' in response.content.decode()
+
 
 
 def test_post(server):

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -31,10 +31,7 @@ def test_build_request(server):
     assert response.status_code == 200
     assert response.url == url
 
-    response_data = response.json()
-    for header_name, value in headers.items():
-        assert header_name in response_data
-        assert response_data[header_name] == value
+    assert response.json()["Custom-header"] == "value"
 
 
 def test_post(server):

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -21,9 +21,7 @@ def test_get(server):
 
 def test_build_request(server):
     url = server.url.copy_with(path="/echo_headers")
-    headers = {
-        'Custom-header': 'value'
-    }
+    headers = {"Custom-header": "value"}
 
     with httpx.Client() as http:
         request = http.build_request("GET", url)
@@ -34,8 +32,7 @@ def test_build_request(server):
     assert response.url == url
 
     for header_name, value in headers.items():
-        assert f'{header_name}: {value}' in response.content.decode()
-
+        assert f"{header_name}: {value}" in response.content.decode()
 
 
 def test_post(server):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,9 +116,7 @@ async def echo_body(scope, receive, send):
 async def echo_headers(scope, receive, send):
     body: bytes = b""
 
-    more_body = scope.get("headers", [])
-    for h in more_body:
-        name, value = h[0], h[1]
+    for name, value in scope.get("headers", []):
         value = f"{name.capitalize().decode()}: {value.decode()}\n"
         body += value.encode()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import os
 import threading
 import time
@@ -114,20 +115,18 @@ async def echo_body(scope, receive, send):
 
 
 async def echo_headers(scope, receive, send):
-    body: bytes = b""
-
+    body = {}
     for name, value in scope.get("headers", []):
-        value = f"{name.capitalize().decode()}: {value.decode()}\n"
-        body += value.encode()
+        body[name.capitalize().decode()] = value.decode()
 
     await send(
         {
             "type": "http.response.start",
             "status": 200,
-            "headers": [[b"content-type", b"text/plain"]],
+            "headers": [[b"content-type", b"application/json"]],
         }
     )
-    await send({"type": "http.response.body", "body": body})
+    await send({"type": "http.response.body", "body": json.dumps(body).encode()})
 
 
 class CAWithPKEncryption(trustme.CA):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,8 @@ async def app(scope, receive, send):
         await status_code(scope, receive, send)
     elif scope["path"].startswith("/echo_body"):
         await echo_body(scope, receive, send)
+    elif scope["path"].startswith("/echo_headers"):
+        await echo_headers(scope, receive, send)
     else:
         await hello_world(scope, receive, send)
 
@@ -100,6 +102,25 @@ async def echo_body(scope, receive, send):
         message = await receive()
         body += message.get("body", b"")
         more_body = message.get("more_body", False)
+
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [[b"content-type", b"text/plain"]],
+        }
+    )
+    await send({"type": "http.response.body", "body": body})
+
+
+async def echo_headers(scope, receive, send):
+    body: bytes = b""
+
+    more_body = scope.get("headers", [])
+    for h in more_body:
+        name, value = h[0], h[1]
+        value = f"{name.capitalize().decode()}: {value.decode()}\n"
+        body += value.encode()
 
     await send(
         {


### PR DESCRIPTION
Using a Client instance to make build requests
```python
>>> client = httpx.Client()
>>> r = client.build_request("GET", "https://example.com")
>>> r
<AsyncRequest('GET', 'https://example.com')>
>>> client.send(r)
<Response [200 OK]>
```
And async client
```python
>>> import httpx
>>> client = httpx.AsyncClient()
>>> r = client.build_request("GET", "https://example.com")
>>> r
<AsyncRequest('GET', 'https://example.com')>
>>> client.send(r)
<coroutine object AsyncClient.send at 0x7fbc588f7560>
```

Closes #174 