### PR TITLE
Query parameter encoding fixes

### DIFF
--- a/httpx/client.py
+++ b/httpx/client.py
@@ -115,7 +115,8 @@ class BaseClient:
         )
 
         if params is None:
-            params = {}
+            # Cast since mypy complains if we assign to `{}` here.
+            params = typing.cast(typing.Mapping, {})
 
         self.auth = auth
         self._params = QueryParams(params)

--- a/httpx/models.py
+++ b/httpx/models.py
@@ -52,6 +52,7 @@ QueryParamTypes = typing.Union[
     "QueryParams",
     typing.Mapping[str, PrimitiveData],
     typing.List[typing.Tuple[str, PrimitiveData]],
+    typing.Mapping[str, typing.Sequence[PrimitiveData]],
     str,
 ]
 
@@ -298,7 +299,7 @@ class QueryParams(typing.Mapping[str, str]):
                 for u in (
                     v  # type: ignore
                     if hasattr(v, "__iter__") and not isinstance(v, (str, bytes))
-                    else [v]
+                    else [v]  # type: ignore
                 )
             ]
 

--- a/httpx/models.py
+++ b/httpx/models.py
@@ -51,8 +51,8 @@ URLTypes = typing.Union["URL", str]
 QueryParamTypes = typing.Union[
     "QueryParams",
     typing.Mapping[str, PrimitiveData],
-    typing.List[typing.Tuple[str, PrimitiveData]],
     typing.Mapping[str, typing.Sequence[PrimitiveData]],
+    typing.List[typing.Tuple[str, PrimitiveData]],
     str,
 ]
 

--- a/httpx/utils.py
+++ b/httpx/utils.py
@@ -11,6 +11,9 @@ from time import perf_counter
 from types import TracebackType
 from urllib.request import getproxies
 
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from .models import PrimitiveData
+
 
 def normalize_header_key(value: typing.AnyStr, encoding: str = None) -> bytes:
     """
@@ -30,7 +33,7 @@ def normalize_header_value(value: typing.AnyStr, encoding: str = None) -> bytes:
     return value.encode(encoding or "ascii")
 
 
-def str_query_param(value: typing.Optional[typing.Union[str, int, float, bool]]) -> str:
+def str_query_param(value: "PrimitiveData") -> str:
     """
     Coerce a primitive data type into a string value for query params.
 

--- a/httpx/utils.py
+++ b/httpx/utils.py
@@ -42,6 +42,8 @@ def str_query_param(value: typing.Optional[typing.Union[str, int, float, bool]])
         return "false"
     elif value is None:
         return ""
+    elif isinstance(value, bytes):
+        return value.decode()
     return str(value)
 
 

--- a/tests/models/test_queryparams.py
+++ b/tests/models/test_queryparams.py
@@ -1,8 +1,18 @@
+import pytest
+
 from httpx import QueryParams
 
 
-def test_queryparams():
-    q = QueryParams("a=123&a=456&b=789")
+@pytest.mark.parametrize(
+    "source",
+    [
+        "a=123&a=456&b=789",
+        {"a": ["123", "456"], "b": 789},
+        {"a": ("123", "456"), "b": 789},
+    ],
+)
+def test_queryparams(source):
+    q = QueryParams(source)
     assert "a" in q
     assert "A" not in q
     assert "c" not in q

--- a/tests/models/test_queryparams.py
+++ b/tests/models/test_queryparams.py
@@ -28,39 +28,41 @@ def test_queryparams(source):
     assert dict(q) == {"a": "456", "b": "789"}
     assert str(q) == "a=123&a=456&b=789"
     assert repr(q) == "QueryParams('a=123&a=456&b=789')"
