### PR TITLE
Expose ASGIDispatch & WSGIDispatch in the 'dispatch' namespace.

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -53,7 +53,7 @@ For example:
 
 ```python
 # Instantiate a client that makes WSGI requests with a client IP of "1.2.3.4".
-dispatch = httpx.WSGIDispatch(app=app, remote_addr="1.2.3.4")
+dispatch = httpx.dispatch.WSGIDispatch(app=app, remote_addr="1.2.3.4")
 client = httpx.Client(dispatch=dispatch)
 ```
 

--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -19,6 +19,7 @@ from .config import (
     TimeoutTypes,
     VerifyTypes,
 )
+from .dispatch import ASGIDispatch, WSGIDispatch
 from .dispatch.base import AsyncDispatcher, Dispatcher
 from .dispatch.connection import HTTPConnection
 from .dispatch.connection_pool import ConnectionPool
@@ -115,6 +116,8 @@ __all__ = [
     "BaseTCPStream",
     "ConcurrencyBackend",
     "Dispatcher",
+    "ASGIDispatch",
+    "WSGIDispatch",
     "URL",
     "URLTypes",
     "StatusCode",

--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -19,7 +19,6 @@ from .config import (
     TimeoutTypes,
     VerifyTypes,
 )
-from .dispatch import ASGIDispatch, WSGIDispatch
 from .dispatch.base import AsyncDispatcher, Dispatcher
 from .dispatch.connection import HTTPConnection
 from .dispatch.connection_pool import ConnectionPool
@@ -116,8 +115,6 @@ __all__ = [
     "BaseTCPStream",
     "ConcurrencyBackend",
     "Dispatcher",
-    "ASGIDispatch",
-    "WSGIDispatch",
     "URL",
     "URLTypes",
     "StatusCode",

--- a/httpx/dispatch/__init__.py
+++ b/httpx/dispatch/__init__.py
@@ -5,8 +5,4 @@ details of making the HTTP request and receiving the response.
 from .asgi import ASGIDispatch
 from .wsgi import WSGIDispatch
 
-
-__all__ = [
-    "ASGIDispatch",
-    "WSGIDispatch"
-]
+__all__ = ["ASGIDispatch", "WSGIDispatch"]

--- a/httpx/dispatch/__init__.py
+++ b/httpx/dispatch/__init__.py
@@ -2,3 +2,11 @@
 Dispatch classes handle the raw network connections and the implementation
 details of making the HTTP request and receiving the response.
 """
+from .asgi import ASGIDispatch
+from .wsgi import WSGIDispatch
+
+
+__all__ = [
+    "ASGIDispatch",
+    "WSGIDispatch"
+]


### PR DESCRIPTION
Resolves #398

`ASGIDispatch` and `WSGIDispatch` were added to `dispatch` namespace first, then imported from there in the top-level package.
This way they're available at both `httpx.ASGIDispatch` and `httpx.dispatch.ASGIDispatch` which might be handy.