### PR TITLE
setup.py: add AsyncIO and Trio frameworks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,8 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Topic :: Internet :: WWW/HTTP",
+        "Framework :: AsyncIO",
+        "Framework :: Trio",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
This should help to discover httpx from PyPI. We can always remove the Trio framework when moving its support to a third-party package.