### PR TITLE
Fix link to parallel page from async page

### DIFF
--- a/docs/async.md
+++ b/docs/async.md
@@ -48,7 +48,7 @@ The async response methods are:
 * `.raw()`
 * `.close()`
 
-If you're making [parallel requests](../parallel/), then you'll also need to use an async API:
+If you're making [parallel requests](parallel.md), then you'll also need to use an async API:
 
 ```python
 >>> async with httpx.AsyncClient() as client:


### PR DESCRIPTION
Current page 404s since the href is incorrect.

https://www.encode.io/httpx/async/ contains a link to 'paralell requests' that points to https://www.encode.io/parallel/