### PR TITLE
Allow lists in query params

### DIFF
--- a/httpx/models.py
+++ b/httpx/models.py
@@ -32,6 +32,7 @@ from .exceptions import (
 from .multipart import multipart_encode
 from .status_codes import StatusCode
 from .utils import (
+    flatten_queryparams,
     guess_json_utf,
     is_known_encoding,
     normalize_header_key,
@@ -51,7 +52,7 @@ URLTypes = typing.Union["URL", str]
 
 QueryParamTypes = typing.Union[
     "QueryParams",
-    typing.Mapping[str, PrimitiveData],
+    typing.Mapping[str, typing.Union[PrimitiveData, typing.Sequence[PrimitiveData]]],
     typing.List[typing.Tuple[str, PrimitiveData]],
     str,
 ]
@@ -311,14 +312,15 @@ class QueryParams(typing.Mapping[str, str]):
 
         value = args[0] if args else kwargs
 
+        items: typing.Sequence[typing.Tuple[str, PrimitiveData]]
         if isinstance(value, str):
             items = parse_qsl(value)
         elif isinstance(value, QueryParams):
             items = value.multi_items()
         elif isinstance(value, list):
-            items = value  # type: ignore
+            items = value
         else:
-            items = value.items()  # type: ignore
+            items = flatten_queryparams(value)
 
         self._list = [(str(k), str_query_param(v)) for k, v in items]
         self._dict = {str(k): str_query_param(v) for k, v in items}

--- a/tests/models/test_queryparams.py
+++ b/tests/models/test_queryparams.py
@@ -1,8 +1,18 @@
+import pytest
+
 from httpx import QueryParams
 
 
-def test_queryparams():
-    q = QueryParams("a=123&a=456&b=789")
+@pytest.mark.parametrize(
+    "source",
+    [
+        "a=123&a=456&b=789",
+        {"a": ["123", "456"], "b": 789},
+        {"a": ("123", "456"), "b": 789},
+    ],
+)
+def test_queryparams(source):
+    q = QueryParams(source)
     assert "a" in q
     assert "A" not in q
     assert "c" not in q


### PR DESCRIPTION
Fixes #366 

Re-running the example from https://github.com/encode/httpx/issues/366#issuecomment-533786466:

```python
import httpx
import requests

URL = "https://httpbin.org/get"
PARAMS = {"documentIds": ["a55b2f894b90dd1213201471_25", "b54b2f894b90dd1213201471_9"]}

resp = requests.get(URL, params=PARAMS)
print("requests", resp.json()["args"])

r = httpx.get(URL, params=PARAMS)
json = r.json()
assert isinstance(json, dict)
print("httpx", json["args"])

print("httpx", str(httpx.QueryParams(PARAMS)))
```

```console
requests {'documentIds': ['a55b2f894b90dd1213201471_25', 'b54b2f894b90dd1213201471_9']}
httpx {'documentIds': ['a55b2f894b90dd1213201471_25', 'b54b2f894b90dd1213201471_9']}
httpx documentIds=a55b2f894b90dd1213201471_25&documentIds=b54b2f894b90dd1213201471_9
```
