### PR TITLE
Remove wheels package from test-requirements.txt

### DIFF
--- a/scripts/publish
+++ b/scripts/publish
@@ -15,6 +15,12 @@ if ! command -v "${PREFIX}twine" &>/dev/null ; then
     exit 1
 fi
 
+if ! ${PREFIX}pip show wheel &>/dev/null ; then
+    echo "Unable to find the 'wheel' command."
+    echo "Install from PyPI, using '${PREFIX}pip install wheel'."
+    exit 1
+fi
+
 if ! command -v "${PREFIX}mkdocs" &>/dev/null ; then
     echo "Unable to find the 'mkdocs' command."
     echo "Install from PyPI, using '${PREFIX}pip install mkdocs'."

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -17,7 +17,6 @@ pytest-cov
 trio
 trustme
 uvicorn
-wheel
 
 # https://github.com/MagicStack/uvloop/issues/266
 uvloop<0.13; sys_platform != 'win32' and sys_platform != 'cygwin' and platform_python_implementation != 'pypy'


### PR DESCRIPTION
As [discussed here](https://github.com/encode/httpx/pull/439#discussion_r331390607) removed `wheel` package from `test-requirements.txt` and moved the check in `./scripts/publish`.