### PR TITLE
Mark `BaseTCPStream.is_connection_dropped` as async

### DIFF
--- a/httpx/concurrency/asyncio.py
+++ b/httpx/concurrency/asyncio.py
@@ -111,7 +111,7 @@ class TCPStream(BaseTCPStream):
                 if should_raise:
                     raise WriteTimeout() from None
 
-    def is_connection_dropped(self) -> bool:
+    async def is_connection_dropped(self) -> bool:
         return self.stream_reader.at_eof()
 
     async def close(self) -> None:

--- a/httpx/concurrency/base.py
+++ b/httpx/concurrency/base.py
@@ -61,7 +61,7 @@ class BaseTCPStream:
     async def close(self) -> None:
         raise NotImplementedError()  # pragma: no cover
 
-    def is_connection_dropped(self) -> bool:
+    async def is_connection_dropped(self) -> bool:
         raise NotImplementedError()  # pragma: no cover
 
 

--- a/httpx/dispatch/connection.py
+++ b/httpx/dispatch/connection.py
@@ -127,12 +127,12 @@ class HTTPConnection(AsyncDispatcher):
             assert self.h11_connection is not None
             return self.h11_connection.is_closed
 
-    def is_connection_dropped(self) -> bool:
+    async def is_connection_dropped(self) -> bool:
         if self.h2_connection is not None:
-            return self.h2_connection.is_connection_dropped()
+            return await self.h2_connection.is_connection_dropped()
         else:
             assert self.h11_connection is not None
-            return self.h11_connection.is_connection_dropped()
+            return await self.h11_connection.is_connection_dropped()
 
     def __repr__(self) -> str:
         class_name = self.__class__.__name__

--- a/httpx/dispatch/http11.py
+++ b/httpx/dispatch/http11.py
@@ -204,5 +204,5 @@ class HTTP11Connection:
     def is_closed(self) -> bool:
         return self.h11_state.our_state in (h11.CLOSED, h11.ERROR)
 
-    def is_connection_dropped(self) -> bool:
-        return self.stream.is_connection_dropped()
+    async def is_connection_dropped(self) -> bool:
+        return await self.stream.is_connection_dropped()

--- a/httpx/dispatch/http2.py
+++ b/httpx/dispatch/http2.py
@@ -220,5 +220,5 @@ class HTTP2Connection:
     def is_closed(self) -> bool:
         return False
 
-    def is_connection_dropped(self) -> bool:
-        return self.stream.is_connection_dropped()
+    async def is_connection_dropped(self) -> bool:
+        return await self.stream.is_connection_dropped()

--- a/httpx/dispatch/proxy_http.py
+++ b/httpx/dispatch/proxy_http.py
@@ -95,7 +95,7 @@ class HTTPProxy(ConnectionPool):
         """Creates a new HTTPConnection via the CONNECT method
         usually reserved for proxying HTTPS connections.
         """
-        connection = self.pop_connection(origin)
+        connection = await self.pop_connection(origin)
 
         if connection is None:
             connection = await self.request_tunnel_proxy_connection(origin)

--- a/tests/dispatch/utils.py
+++ b/tests/dispatch/utils.py
@@ -88,7 +88,7 @@ class MockHTTP2Server(BaseTCPStream):
     async def close(self) -> None:
         pass
 
-    def is_connection_dropped(self) -> bool:
+    async def is_connection_dropped(self) -> bool:
         return self.close_connection
 
     # Server implementation

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -24,11 +24,13 @@ async def test_start_tls_on_socket_stream(https_server):
     )
 
     try:
-        assert stream.is_connection_dropped() is False
+        connection_dropped = await stream.is_connection_dropped()
+        assert connection_dropped is False
         assert stream.stream_writer.get_extra_info("cipher", default=None) is None
 
         stream = await backend.start_tls(stream, https_server.url.host, ctx, timeout)
-        assert stream.is_connection_dropped() is False
+        connection_dropped = await stream.is_connection_dropped()
+        assert connection_dropped is False
         assert stream.stream_writer.get_extra_info("cipher", default=None) is not None
 
         await stream.write(b"GET / HTTP/1.1\r\n\r\n")


### PR DESCRIPTION
The current implementation doesn't require blocking, but given
https://github.com/encode/httpx/issues/346 discussed some possible future improvements,
[trio.hazmat.wait_readable](https://trio.readthedocs.io/en/stable/reference-hazmat.html#trio.hazmat.wait_readable) is async,
and [urllib3 relies on blocking APIs to detect dropped connections](https://github.com/urllib3/urllib3/blob/f7a4bed04085975918b3469bf94e195df9faf29a/src/urllib3/util/wait.py#L105) it is worth marking this API as async pre-1.0 to avoid future breaking changes.

Closes #356 