### PR TITLE
Build and upload wheels to PyPI

### DIFF
--- a/scripts/publish
+++ b/scripts/publish
@@ -24,7 +24,7 @@ fi
 find ${PACKAGE} -type f -name "*.py[co]" -delete
 find ${PACKAGE} -type d -name __pycache__ -delete
 
-${PREFIX}python setup.py sdist
+${PREFIX}python setup.py sdist bdist_wheel
 ${PREFIX}twine upload dist/*
 ${PREFIX}mkdocs gh-deploy
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[bdist_wheel]
+universal = 1
+
 [flake8]
 ignore = W503, E203, B305
 max-line-length = 88

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -17,6 +17,7 @@ pytest-cov
 trio
 trustme
 uvicorn
+wheel
 
 # https://github.com/MagicStack/uvloop/issues/266
 uvloop<0.13; sys_platform != 'win32' and sys_platform != 'cygwin' and platform_python_implementation != 'pypy'


### PR DESCRIPTION
Closes #432

For now both sdist and wheel are built and uploaded, but as @graingert commented https://github.com/encode/httpx/issues/432#issuecomment-537913387 I can drop the sdist if you want.

Tested locally and the wheel is built correctly, the only step I could not test is the upload with twine to PyPI.