### PR TITLE
Skip Python 3.8-dev builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,12 @@ matrix:
       env: NOX_SESSION=test-3.8
       dist: bionic # Required to get OpenSSL 1.1.1+
 
+  # Allow builds to fail when using '-dev' Python versions
+  # Should still investigate failures periodically for new APIs.
+  fast_finish: true
+  allow_failures:
+    - python: 3.8-dev
+
 install:
   - pip install --upgrade nox
 


### PR DESCRIPTION
Taken from [this comment](https://github.com/encode/httpx/pull/423#issuecomment-537455052).
Until we get a stable 3.8 release we'll say passing 3.8 is optional.