### PR TITLE
Fix #317

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ site/
 *.egg-info/
 venv/
 .nox
+TAGS

--- a/httpx/middleware.py
+++ b/httpx/middleware.py
@@ -147,16 +147,37 @@ class RedirectMiddleware(BaseMiddleware):
         if url.origin != request.url.origin:
             # Strip Authorization headers when responses are redirected away from
             # the origin.
-            del headers["Authorization"]
-            del headers["Host"]
+            self._strip_headers(headers)
 
         if method != request.method and method == "GET":
-            # If we've switch to a 'GET' request, then strip any headers which
-            # are only relevant to the request body.
-            del headers["Content-Length"]
-            del headers["Transfer-Encoding"]
+         self._delete_request_body_headers(headers)
 
         return headers
+
+    def _strip_headers(self, headers: Headers) -> None:
+        """
+        Strip headers in case of redirect
+        """
+        headers_to_strip = [
+            'Authorization',
+            'Host'
+        ]
+        for header in headers_to_strip:
+            if header in headers:
+                del headers[header]
+
+    def _delete_request_body_headers(self, headers: Headers) -> None:
+        """
+        Strip any headers which are only relevant to request body,
+        if they exist
+        """
+        req_body_headers = {
+            "Content-Length",
+            "Transfer-Encoding"
+        }
+        for header in req_body_headers:
+            if header in headers:
+                del[header]
 
     def redirect_content(self, request: AsyncRequest, method: str) -> bytes:
         """

--- a/httpx/models.py
+++ b/httpx/models.py
@@ -473,6 +473,8 @@ class Headers(typing.MutableMapping[str, str]):
         for idx, (item_key, _) in enumerate(self._list):
             if item_key == del_key:
                 pop_indexes.append(idx)
+        if not pop_indexes:
+            raise KeyError(key)
 
         for idx in reversed(pop_indexes):
             del self._list[idx]
@@ -624,7 +626,7 @@ class AsyncRequest(BaseRequest):
             assert hasattr(data, "__aiter__")
             self.is_streaming = True
             self.content_aiter = data
-
+            
         self.prepare()
 
     async def read(self) -> bytes:

--- a/tests/client/test_headers.py
+++ b/tests/client/test_headers.py
@@ -2,6 +2,8 @@
 
 import json
 
+import pytest
+
 from httpx import (
     AsyncDispatcher,
     AsyncRequest,
@@ -122,3 +124,10 @@ def test_header_update():
             "user-agent": "python-myclient/0.2.1",
         }
     }
+
+def test_header_does_not_exist():
+    from httpx.models import Headers
+    headers = Headers({"foo": "bar"})
+    with pytest.raises(KeyError):
+        del headers["baz"]
+    


### PR DESCRIPTION
Fixes issue #317 
KeyError is raised if a header that was to be deleted did not exist in Headers
`RedirectMiddleware` now can't directly delete a header without checking.
Hence added checks for stripping off request body headers(Content-Length, Transfer-Encoding)
and Authorization headers in case of redirects
Also added a test to check if KeyError is raised for a header to be deleted which does not exist