### PR TITLE
Add flake8 pie plugin

### DIFF
--- a/httpx/client.py
+++ b/httpx/client.py
@@ -325,7 +325,7 @@ class BaseClient:
         headers = self.merge_headers(headers)
         cookies = self.merge_cookies(cookies)
         params = self.merge_queryparams(params)
-        request = AsyncRequest(
+        return AsyncRequest(
             method,
             url,
             data=data,
@@ -335,7 +335,6 @@ class BaseClient:
             headers=headers,
             cookies=cookies,
         )
-        return request
 
 
 class AsyncClient(BaseClient):
@@ -718,7 +717,7 @@ class Client(BaseClient):
             headers=headers,
             cookies=cookies,
         )
-        response = self.send(
+        return self.send(
             request,
             stream=stream,
             auth=auth,
@@ -728,7 +727,6 @@ class Client(BaseClient):
             timeout=timeout,
             trust_env=trust_env,
         )
-        return response
 
     def send(
         self,

--- a/noxfile.py
+++ b/noxfile.py
@@ -20,7 +20,13 @@ def lint(session):
 @nox.session(reuse_venv=True)
 def check(session):
     session.install(
-        "black", "flake8", "flake8-bugbear", "flake8-comprehensions", "isort", "mypy"
+        "black",
+        "flake8",
+        "flake8-bugbear",
+        "flake8-comprehensions",
+        "flake8-pie",
+        "isort",
+        "mypy",
     )
 
     session.run("black", "--check", "--diff", "--target-version=py36", *source_files)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,6 +7,7 @@ cryptography
 flake8
 flake8-bugbear
 flake8-comprehensions
+flake8-pie
 isort
 mypy
 pytest

--- a/tests/dispatch/test_proxy_http.py
+++ b/tests/dispatch/test_proxy_http.py
@@ -26,7 +26,7 @@ async def test_proxy_tunnel_success(backend):
         backend=raw_io,
         proxy_mode=httpx.HTTPProxyMode.TUNNEL_ONLY,
     ) as proxy:
-        response = await proxy.request("GET", f"http://example.com")
+        response = await proxy.request("GET", "http://example.com")
 
         assert response.status_code == 404
         assert response.headers["Server"] == "origin-server"
@@ -64,7 +64,7 @@ async def test_proxy_tunnel_non_2xx_response(backend, status_code):
             backend=raw_io,
             proxy_mode=httpx.HTTPProxyMode.TUNNEL_ONLY,
         ) as proxy:
-            await proxy.request("GET", f"http://example.com")
+            await proxy.request("GET", "http://example.com")
 
     # ProxyError.request should be the CONNECT request not the original request
     assert e.value.request.method == "CONNECT"
@@ -116,7 +116,7 @@ async def test_proxy_tunnel_start_tls(backend):
         backend=raw_io,
         proxy_mode=httpx.HTTPProxyMode.TUNNEL_ONLY,
     ) as proxy:
-        resp = await proxy.request("GET", f"https://example.com")
+        resp = await proxy.request("GET", "https://example.com")
 
         assert resp.status_code == 404
         assert resp.headers["Server"] == "origin-server"
@@ -128,7 +128,7 @@ async def test_proxy_tunnel_start_tls(backend):
         await resp.read()
 
         # Make another request to see that the tunnel is re-used.
-        resp = await proxy.request("GET", f"https://example.com/target")
+        resp = await proxy.request("GET", "https://example.com/target")
 
         assert resp.status_code == 200
         assert resp.headers["Server"] == "origin-server"
@@ -172,7 +172,7 @@ async def test_proxy_forwarding(backend, proxy_mode):
         proxy_headers={"Proxy-Authorization": "test", "Override": "2"},
     ) as proxy:
         response = await proxy.request(
-            "GET", f"http://example.com", headers={"override": "1"}
+            "GET", "http://example.com", headers={"override": "1"}
         )
 
         assert response.status_code == 200


### PR DESCRIPTION
As mentioned in https://github.com/encode/httpx/pull/375#issuecomment-534197215, this adds `flake8-pie` as a dependency which adds a few checks, two of which are triggered in the current codebase:

- PIE781: You are assigning to a variable and then returning. Instead remove the assignment and return.
- PIE782: Unnecessary f-string. You can safely remove the f prefix.

The following lint messages were fixed after adding the requirement (found with `nox -s check`):
```
nox > flake8 httpx tools tests setup.py noxfile.py
httpx/client.py:338:9: PIE781: You are assigning to a variable and then returning. Instead remove the assignment and return.
httpx/client.py:731:9: PIE781: You are assigning to a variable and then returning. Instead remove the assignment and return.
tests/dispatch/test_proxy_http.py:29:47: PIE782: Unnecessary f-string. You can safely remove the `f` prefix.
tests/dispatch/test_proxy_http.py:67:40: PIE782: Unnecessary f-string. You can safely remove the `f` prefix.
tests/dispatch/test_proxy_http.py:119:43: PIE782: Unnecessary f-string. You can safely remove the `f` prefix.
tests/dispatch/test_proxy_http.py:131:43: PIE782: Unnecessary f-string. You can safely remove the `f` prefix.
tests/dispatch/test_proxy_http.py:175:20: PIE782: Unnecessary f-string. You can safely remove the `f` prefix.
```