### PR TITLE
Pin uvloop<0.13 to fix 3.8-dev build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ __pycache__/
 htmlcov/
 site/
 *.egg-info/
-venv/
+venv*/
 .nox
+.python-version

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -14,3 +14,6 @@ pytest-asyncio
 pytest-cov
 trustme
 uvicorn
+
+# https://github.com/MagicStack/uvloop/issues/266
+uvloop<0.13; sys_platform != 'win32' and sys_platform != 'cygwin' and platform_python_implementation != 'pypy'


### PR DESCRIPTION
Refs https://github.com/MagicStack/uvloop/issues/266, and prompted by https://github.com/encode/httpx/pull/153 and https://github.com/encode/httpx/pull/276#issuecomment-528998323.

Opening this mostly to see if this fixes the build. We don't know how long the issue may stay though, so perhaps we could consider keeping this until things are sorted out?

(Also, this is probably affecting uvicorn as well.)