### PR TITLE
Add debug logs to ASGIDispatch

### DIFF
--- a/httpx/dispatch/asgi.py
+++ b/httpx/dispatch/asgi.py
@@ -14,7 +14,7 @@ class ASGIDispatch(AsyncDispatcher):
     """
     A custom dispatcher that handles sending requests directly to an ASGI app.
 
-    The simplest way to use this functionality is to use the `app`argument.
+    The simplest way to use this functionality is to use the `app` argument.
     This will automatically infer if 'app' is a WSGI or an ASGI application,
     and will setup an appropriate dispatch class:
 
@@ -33,6 +33,7 @@ class ASGIDispatch(AsyncDispatcher):
         client=("1.2.3.4", 123)
     )
     client = httpx.Client(dispatch=dispatch)
+    ```
 
     Arguments:
 
@@ -89,8 +90,6 @@ class ASGIDispatch(AsyncDispatcher):
         request_stream = request.stream()
 
         async def receive() -> dict:
-            nonlocal request_stream
-
             try:
                 body = await request_stream.__anext__()
             except StopAsyncIteration:
@@ -98,23 +97,25 @@ class ASGIDispatch(AsyncDispatcher):
             return {"type": "http.request", "body": body, "more_body": True}
 
         async def send(message: dict) -> None:
-            nonlocal status_code, headers, response_started_or_failed
-            nonlocal response_body, request
+            nonlocal status_code, headers
 
             if message["type"] == "http.response.start":
                 status_code = message["status"]
                 headers = message.get("headers", [])
                 response_started_or_failed.set()
+
             elif message["type"] == "http.response.body":
                 body = message.get("body", b"")
                 more_body = message.get("more_body", False)
+
                 if body and request.method != "HEAD":
                     await response_body.put(body)
+
                 if not more_body:
                     await response_body.mark_as_done()
 
         async def run_app() -> None:
-            nonlocal app, scope, receive, send, app_exc, response_body
+            nonlocal app_exc
             try:
                 await app(scope, receive, send)
             except Exception as exc:
@@ -140,7 +141,6 @@ class ASGIDispatch(AsyncDispatcher):
         assert headers is not None
 
         async def on_close() -> None:
-            nonlocal response_body
             await response_body.drain()
             await background.close(app_exc)
             if app_exc is not None and self.raise_app_exceptions:

--- a/httpx/dispatch/asgi.py
+++ b/httpx/dispatch/asgi.py
@@ -4,7 +4,10 @@ from ..concurrency.asyncio import AsyncioBackend
 from ..concurrency.base import ConcurrencyBackend
 from ..config import CertTypes, TimeoutTypes, VerifyTypes
 from ..models import AsyncRequest, AsyncResponse
+from ..utils import MessageLoggerASGIMiddleware, get_logger
 from .base import AsyncDispatcher
+
+logger = get_logger(__name__)
 
 
 class ASGIDispatch(AsyncDispatcher):
@@ -77,7 +80,7 @@ class ASGIDispatch(AsyncDispatcher):
             "client": self.client,
             "root_path": self.root_path,
         }
-        app = self.app
+        app = MessageLoggerASGIMiddleware(self.app, logger=logger)
         app_exc = None
         status_code = None
         headers = None

--- a/httpx/models.py
+++ b/httpx/models.py
@@ -36,6 +36,7 @@ from .utils import (
     is_known_encoding,
     normalize_header_key,
     normalize_header_value,
+    obfuscate_sensitive_headers,
     parse_header_links,
     str_query_param,
 )
@@ -554,13 +555,11 @@ class Headers(typing.MutableMapping[str, str]):
         if self.encoding != "ascii":
             encoding_str = f", encoding={self.encoding!r}"
 
-        sensitive_headers = {"authorization", "proxy-authorization"}
-        as_list = [
-            (k, "[secure]" if k in sensitive_headers else v) for k, v in self.items()
-        ]
-
+        as_list = list(obfuscate_sensitive_headers(self.items()))
         as_dict = dict(as_list)
-        if len(as_dict) == len(as_list):
+
+        no_duplicate_keys = len(as_dict) == len(as_list)
+        if no_duplicate_keys:
             return f"{class_name}({as_dict!r}{encoding_str})"
         return f"{class_name}({as_list!r}{encoding_str})"
 

--- a/httpx/utils.py
+++ b/httpx/utils.py
@@ -167,7 +167,7 @@ def obfuscate_sensitive_headers(
     items: typing.Iterable[typing.Tuple[typing.AnyStr, typing.AnyStr]]
 ) -> typing.Iterator[typing.Tuple[typing.AnyStr, typing.AnyStr]]:
     for k, v in items:
-        if to_str(k) in SENSITIVE_HEADERS:
+        if to_str(k.lower()) in SENSITIVE_HEADERS:
             v = to_bytes_or_str("[secure]", match_type_of=v)
         yield k, v
 

--- a/tests/models/test_headers.py
+++ b/tests/models/test_headers.py
@@ -1,3 +1,5 @@
+import pytest
+
 import httpx
 
 
@@ -151,3 +153,13 @@ def test_multiple_headers():
 
     h = httpx.Headers([("vary", "a, b"), ("vary", "c")])
     h.getlist("Vary") == ["a", "b", "c"]
+
+
+@pytest.mark.parametrize("header", ["authorization", "proxy-authorization"])
+def test_sensitive_headers(header):
+    """
+    Some headers should be obfuscated because they contain sensitive data.
+    """
+    value = "s3kr3t"
+    h = httpx.Headers({header: value})
+    assert repr(h) == "Headers({'%s': '[secure]'})" % header

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,7 @@ from httpx.utils import (
     get_environment_proxies,
     get_netrc_login,
     guess_json_utf,
+    obfuscate_sensitive_headers,
     parse_header_links,
 )
 
@@ -192,3 +193,18 @@ def test_get_environment_proxies(environment, proxies):
     os.environ.update(environment)
 
     assert get_environment_proxies() == proxies
+
+
+@pytest.mark.parametrize(
+    "headers, output",
+    [
+        ([("content-type", "text/html")], [("content-type", "text/html")]),
+        ([("authorization", "s3kr3t")], [("authorization", "[secure]")]),
+        ([("proxy-authorization", "s3kr3t")], [("proxy-authorization", "[secure]")]),
+    ],
+)
+def test_obfuscate_sensitive_headers(headers, output):
+    bytes_headers = [(k.encode(), v.encode()) for k, v in headers]
+    bytes_output = [(k.encode(), v.encode()) for k, v in output]
+    assert list(obfuscate_sensitive_headers(headers)) == output
+    assert list(obfuscate_sensitive_headers(bytes_headers)) == bytes_output


### PR DESCRIPTION
Working on and debugging #352, I noticed we didn't have debug logs for the `ASGIDispatch`, so here they are. :)

Example output:

```python
import httpx

async def app(scope, receive, send):
    assert scope["type"] == "http"
    await send(
        {
            "type": "http.response.start",
            "status": 200,
            "headers": [[b"content-type", b"text/plain"]],
        }
    )
    await send({"type": "http.response.body", "body": b"Hello, world!"})

with httpx.Client(app=app) as client:
    r = client.get("http://app")
    print(r)
```

```console
20:18:22.096 - httpx.dispatch.asgi - started
20:18:22.096 - httpx.dispatch.asgi - received message={'type': 'http.response.start', 'status': 200, 'headers': '<...>'}
20:18:22.096 - httpx.dispatch.asgi - received message={'type': 'http.response.body', 'body': '<13 bytes>'}
20:18:22.097 - httpx.dispatch.asgi - completed
<Response [200 OK]>
```