### PR TITLE
Introduce Hypercorn as a test HTTP/2 server

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ combine_as_imports = True
 force_grid_wrap = 0
 include_trailing_comma = True
 known_first_party = httpx,httpxprof,tests
-known_third_party = brotli,certifi,chardet,click,cryptography,h11,h2,hstspreload,nox,pytest,requests,rfc3986,setuptools,tqdm,trio,trustme,uvicorn
+known_third_party = brotli,certifi,chardet,click,cryptography,h11,h2,hstspreload,hypercorn,nox,pytest,requests,rfc3986,setuptools,tqdm,trio,trustme,uvicorn
 line_length = 88
 multi_line_output = 3
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,6 +8,7 @@ flake8
 flake8-bugbear
 flake8-comprehensions
 flake8-pie
+hypercorn
 isort
 mypy
 pytest

--- a/tests/dispatch/test_http2.py
+++ b/tests/dispatch/test_http2.py
@@ -1,15 +1,207 @@
+import asyncio
 import json
+import sys
+import threading
 
 import h2.connection
 import h2.events
+import pytest
 from h2.settings import SettingCodes
+from hypercorn.asyncio import serve
+from hypercorn.config import Config
 
 from httpx import AsyncClient, Client, Response
 
 from .utils import MockHTTP2Backend
 
 
