### PR TITLE
Fix bug when using client without timeouts under 3.6

### DIFF
--- a/httpx/concurrency/asyncio.py
+++ b/httpx/concurrency/asyncio.py
@@ -81,6 +81,12 @@ class TCPStream(BaseTCPStream):
             except asyncio.TimeoutError:
                 if should_raise:
                     raise ReadTimeout() from None
+                # FIX(py3.6): yield control back to the event loop to give it a chance
+                # to cancel `.read(n)` before we retry.
+                # This prevents concurrent `.read()` calls, which asyncio
+                # doesn't seem to allow on 3.6.
+                # See: https://github.com/encode/httpx/issues/382
+                await asyncio.sleep(0)
 
         return data
 

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -2,6 +2,7 @@ import pytest
 
 from httpx import (
     AsyncClient,
+    Client,
     ConnectTimeout,
     PoolLimits,
     PoolTimeout,
@@ -47,3 +48,13 @@ async def test_pool_timeout(server, backend):
             await client.get("http://localhost:8000/")
 
         await response.read()
+
+
+def test_sync_infinite_timeout(server):
+    """Regression test for a bug that occurred under Python 3.6.
+
+    See: https://github.com/encode/httpx/issues/382
+    """
+    no_timeout = TimeoutConfig()
+    with Client(timeout=no_timeout) as client:
+        client.get(server.url.copy_with(path="/slow_response/50"))


### PR DESCRIPTION
Fixes #382 cc @StephenBrown2 