### PR TITLE
AnyIO-based UDP PoC

### DIFF
--- a/httpx/concurrency/anyio.py
+++ b/httpx/concurrency/anyio.py
@@ -1,0 +1,73 @@
+import typing
+
+import anyio
+
+from ..config import TimeoutConfig
+from ..exceptions import ConnectTimeout, ReadTimeout
+
+
+class Datagram:
+    def __init__(self, data: bytes, address: str, port: int):
+        self.data = data
+        self.address = address
+        self.port = port
+
+
+class UDPStream:
+    def __init__(self, socket: anyio.UDPSocket, timeout: TimeoutConfig):
+        self.socket = socket
+        self.timeout = timeout
+
+    async def read(
+        self, n: int, timeout: TimeoutConfig = None, flag: typing.Any = None
+    ) -> Datagram:
+        if timeout is None:
+            timeout = self.timeout
+
+        read_timeout = (
+            timeout.read_timeout if timeout.read_timeout is not None else float("inf")
+        )
+
+        while True:
+            # Check our flag at the first possible moment, and use a fine
+            # grained retry loop if we're not yet in read-timeout mode.
+            should_raise = flag is None or flag.raise_on_read_timeout
+
+            if should_raise:
+                read_timeout = (
+                    timeout.read_timeout
+                    if timeout.read_timeout is not None
+                    else float("inf")
+                )
+            else:
+                read_timeout = 0.01
+
+            async with anyio.move_on_after(read_timeout):
+                data, (address, port) = await self.socket.receive(n)
+                return Datagram(data=data, address=address, port=port)
+
+            if should_raise:
+                raise ReadTimeout() from None
+
+    async def write(self, data: bytes) -> None:
+        await self.socket.send(data)
+
+    async def close(self) -> None:
+        await self.socket.close()
+
+
+class AnyioBackend:
+    async def open_udp_stream(
+        self, host: str, port: int, timeout: TimeoutConfig
+    ) -> UDPStream:
+        connect_timeout = (
+            timeout.connect_timeout
+            if timeout.connect_timeout is not None
+            else float("int")
+        )
+
+        async with anyio.move_on_after(connect_timeout):
+            socket = await anyio.create_udp_socket(target_host=host, target_port=port)
+            return UDPStream(socket=socket, timeout=timeout)
+
+        raise ConnectTimeout()

--- a/httpx/concurrency/base.py
+++ b/httpx/concurrency/base.py
@@ -3,6 +3,7 @@ import typing
 from types import TracebackType
 
 from ..config import PoolLimits, TimeoutConfig
+from ..models import Datagram
 
 
 class TimeoutFlag:
@@ -65,6 +66,23 @@ class BaseStream:
         raise NotImplementedError()  # pragma: no cover
 
 
+class BaseUDPStream:
+    """
+    An UDP stream with read/write operations.
+    """
+
+    async def read(
+        self, n: int, timeout: TimeoutConfig = None, flag: typing.Any = None
+    ) -> Datagram:
+        raise NotImplementedError()  # pragma: no cover
+
+    async def write(self, data: bytes) -> None:
+        raise NotImplementedError()  # pragma: no cover
+
+    async def close(self) -> None:
+        raise NotImplementedError()  # pragma: no cover
+
+
 class BaseQueue:
     """
     A FIFO queue. Abstracts away any asyncio-specific interfaces.
@@ -118,6 +136,11 @@ class ConcurrencyBackend:
         timeout: TimeoutConfig,
     ) -> BaseStream:
         raise NotImplementedError()  # pragma: no cover
+
+    async def open_udp_stream(
+        self, host: str, port: int, timeout: TimeoutConfig
+    ) -> BaseUDPStream:
+        raise NotImplementedError  # pragma: no cover
 
     async def start_tls(
         self,

--- a/httpx/models.py
+++ b/httpx/models.py
@@ -1239,3 +1239,14 @@ class Cookies(MutableMapping):
             for key, value in self.response.headers.items():
                 info[key] = value
             return info
+
+
+class Datagram:
+    """
+    Representation of an UDP datagram.
+    """
+
+    def __init__(self, data: bytes, address: str, port: int):
+        self.data = data
+        self.address = address
+        self.port = port

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,7 @@
 -e .
 
 # Optional
+anyio
 brotlipy==0.7.*
 
 cryptography


### PR DESCRIPTION
Prompted by https://github.com/encode/httpx/issues/275#issuecomment-531369129

This demonstrates how we could build an `UDPStream` interface to support the needs of HTTP/3 support via aioquic.

@jlaine This PoC only provides single-target read/write operations. Will we actually need to send data to arbitrary hosts to implement QUIC+HTTP/3?

@sethmlarson While there would be a clear benefit to using AnyIO in terms of slimming down the burden of maintaining I/O operations for various libraries, I think this PR shows we'd still need our stream and concurrency backend interfaces, if only for the timeout/retry policies.

Example server:

```python
"""Hello world UDP server."""

import anyio


async def main() -> None:
    async with await anyio.create_udp_socket(port=5678) as socket:
        print("Connected")
        async for packet, (host, port) in socket.receive_packets(1024):
            response = b", ".join((b"Hello", packet))
            print(f"Response(data={response!r}, host={host!r}, port={port!r})")
            await socket.send(response, host, port)


anyio.run(main)
```

Example client:

```python
"""Hello world UDP client."""
import anyio

from httpx.concurrency.anyio import AnyioBackend
from httpx.config import DEFAULT_TIMEOUT_CONFIG


async def main() -> None:
    backend = AnyioBackend()
    stream = await backend.open_udp_stream(
        "127.0.0.1", 5678, timeout=DEFAULT_TIMEOUT_CONFIG
    )
    await stream.write(b"Bob")
    datagram = await stream.read(1024)
    assert datagram.data == b"Hello, Bob", datagram.data
    assert datagram.address == "127.0.0.1", datagram.address
    assert datagram.port == 5678, datagram.port

    await stream.close()


anyio.run(main)
```