-def app(request):
+async def app(scope, receive, send):
+    if scope["type"] == "lifespan":
+        while True:
+            message = await receive()
+            if message["type"] == "lifespan.startup":
+                await send({"type": "lifespan.startup.complete"})
+            elif message["type"] == "lifespan.shutdown":
+                await send({"type": "lifespan.shutdown.complete"})
+                return
+    elif scope["type"] == "http":
+        assert scope["http_version"] == "2"
+
+        body = b""
+        more_body = True
+        while more_body:
+            message = await receive()
+            body += message.get("body", b"")
+            more_body = message.get("more_body", False)
+
+        content = json.dumps(
+            {"method": scope["method"], "path": scope["path"], "body": body.decode()}
+        ).encode()
+        headers = [(b"content-length", b"%d" % len(content))]
+        await send({"type": "http.response.start", "status": 200, "headers": headers})
+        await send({"type": "http.response.body", "body": content, "more_body": False})
+    else:
+        raise Exception()
+
+
+@pytest.fixture(name="h2_server", scope="module")
+def _h2_server(cert_pem_file, cert_private_key_file):
+    bind = "0.0.0.0:8543"
+    shutdown_event = threading.Event()
+
+    async def _shutdown_trigger():
+        while not shutdown_event.is_set():
+            await asyncio.sleep(0.1)
+
+    def _run():
+        config = Config()
+        config.bind = bind
+        config.certfile = cert_pem_file
+        config.keyfile = cert_private_key_file
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+        loop.run_until_complete(serve(app, config, shutdown_trigger=_shutdown_trigger))
+
+    thread = threading.Thread(target=_run)
+    thread.start()
+    import time
+
+    time.sleep(0.5)
+    yield f"https://{bind}"
+    shutdown_event.set()
+    thread.join()
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 7), reason="Hypercorn requires python3.7 or higher"
+)
+def test_http2_get_request(h2_server):
+    with Client(http_versions=["HTTP/2"], verify=False) as client:
+        response = client.get(h2_server)
+
+    assert response.status_code == 200
+    assert json.loads(response.content) == {"method": "GET", "path": "/", "body": ""}
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 7), reason="Hypercorn requires python3.7 or higher"
+)
+async def test_async_http2_get_request(backend, h2_server):
+    async with AsyncClient(
+        backend=backend, http_versions=["HTTP/2"], verify=False
+    ) as client:
+        response = await client.get(h2_server)
+
+    assert response.status_code == 200
+    assert json.loads(response.content) == {"method": "GET", "path": "/", "body": ""}
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 7), reason="Hypercorn requires python3.7 or higher"
+)
+def test_http2_post_request(h2_server):
+    with Client(http_versions=["HTTP/2"], verify=False) as client:
+        response = client.post(h2_server, data=b"<data>")
+
+    assert response.status_code == 200
+    assert json.loads(response.content) == {
+        "method": "POST",
+        "path": "/",
+        "body": "<data>",
+    }
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 7), reason="Hypercorn requires python3.7 or higher"
+)
+async def test_async_http2_post_request(backend, h2_server):
+    async with AsyncClient(
+        backend=backend, http_versions=["HTTP/2"], verify=False
+    ) as client:
+        response = await client.post(h2_server, data=b"<data>")
+
+    assert response.status_code == 200
+    assert json.loads(response.content) == {
+        "method": "POST",
+        "path": "/",
+        "body": "<data>",
+    }
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 7), reason="Hypercorn requires python3.7 or higher"
+)
+def test_http2_large_post_request(h2_server):
+    data = b"a" * 100000
+    with Client(http_versions=["HTTP/2"], verify=False) as client:
+        response = client.post(h2_server, data=data)
+    assert response.status_code == 200
+    assert json.loads(response.content) == {
+        "method": "POST",
+        "path": "/",
+        "body": data.decode(),
+    }
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 7), reason="Hypercorn requires python3.7 or higher"
+)
+async def test_async_http2_large_post_request(backend, h2_server):
+    data = b"a" * 100000
+    async with AsyncClient(
+        backend=backend, http_versions=["HTTP/2"], verify=False
+    ) as client:
+        response = await client.post(h2_server, data=data)
+    assert response.status_code == 200
+    assert json.loads(response.content) == {
+        "method": "POST",
+        "path": "/",
+        "body": data.decode(),
+    }
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 7), reason="Hypercorn requires python3.7 or higher"
+)
+def test_http2_multiple_requests(h2_server):
+    with Client(http_versions=["HTTP/2"], verify=False) as client:
+        response_1 = client.get(f"{h2_server}/1")
+        response_2 = client.get(f"{h2_server}/2")
+        response_3 = client.get(f"{h2_server}/3")
+
+    assert response_1.status_code == 200
+    assert json.loads(response_1.content) == {"method": "GET", "path": "/1", "body": ""}
+
+    assert response_2.status_code == 200
+    assert json.loads(response_2.content) == {"method": "GET", "path": "/2", "body": ""}
+
+    assert response_3.status_code == 200
+    assert json.loads(response_3.content) == {"method": "GET", "path": "/3", "body": ""}
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 7), reason="Hypercorn requires python3.7 or higher"
+)
+async def test_async_http2_multiple_requests(backend, h2_server):
+    async with AsyncClient(
+        backend=backend, http_versions=["HTTP/2"], verify=False
+    ) as client:
+        response_1 = await client.get(f"{h2_server}/1")
+        response_2 = await client.get(f"{h2_server}/2")
+        response_3 = await client.get(f"{h2_server}/3")
+
+    assert response_1.status_code == 200
+    assert json.loads(response_1.content) == {"method": "GET", "path": "/1", "body": ""}
+
+    assert response_2.status_code == 200
+    assert json.loads(response_2.content) == {"method": "GET", "path": "/2", "body": ""}
+
+    assert response_3.status_code == 200
+    assert json.loads(response_3.content) == {"method": "GET", "path": "/3", "body": ""}
+
+
+def mock_app(request):
     content = json.dumps(
         {
             "method": request.method,
@@ -21,128 +213,15 @@ def app(request):
     return Response(200, headers=headers, content=content)
 
 
-def test_http2_get_request():
-    backend = MockHTTP2Backend(app=app)
-
-    with Client(backend=backend) as client:
-        response = client.get("http://example.org")
-
-    assert response.status_code == 200
-    assert json.loads(response.content) == {"method": "GET", "path": "/", "body": ""}
-
-
-async def test_async_http2_get_request(backend):
-    backend = MockHTTP2Backend(app=app, backend=backend)
-
-    async with AsyncClient(backend=backend) as client:
-        response = await client.get("http://example.org")
-
-    assert response.status_code == 200
-    assert json.loads(response.content) == {"method": "GET", "path": "/", "body": ""}
-
-
-def test_http2_post_request():
-    backend = MockHTTP2Backend(app=app)
-
-    with Client(backend=backend) as client:
-        response = client.post("http://example.org", data=b"<data>")
-
-    assert response.status_code == 200
-    assert json.loads(response.content) == {
-        "method": "POST",
-        "path": "/",
-        "body": "<data>",
-    }
-
-
-async def test_async_http2_post_request(backend):
-    backend = MockHTTP2Backend(app=app, backend=backend)
-
-    async with AsyncClient(backend=backend) as client:
-        response = await client.post("http://example.org", data=b"<data>")
-
-    assert response.status_code == 200
-    assert json.loads(response.content) == {
-        "method": "POST",
-        "path": "/",
-        "body": "<data>",
-    }
-
-
-def test_http2_large_post_request():
-    backend = MockHTTP2Backend(app=app)
-
-    data = b"a" * 100000
-    with Client(backend=backend) as client:
-        response = client.post("http://example.org", data=data)
-    assert response.status_code == 200
-    assert json.loads(response.content) == {
-        "method": "POST",
-        "path": "/",
-        "body": data.decode(),
-    }
-
-
-async def test_async_http2_large_post_request(backend):
-    backend = MockHTTP2Backend(app=app, backend=backend)
-
-    data = b"a" * 100000
-    async with AsyncClient(backend=backend) as client:
-        response = await client.post("http://example.org", data=data)
-    assert response.status_code == 200
-    assert json.loads(response.content) == {
-        "method": "POST",
-        "path": "/",
-        "body": data.decode(),
-    }
-
-
-def test_http2_multiple_requests():
-    backend = MockHTTP2Backend(app=app)
-
-    with Client(backend=backend) as client:
-        response_1 = client.get("http://example.org/1")
-        response_2 = client.get("http://example.org/2")
-        response_3 = client.get("http://example.org/3")
-
-    assert response_1.status_code == 200
-    assert json.loads(response_1.content) == {"method": "GET", "path": "/1", "body": ""}
-
-    assert response_2.status_code == 200
-    assert json.loads(response_2.content) == {"method": "GET", "path": "/2", "body": ""}
-
-    assert response_3.status_code == 200
-    assert json.loads(response_3.content) == {"method": "GET", "path": "/3", "body": ""}
-
-
-async def test_async_http2_multiple_requests(backend):
-    backend = MockHTTP2Backend(app=app, backend=backend)
-
-    async with AsyncClient(backend=backend) as client:
-        response_1 = await client.get("http://example.org/1")
-        response_2 = await client.get("http://example.org/2")
-        response_3 = await client.get("http://example.org/3")
-
-    assert response_1.status_code == 200
-    assert json.loads(response_1.content) == {"method": "GET", "path": "/1", "body": ""}
-
-    assert response_2.status_code == 200
-    assert json.loads(response_2.content) == {"method": "GET", "path": "/2", "body": ""}
-
-    assert response_3.status_code == 200
-    assert json.loads(response_3.content) == {"method": "GET", "path": "/3", "body": ""}
-
-
 def test_http2_reconnect():
     """
     If a connection has been dropped between requests, then we should
     be seemlessly reconnected.
     """
-    backend = MockHTTP2Backend(app=app)
+    backend = MockHTTP2Backend(app=mock_app)
 
     with Client(backend=backend) as client:
         response_1 = client.get("http://example.org/1")
-        backend.server.close_connection = True
         response_2 = client.get("http://example.org/2")
 
     assert response_1.status_code == 200
@@ -157,7 +236,7 @@ async def test_async_http2_reconnect(backend):
     If a connection has been dropped between requests, then we should
     be seemlessly reconnected.
     """
-    backend = MockHTTP2Backend(app=app, backend=backend)
+    backend = MockHTTP2Backend(app=mock_app, backend=backend)
 
     async with AsyncClient(backend=backend) as client:
         response_1 = await client.get("http://example.org/1")
@@ -172,7 +251,7 @@ async def test_async_http2_reconnect(backend):
 
 
 async def test_http2_settings_in_handshake(backend):
-    backend = MockHTTP2Backend(app=app, backend=backend)
+    backend = MockHTTP2Backend(app=mock_app, backend=backend)
 
     async with AsyncClient(backend=backend) as client:
         await client.get("http://example.org")

--- a/tests/dispatch/test_http2.py
+++ b/tests/dispatch/test_http2.py
@@ -1,207 +1,14 @@
-import asyncio
 import json
-import sys
-import threading
 
 import h2.connection
-import h2.events
-import pytest
 from h2.settings import SettingCodes
-from hypercorn.asyncio import serve
-from hypercorn.config import Config
 
 from httpx import AsyncClient, Client, Response
 
 from .utils import MockHTTP2Backend
 
 
-async def app(scope, receive, send):
-    if scope["type"] == "lifespan":
-        while True:
-            message = await receive()
-            if message["type"] == "lifespan.startup":
-                await send({"type": "lifespan.startup.complete"})
-            elif message["type"] == "lifespan.shutdown":
-                await send({"type": "lifespan.shutdown.complete"})
-                return
-    elif scope["type"] == "http":
-        assert scope["http_version"] == "2"
-
-        body = b""
-        more_body = True
-        while more_body:
-            message = await receive()
-            body += message.get("body", b"")
-            more_body = message.get("more_body", False)
-
-        content = json.dumps(
-            {"method": scope["method"], "path": scope["path"], "body": body.decode()}
-        ).encode()
-        headers = [(b"content-length", b"%d" % len(content))]
-        await send({"type": "http.response.start", "status": 200, "headers": headers})
-        await send({"type": "http.response.body", "body": content, "more_body": False})
-    else:
-        raise Exception()
-
-
-@pytest.fixture(name="h2_server", scope="module")
-def _h2_server(cert_pem_file, cert_private_key_file):
-    bind = "0.0.0.0:8543"
-    shutdown_event = threading.Event()
-
-    async def _shutdown_trigger():
-        while not shutdown_event.is_set():
-            await asyncio.sleep(0.1)
-
-    def _run():
-        config = Config()
-        config.bind = bind
-        config.certfile = cert_pem_file
-        config.keyfile = cert_private_key_file
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-
-        loop.run_until_complete(serve(app, config, shutdown_trigger=_shutdown_trigger))
-
-    thread = threading.Thread(target=_run)
-    thread.start()
-    import time
-
-    time.sleep(0.5)
-    yield f"https://{bind}"
-    shutdown_event.set()
-    thread.join()
-
-
-@pytest.mark.skipif(
-    sys.version_info < (3, 7), reason="Hypercorn requires python3.7 or higher"
-)
-def test_http2_get_request(h2_server):
-    with Client(http_versions=["HTTP/2"], verify=False) as client:
-        response = client.get(h2_server)
-
-    assert response.status_code == 200
-    assert json.loads(response.content) == {"method": "GET", "path": "/", "body": ""}
-
-
-@pytest.mark.skipif(
-    sys.version_info < (3, 7), reason="Hypercorn requires python3.7 or higher"
-)
-async def test_async_http2_get_request(backend, h2_server):
-    async with AsyncClient(
-        backend=backend, http_versions=["HTTP/2"], verify=False
-    ) as client:
-        response = await client.get(h2_server)
-
-    assert response.status_code == 200
-    assert json.loads(response.content) == {"method": "GET", "path": "/", "body": ""}
-
-
-@pytest.mark.skipif(
-    sys.version_info < (3, 7), reason="Hypercorn requires python3.7 or higher"
-)
-def test_http2_post_request(h2_server):
-    with Client(http_versions=["HTTP/2"], verify=False) as client:
-        response = client.post(h2_server, data=b"<data>")
-
-    assert response.status_code == 200
-    assert json.loads(response.content) == {
-        "method": "POST",
-        "path": "/",
-        "body": "<data>",
-    }
-
-
-@pytest.mark.skipif(
-    sys.version_info < (3, 7), reason="Hypercorn requires python3.7 or higher"
-)
-async def test_async_http2_post_request(backend, h2_server):
-    async with AsyncClient(
-        backend=backend, http_versions=["HTTP/2"], verify=False
-    ) as client:
-        response = await client.post(h2_server, data=b"<data>")
-
-    assert response.status_code == 200
-    assert json.loads(response.content) == {
-        "method": "POST",
-        "path": "/",
-        "body": "<data>",
-    }
-
-
-@pytest.mark.skipif(
-    sys.version_info < (3, 7), reason="Hypercorn requires python3.7 or higher"
-)
-def test_http2_large_post_request(h2_server):
-    data = b"a" * 100000
-    with Client(http_versions=["HTTP/2"], verify=False) as client:
-        response = client.post(h2_server, data=data)
-    assert response.status_code == 200
-    assert json.loads(response.content) == {
-        "method": "POST",
-        "path": "/",
-        "body": data.decode(),
-    }
-
-
-@pytest.mark.skipif(
-    sys.version_info < (3, 7), reason="Hypercorn requires python3.7 or higher"
-)
-async def test_async_http2_large_post_request(backend, h2_server):
-    data = b"a" * 100000
-    async with AsyncClient(
-        backend=backend, http_versions=["HTTP/2"], verify=False
-    ) as client:
-        response = await client.post(h2_server, data=data)
-    assert response.status_code == 200
-    assert json.loads(response.content) == {
-        "method": "POST",
-        "path": "/",
-        "body": data.decode(),
-    }
-
-
-@pytest.mark.skipif(
-    sys.version_info < (3, 7), reason="Hypercorn requires python3.7 or higher"
-)
-def test_http2_multiple_requests(h2_server):
-    with Client(http_versions=["HTTP/2"], verify=False) as client:
-        response_1 = client.get(f"{h2_server}/1")
-        response_2 = client.get(f"{h2_server}/2")
-        response_3 = client.get(f"{h2_server}/3")
-
-    assert response_1.status_code == 200
-    assert json.loads(response_1.content) == {"method": "GET", "path": "/1", "body": ""}
-
-    assert response_2.status_code == 200
-    assert json.loads(response_2.content) == {"method": "GET", "path": "/2", "body": ""}
-
-    assert response_3.status_code == 200
-    assert json.loads(response_3.content) == {"method": "GET", "path": "/3", "body": ""}
-
-
-@pytest.mark.skipif(
-    sys.version_info < (3, 7), reason="Hypercorn requires python3.7 or higher"
-)
-async def test_async_http2_multiple_requests(backend, h2_server):
-    async with AsyncClient(
-        backend=backend, http_versions=["HTTP/2"], verify=False
-    ) as client:
-        response_1 = await client.get(f"{h2_server}/1")
-        response_2 = await client.get(f"{h2_server}/2")
-        response_3 = await client.get(f"{h2_server}/3")
-
-    assert response_1.status_code == 200
-    assert json.loads(response_1.content) == {"method": "GET", "path": "/1", "body": ""}
-
-    assert response_2.status_code == 200
-    assert json.loads(response_2.content) == {"method": "GET", "path": "/2", "body": ""}
-
-    assert response_3.status_code == 200
-    assert json.loads(response_3.content) == {"method": "GET", "path": "/3", "body": ""}
-
-
-def mock_app(request):
+def app(request):
     content = json.dumps(
         {
             "method": request.method,
@@ -213,15 +20,120 @@ def mock_app(request):
     return Response(200, headers=headers, content=content)
 
 
+def test_http2_get_request(h2_server):
+    with Client(http_versions=["HTTP/2"], verify=False) as client:
+        response = client.get(h2_server.url)
+
+    assert response.status_code == 200
+    assert json.loads(response.content) == {"method": "GET", "path": "/", "body": ""}
+
+
+async def test_async_http2_get_request(backend, h2_server):
+    async with AsyncClient(
+        backend=backend, http_versions=["HTTP/2"], verify=False
+    ) as client:
+        response = await client.get(h2_server.url)
+
+    assert response.status_code == 200
+    assert json.loads(response.content) == {"method": "GET", "path": "/", "body": ""}
+
+
+def test_http2_post_request(h2_server):
+    with Client(http_versions=["HTTP/2"], verify=False) as client:
+        response = client.post(h2_server.url, data=b"<data>")
+
+    assert response.status_code == 200
+    assert json.loads(response.content) == {
+        "method": "POST",
+        "path": "/",
+        "body": "<data>",
+    }
+
+
+async def test_async_http2_post_request(backend, h2_server):
+    async with AsyncClient(
+        backend=backend, http_versions=["HTTP/2"], verify=False
+    ) as client:
+        response = await client.post(h2_server.url, data=b"<data>")
+
+    assert response.status_code == 200
+    assert json.loads(response.content) == {
+        "method": "POST",
+        "path": "/",
+        "body": "<data>",
+    }
+
+
+def test_http2_large_post_request(h2_server):
+    data = b"a" * 100000
+    with Client(http_versions=["HTTP/2"], verify=False) as client:
+        response = client.post(h2_server.url, data=data)
+    assert response.status_code == 200
+    assert json.loads(response.content) == {
+        "method": "POST",
+        "path": "/",
+        "body": data.decode(),
+    }
+
+
+async def test_async_http2_large_post_request(backend, h2_server):
+    data = b"a" * 100000
+    async with AsyncClient(
+        backend=backend, http_versions=["HTTP/2"], verify=False
+    ) as client:
+        response = await client.post(h2_server.url, data=data)
+    assert response.status_code == 200
+    assert json.loads(response.content) == {
+        "method": "POST",
+        "path": "/",
+        "body": data.decode(),
+    }
+
+
+def test_http2_multiple_requests(h2_server):
+    with Client(http_versions=["HTTP/2"], verify=False) as client:
+        response_1 = client.get(h2_server.url.copy_with(path="/1"))
+        response_2 = client.get(h2_server.url.copy_with(path="/2"))
+        response_3 = client.get(h2_server.url.copy_with(path="/3"))
+
+    assert response_1.status_code == 200
+    assert json.loads(response_1.content) == {"method": "GET", "path": "/1", "body": ""}
+
+    assert response_2.status_code == 200
+    assert json.loads(response_2.content) == {"method": "GET", "path": "/2", "body": ""}
+
+    assert response_3.status_code == 200
+    assert json.loads(response_3.content) == {"method": "GET", "path": "/3", "body": ""}
+
+
+async def test_async_http2_multiple_requests(backend, h2_server):
+    async with AsyncClient(
+        backend=backend, http_versions=["HTTP/2"], verify=False
+    ) as client:
+        response_1 = await client.get(h2_server.url.copy_with(path="/1"))
+        response_2 = await client.get(h2_server.url.copy_with(path="/2"))
+        response_3 = await client.get(h2_server.url.copy_with(path="/3"))
+
+    assert response_1.status_code == 200
+    assert json.loads(response_1.content) == {"method": "GET", "path": "/1", "body": ""}
+
+    assert response_2.status_code == 200
+    assert json.loads(response_2.content) == {"method": "GET", "path": "/2", "body": ""}
+
+    assert response_3.status_code == 200
+    assert json.loads(response_3.content) == {"method": "GET", "path": "/3", "body": ""}
+
+
 def test_http2_reconnect():
     """
     If a connection has been dropped between requests, then we should
     be seemlessly reconnected.
     """
-    backend = MockHTTP2Backend(app=mock_app)
+    backend = MockHTTP2Backend(app=app)
 
     with Client(backend=backend) as client:
         response_1 = client.get("http://example.org/1")
+        backend.server.close_connection = True
         response_2 = client.get("http://example.org/2")
 
     assert response_1.status_code == 200
@@ -236,7 +148,7 @@ async def test_async_http2_reconnect(backend):
     If a connection has been dropped between requests, then we should
     be seemlessly reconnected.
     """
-    backend = MockHTTP2Backend(app=mock_app, backend=backend)
+    backend = MockHTTP2Backend(app=app, backend=backend)
 
     async with AsyncClient(backend=backend) as client:
         response_1 = await client.get("http://example.org/1")
@@ -251,7 +163,7 @@ async def test_async_http2_reconnect(backend):
 
 
 async def test_http2_settings_in_handshake(backend):
-    backend = MockHTTP2Backend(app=mock_app, backend=backend)
+    backend = MockHTTP2Backend(app=app, backend=backend)
 
     async with AsyncClient(backend=backend) as client:
         await client.get("http://example.org")


### PR DESCRIPTION
This allows the HTTP/2 tests to be directed at an actual HTTP/2 server
rather than a mock server. This is beneficial as it is closer to the
actual usage by users.