-    assert QueryParams({"a": "123", "b": "456"}) == QueryParams(
-        [("a", "123"), ("b", "456")]
-    )
-    assert QueryParams({"a": "123", "b": "456"}) == QueryParams("a=123&b=456")
-    assert QueryParams({"a": "123", "b": "456"}) == QueryParams(
-        {"b": "456", "a": "123"}
-    )
-    assert QueryParams() == QueryParams({})
-    assert QueryParams([("a", "123"), ("a", "456")]) == QueryParams("a=123&a=456")
-    assert QueryParams({"a": "123", "b": "456"}) != "invalid"
-
-    q = QueryParams([("a", "123"), ("a", "456")])
-    assert QueryParams(q) == q
 
 
-def test_queryparam_types():
-    q = QueryParams({"a": True})
-    assert str(q) == "a=true"
+@pytest.mark.parametrize(
+    "one, other",
+    [
+        [
+            QueryParams({"a": "123", "b": "456"}),
+            QueryParams([("a", "123"), ("b", "456")]),
+        ],
+        [QueryParams({"a": "123", "b": "456"}), QueryParams("a=123&b=456")],
+        [QueryParams({"a": "123", "b": "456"}), QueryParams({"b": "456", "a": "123"})],
+        [QueryParams(), QueryParams({})],
+        [QueryParams([("a", "123"), ("a", "456")]), QueryParams("a=123&a=456")],
+        [
+            QueryParams([("a", "123"), ("a", "456")]),
+            QueryParams(QueryParams([("a", "123"), ("a", "456")])),
+        ],
+    ],
+)
+def test_queryparams_equality(one, other):
+    assert one == other
 
-    q = QueryParams({"a": False})
-    assert str(q) == "a=false"
 
-    q = QueryParams({"a": ""})
-    assert str(q) == "a="
-
-    q = QueryParams({"a": None})
-    assert str(q) == "a="
-
-    q = QueryParams({"a": 1.23})
-    assert str(q) == "a=1.23"
-
-    q = QueryParams({"a": 123})
-    assert str(q) == "a=123"
-
-    q = QueryParams({"a": b"123"})
-    assert str(q) == "a=123"
+@pytest.mark.parametrize(
+    "source, output",
+    [
+        ({"a": True}, "a=true"),
+        ({"a": False}, "a=false"),
+        ({"a": ""}, "a="),
+        ({"a": None}, "a="),
+        ({"a": 1.23}, "a=1.23"),
+        ({"a": 123}, "a=123"),
+        ({"a": b"123"}, "a=123"),
+    ],
+)
+def test_queryparam_types(source, output):
+    q = QueryParams(source)
+    assert str(q) == output

--- a/tests/models/test_queryparams.py
+++ b/tests/models/test_queryparams.py
@@ -61,3 +61,6 @@ def test_queryparam_types():
 
     q = QueryParams({"a": 123})
     assert str(q) == "a=123"
+
+    q = QueryParams({"a": b"123"})
+    assert str(q) == "a=123"


### PR DESCRIPTION
Fixes #366 

Re-running the example from https://github.com/encode/httpx/issues/366#issuecomment-533786466:

```python
import httpx
import requests

URL = "https://httpbin.org/get"
PARAMS = {"documentIds": ["a55b2f894b90dd1213201471_25", "b54b2f894b90dd1213201471_9"]}

resp = requests.get(URL, params=PARAMS)
print("requests", resp.json()["args"])

r = httpx.get(URL, params=PARAMS)
json = r.json()
assert isinstance(json, dict)
print("httpx", json["args"])

print("httpx", str(httpx.QueryParams(PARAMS)))
```

```console
requests {'documentIds': ['a55b2f894b90dd1213201471_25', 'b54b2f894b90dd1213201471_9']}
httpx {'documentIds': ['a55b2f894b90dd1213201471_25', 'b54b2f894b90dd1213201471_9']}
httpx documentIds=a55b2f894b90dd1213201471_25&documentIds=b54b2f894b90dd1213201471_9
```

cc @Senpos

This also fixes encoding of bytes-type query params:

```python
import httpx

q = httpx.QueryParams({"data": b"hello"})
print(q)  # 'data=hello'
# Previously: 'b%27hello%27'
```

I dared to include a refactoring of the tests to make use for parametrization — the main motivation is to not stop at the first failing `assert`.