### PR TITLE
Fix missing py.typed file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
     package_data={"httpx": ["py.typed"]},
     packages=get_packages("httpx"),
     include_package_data=True,
+    zip_safe=False,
     install_requires=[
         "certifi",
         "chardet==3.*",


### PR DESCRIPTION
Fixes #193

I realized `zip_safe=False` was missing by [comparing with Starlette](https://github.com/encode/starlette/blob/master/setup.py). Upon more research, it seems this is actually a [mypy/setuptools requirement](https://mypy.readthedocs.io/en/latest/installed_packages.html#making-pep-561-compatible-packages).

My QA process:

```bash
python -m venv venv
. venv/bin/activate
pip install /path/to/httpx
ls venv/lib/python3.7/site-packages/httpx | grep py.typed
# OK
```