### PR TITLE
Propogate Client config to HTTPProxy

### DIFF
--- a/httpx/dispatch/proxy_http.py
+++ b/httpx/dispatch/proxy_http.py
@@ -7,6 +7,7 @@ from ..config import (
     DEFAULT_POOL_LIMITS,
     DEFAULT_TIMEOUT_CONFIG,
     CertTypes,
+    HTTPVersionTypes,
     PoolLimits,
     SSLConfig,
     TimeoutTypes,
@@ -51,8 +52,10 @@ class HTTPProxy(ConnectionPool):
         proxy_mode: HTTPProxyMode = HTTPProxyMode.DEFAULT,
         verify: VerifyTypes = True,
         cert: CertTypes = None,
+        trust_env: bool = None,
         timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
         pool_limits: PoolLimits = DEFAULT_POOL_LIMITS,
+        http_versions: HTTPVersionTypes = None,
         backend: ConcurrencyBackend = None,
     ):
 
@@ -62,6 +65,8 @@ class HTTPProxy(ConnectionPool):
             timeout=timeout,
             pool_limits=pool_limits,
             backend=backend,
+            trust_env=trust_env,
+            http_versions=http_versions,
         )
 
         self.proxy_url = URL(proxy_url)

--- a/tests/client/test_proxies.py
+++ b/tests/client/test_proxies.py
@@ -27,3 +27,22 @@ def test_proxies_parameter(proxies, expected_proxies):
         assert client.proxies[proxy_key].proxy_url == url
 
     assert len(expected_proxies) == len(client.proxies)
+
+
+def test_proxies_has_same_properties_as_dispatch():
+    client = httpx.AsyncClient(proxies="http://127.0.0.1")
+    pool = client.dispatch
+    proxy = client.proxies["all"]
+
+    assert isinstance(pool, httpx.ConnectionPool)
+    assert isinstance(proxy, httpx.HTTPProxy)
+
+    for prop in [
+        "verify",
+        "cert",
+        "timeout",
+        "pool_limits",
+        "http_versions",
+        "backend",
+    ]:
+        assert getattr(pool, prop) == getattr(proxy, prop)


### PR DESCRIPTION
Proxies aren't being constructed in the same way as the primary dispatcher for the Client so end up with defaults for `verify`, etc causing certificates outside of the certifi bundle to fail even when specified via `verify`.

I removed the `proxies` parameter for individual requests as it's broken in the same way but this PR doesn't provide a fix. That work can be done in a separate PR?

Closes #376.