### PR TITLE
Refactor redirect middleware using contextvars

### DIFF
--- a/httpx/compat/contextvars.py
+++ b/httpx/compat/contextvars.py
@@ -1,0 +1,8 @@
+try:
+    # Python 3.6 backport w/ asyncio support.
+    # Try to import it first since it installs the contextvars backport too.
+    import aiocontextvars as _contextvars
+except ImportError:
+    import contextvars as _contextvars  # type: ignore
+
+ContextVar = _contextvars.ContextVar

--- a/httpx/middleware/redirect.py
+++ b/httpx/middleware/redirect.py
@@ -1,8 +1,8 @@
 import functools
 import typing
-from contextvars import ContextVar
 
 from ..config import DEFAULT_MAX_REDIRECTS
+from ..compat.contextvars import ContextVar
 from ..exceptions import RedirectBodyUnavailable, RedirectLoop, TooManyRedirects
 from ..models import URL, AsyncRequest, AsyncResponse, Cookies, Headers
 from ..status_codes import codes

--- a/httpx/middleware/redirect.py
+++ b/httpx/middleware/redirect.py
@@ -43,7 +43,10 @@ class RedirectMiddleware(BaseMiddleware):
 
         history.append(response)
         HISTORY.set(history)
-        next_request = self.build_redirect_request(request, response)
+
+        next_request = build_redirect_request(
+            request, response, cookies=Cookies(self.cookies)
+        )
 
         if self.allow_redirects:
             return await self(next_request, get_response)
@@ -51,86 +54,90 @@ class RedirectMiddleware(BaseMiddleware):
         response.call_next = functools.partial(self, next_request, get_response)
         return response
 
-    def build_redirect_request(
-        self, request: AsyncRequest, response: AsyncResponse
-    ) -> AsyncRequest:
-        method = self.redirect_method(request, response)
-        url = self.redirect_url(request, response)
-        headers = self.redirect_headers(request, url, method)  # TODO: merge headers?
-        content = self.redirect_content(request, method)
-        cookies = Cookies(self.cookies)
-        cookies.update(request.cookies)
-        return AsyncRequest(
-            method=method, url=url, headers=headers, data=content, cookies=cookies
-        )
 
-    def redirect_method(self, request: AsyncRequest, response: AsyncResponse) -> str:
-        """
-        When being redirected we may want to change the method of the request
-        based on certain specs or browser behavior.
-        """
-        method = request.method
+def build_redirect_request(
+    request: AsyncRequest, response: AsyncResponse, cookies: Cookies
+) -> AsyncRequest:
+    method = get_redirect_method(request, response)
+    url = get_redirect_url(request, response)
+    headers = get_redirect_headers(request, url, method)  # TODO: merge headers?
+    content = get_redirect_content(request, method)
+    cookies.update(request.cookies)
+    return AsyncRequest(
+        method=method, url=url, headers=headers, data=content, cookies=cookies
+    )
 
-        # https://tools.ietf.org/html/rfc7231#section-6.4.4
-        if response.status_code == codes.SEE_OTHER and method != "HEAD":
-            method = "GET"
 
-        # Do what the browsers do, despite standards...
-        # Turn 302s into GETs.
-        if response.status_code == codes.FOUND and method != "HEAD":
-            method = "GET"
+def get_redirect_method(request: AsyncRequest, response: AsyncResponse) -> str:
+    """
+    When being redirected we may want to change the method of the request
+    based on certain specs or browser behavior.
+    """
+    method = request.method
 
-        # If a POST is responded to with a 301, turn it into a GET.
-        # This bizarre behaviour is explained in 'requests' issue 1704.
-        if response.status_code == codes.MOVED_PERMANENTLY and method == "POST":
-            method = "GET"
+    # https://tools.ietf.org/html/rfc7231#section-6.4.4
+    if response.status_code == codes.SEE_OTHER and method != "HEAD":
+        method = "GET"
 
-        return method
+    # Do what the browsers do, despite standards...
+    # Turn 302s into GETs.
+    if response.status_code == codes.FOUND and method != "HEAD":
+        method = "GET"
 
-    def redirect_url(self, request: AsyncRequest, response: AsyncResponse) -> URL:
-        """
-        Return the URL for the redirect to follow.
-        """
-        location = response.headers["Location"]
+    # If a POST is responded to with a 301, turn it into a GET.
+    # This bizarre behaviour is explained in 'requests' issue 1704.
+    if response.status_code == codes.MOVED_PERMANENTLY and method == "POST":
+        method = "GET"
 
