### PR TITLE
Remove ENABLE_CONNECT_PROTOCOL from HTTP/2 Settings

### DIFF
--- a/httpx/dispatch/http2.py
+++ b/httpx/dispatch/http2.py
@@ -3,7 +3,7 @@ import typing
 
 import h2.connection
 import h2.events
-from h2.settings import Settings, SettingCodes
+from h2.settings import SettingCodes, Settings
 
 from ..concurrency.base import BaseEvent, BaseTCPStream, ConcurrencyBackend, TimeoutFlag
 from ..config import TimeoutConfig, TimeoutTypes
@@ -77,8 +77,8 @@ class HTTP2Connection:
                 SettingCodes.ENABLE_PUSH: 0,
                 # These two are taken from h2 for safe defaults
                 SettingCodes.MAX_CONCURRENT_STREAMS: 100,
-                SettingCodes.MAX_HEADER_LIST_SIZE: 65536
-            }
+                SettingCodes.MAX_HEADER_LIST_SIZE: 65536,
+            },
         )
 
         # Some websites (*cough* Yahoo *cough*) balk at this setting being

--- a/tests/dispatch/test_http2.py
+++ b/tests/dispatch/test_http2.py
@@ -1,5 +1,7 @@
 import json
 
+import h2.connection
+
 from httpx import AsyncClient, Client, Response
 
 from .utils import MockHTTP2Backend
@@ -165,3 +167,15 @@ async def test_async_http2_reconnect(backend):
 
     assert response_2.status_code == 200
     assert json.loads(response_2.content) == {"method": "GET", "path": "/2", "body": ""}
+
+
+async def test_http2_default_settings(backend):
+    backend = MockHTTP2Backend(app=app, backend=backend)
+
+    async with AsyncClient(backend=backend) as client:
+        await client.get("http://example.org")
+
+    h2_conn = backend.server.conn
+
+    assert isinstance(h2_conn, h2.connection.H2Connection)
+    assert h2_conn.remote_settings == {}

--- a/tests/dispatch/test_http2.py
+++ b/tests/dispatch/test_http2.py
@@ -1,6 +1,8 @@
 import json
 
 import h2.connection
+import h2.events
+from h2.settings import SettingCodes
 
 from httpx import AsyncClient, Client, Response
 
@@ -169,7 +171,7 @@ async def test_async_http2_reconnect(backend):
     assert json.loads(response_2.content) == {"method": "GET", "path": "/2", "body": ""}
 
 
-async def test_http2_default_settings(backend):
+async def test_http2_settings_in_handshake(backend):
     backend = MockHTTP2Backend(app=app, backend=backend)
 
     async with AsyncClient(backend=backend) as client:
@@ -178,4 +180,27 @@ async def test_http2_default_settings(backend):
     h2_conn = backend.server.conn
 
     assert isinstance(h2_conn, h2.connection.H2Connection)
-    assert h2_conn.remote_settings == {}
+    expected_settings = {
+        SettingCodes.HEADER_TABLE_SIZE: 4096,
+        SettingCodes.ENABLE_PUSH: 0,
+        SettingCodes.MAX_CONCURRENT_STREAMS: 100,
+        SettingCodes.INITIAL_WINDOW_SIZE: 65535,
+        SettingCodes.MAX_FRAME_SIZE: 16384,
+        SettingCodes.MAX_HEADER_LIST_SIZE: 65536,
+        # This one's here because h2 helpfully populates remote_settings
+        # with default values even if the peer doesn't send the setting.
+        SettingCodes.ENABLE_CONNECT_PROTOCOL: 0
+    }
+    assert dict(h2_conn.remote_settings) == expected_settings
+
+    # We don't expect the ENABLE_CONNECT_PROTOCOL to be in the handshake
+    expected_settings.pop(SettingCodes.ENABLE_CONNECT_PROTOCOL)
+
+    assert len(backend.server.settings_changed) == 1
+    settings = backend.server.settings_changed[0]
+
+    assert isinstance(settings, h2.events.RemoteSettingsChanged)
+    assert len(settings.changed_settings) == len(expected_settings)
+    for setting_code, changed_setting in settings.changed_settings.items():
+        assert isinstance(changed_setting, h2.settings.ChangedSetting)
+        assert changed_setting.new_value == expected_settings[setting_code]

--- a/tests/dispatch/test_http2.py
+++ b/tests/dispatch/test_http2.py
@@ -189,7 +189,7 @@ async def test_http2_settings_in_handshake(backend):
         SettingCodes.MAX_HEADER_LIST_SIZE: 65536,
         # This one's here because h2 helpfully populates remote_settings
         # with default values even if the peer doesn't send the setting.
-        SettingCodes.ENABLE_CONNECT_PROTOCOL: 0
+        SettingCodes.ENABLE_CONNECT_PROTOCOL: 0,
     }
     assert dict(h2_conn.remote_settings) == expected_settings
 

--- a/tests/dispatch/utils.py
+++ b/tests/dispatch/utils.py
@@ -41,6 +41,7 @@ class MockHTTP2Server(BaseTCPStream):
         self.close_connection = False
         self.return_data = {}
         self.returning = {}
+        self.settings_changed = []
 
     # TCP stream interface
 
@@ -81,6 +82,8 @@ class MockHTTP2Server(BaseTCPStream):
                 # This will throw an error if the event is for a not-yet created stream
                 elif self.returning[event.stream_id]:
                     self.send_return_data(event.stream_id)
+            elif isinstance(event, h2.events.RemoteSettingsChanged):
+                self.settings_changed.append(event)
 
     async def write(self, data: bytes, timeout) -> None:
         self.write_no_block(data)


### PR DESCRIPTION
Some servers that are high on the Alexa 1M don't follow RFCs and ignore unknown settings. Since we don't benefit from this setting we should stop sending it.

This is only part 1 of #236