### PR TITLE
Setting HOST header to url.authority.encode('ascii') in redirect middleware

### DIFF
--- a/httpx/middleware.py
+++ b/httpx/middleware.py
@@ -148,7 +148,7 @@ class RedirectMiddleware(BaseMiddleware):
             # Strip Authorization headers when responses are redirected away from
             # the origin.
             del headers["Authorization"]
-            headers["Host"] = url.authority.encode('ascii')
+            headers["Host"] = url.authority
 
         if method != request.method and method == "GET":
             # If we've switch to a 'GET' request, then strip any headers which

--- a/httpx/middleware.py
+++ b/httpx/middleware.py
@@ -148,7 +148,7 @@ class RedirectMiddleware(BaseMiddleware):
             # Strip Authorization headers when responses are redirected away from
             # the origin.
             del headers["Authorization"]
-            del headers["Host"]
+            headers["Host"] = url.authority.encode('ascii')
 
         if method != request.method and method == "GET":
             # If we've switch to a 'GET' request, then strip any headers which

--- a/httpx/models.py
+++ b/httpx/models.py
@@ -447,7 +447,7 @@ class Headers(typing.MutableMapping[str, str]):
         Retains insertion order.
         """
         set_key = key.lower().encode(self.encoding)
-        set_value = value if isinstance(value, bytes) else value.encode(self.encoding)
+        set_value = value.encode(self.encoding)
 
         found_indexes = []
         for idx, (item_key, _) in enumerate(self._list):

--- a/httpx/models.py
+++ b/httpx/models.py
@@ -447,7 +447,7 @@ class Headers(typing.MutableMapping[str, str]):
         Retains insertion order.
         """
         set_key = key.lower().encode(self.encoding)
-        set_value = value.encode(self.encoding)
+        set_value = value if isinstance(value, bytes) else value.encode(self.encoding)
 
         found_indexes = []
         for idx, (item_key, _) in enumerate(self._list):


### PR DESCRIPTION
NOTE:
__setitem__ in class Headers already encodes with its encoding attribute
Added check to skip encoding the value if it is already bytes.

Closes #318