-        url = URL(location, allow_relative=True)
+    return method
 
-        # Facilitate relative 'Location' headers, as allowed by RFC 7231.
-        # (e.g. '/path/to/resource' instead of 'http://domain.tld/path/to/resource')
-        if url.is_relative_url:
-            url = request.url.join(url)
 
-        # Attach previous fragment if needed (RFC 7231 7.1.2)
-        if request.url.fragment and not url.fragment:
-            url = url.copy_with(fragment=request.url.fragment)
+def get_redirect_url(request: AsyncRequest, response: AsyncResponse) -> URL:
+    """
+    Return the URL for the redirect to follow.
+    """
+    location = response.headers["Location"]
 
-        return url
+    url = URL(location, allow_relative=True)
 
-    def redirect_headers(self, request: AsyncRequest, url: URL, method: str) -> Headers:
-        """
-        Return the headers that should be used for the redirect request.
-        """
-        headers = Headers(request.headers)
+    # Facilitate relative 'Location' headers, as allowed by RFC 7231.
+    # (e.g. '/path/to/resource' instead of 'http://domain.tld/path/to/resource')
+    if url.is_relative_url:
+        url = request.url.join(url)
 
-        if url.origin != request.url.origin:
-            # Strip Authorization headers when responses are redirected away from
-            # the origin.
-            headers.pop("Authorization", None)
-            headers["Host"] = url.authority
+    # Attach previous fragment if needed (RFC 7231 7.1.2)
+    if request.url.fragment and not url.fragment:
+        url = url.copy_with(fragment=request.url.fragment)
 
-        if method != request.method and method == "GET":
-            # If we've switch to a 'GET' request, then strip any headers which
-            # are only relevant to the request body.
-            headers.pop("Content-Length", None)
-            headers.pop("Transfer-Encoding", None)
-        return headers
+    return url
 
-    def redirect_content(self, request: AsyncRequest, method: str) -> bytes:
-        """
-        Return the body that should be used for the redirect request.
-        """
-        if method != request.method and method == "GET":
-            return b""
-        if request.is_streaming:
-            raise RedirectBodyUnavailable()
-        return request.content
+
+def get_redirect_headers(request: AsyncRequest, url: URL, method: str) -> Headers:
+    """
+    Return the headers that should be used for the redirect request.
+    """
+    headers = Headers(request.headers)
+
+    if url.origin != request.url.origin:
+        # Strip Authorization headers when responses are redirected away from
+        # the origin.
+        headers.pop("Authorization", None)
+        headers["Host"] = url.authority
+
+    if method != request.method and method == "GET":
+        # If we've switch to a 'GET' request, then strip any headers which
+        # are only relevant to the request body.
+        headers.pop("Content-Length", None)
+        headers.pop("Transfer-Encoding", None)
+    return headers
+
+
+def get_redirect_content(request: AsyncRequest, method: str) -> bytes:
+    """
+    Return the body that should be used for the redirect request.
+    """
+    if method != request.method and method == "GET":
+        return b""
+    if request.is_streaming:
+        raise RedirectBodyUnavailable()
+    return request.content

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         "hstspreload>=2019.8.27",
         "idna==2.*",
         "rfc3986==1.*",
+        "contextvars; python_version<'3.7'",
     ],
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         "hstspreload>=2019.8.27",
         "idna==2.*",
         "rfc3986==1.*",
-        "contextvars; python_version<'3.7'",
+        "aiocontextvars; python_version<'3.7'",
     ],
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
While #325, and having https://github.com/encode/httpx/pull/305#issuecomment-529135254 in mind, I noticed that the `history` was a middleware instance variable on `RedirectMiddleware`, and that surely it could be refactored to use context variables instead. So, here we are! I think the result is quite pleasing.

The docs for contextvars, if need be: [contextvars](https://docs.python.org/3.7/library/contextvars.html).

@yeraydiazdiaz The second commit here illustrates what I suggested in https://github.com/encode/httpx/pull/305#issuecomment-529144881:

> I think we should be able to convert all utility methods into regular functions, and end up with the typical __init__()/__call__() pair of methods, with the logic in __call__ delegating as much as possible to the helper functions.