### PR TITLE
Don't check trio import in definition of backend fixture params

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ from uvicorn.config import Config
 from uvicorn.main import Server
 
 from httpx import URL, AsyncioBackend
+from httpx.concurrency.trio import TrioBackend
 
 ENVIRONMENT_VARIABLES = {
     "SSL_CERT_FILE",
@@ -47,17 +48,12 @@ def clean_environ() -> typing.Dict[str, typing.Any]:
     os.environ.update(original_environ)
 
 
-backend_params = [pytest.param(AsyncioBackend, marks=pytest.mark.asyncio)]
-
-try:
-    from httpx.concurrency.trio import TrioBackend
-except ImportError:  # pragma: no cover
-    pass
-else:
-    backend_params.append(pytest.param(TrioBackend, marks=pytest.mark.trio))
-
-
-@pytest.fixture(params=backend_params)
+@pytest.fixture(
+    params=[
+        pytest.param(AsyncioBackend, marks=pytest.mark.asyncio),
+        pytest.param(TrioBackend, marks=pytest.mark.trio),
+    ]
+)
 def backend(request):
     backend_cls = request.param
     return backend_cls()


### PR DESCRIPTION
Small refactoring based on the observation that trio is always installed during tests.