### PR TITLE
Allow serving docs via nox

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -102,17 +102,12 @@ $ nox -s test -- tests/test_multipart.py
 
 ## Documenting
 
-To work with the documentation, make sure you have `mkdocs` and
-`mkdocs-material` installed on your environment:
+Documentation pages are located under the `docs/` folder.
+
+To run the documentation site locally (useful for previewing changes), use:
 
 ```shell
-$ pip install mkdocs mkdocs-material
-```
-
-To spawn the docs server run:
-
-```shell
-$ mkdocs serve
+$ nox -s serve
 ```
 
 ## Releasing

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,6 +2,7 @@ import nox
 
 nox.options.stop_on_first_error = True
 nox.options.reuse_existing_virtualenvs = True
+nox.options.keywords = "not serve"
 
 source_files = ("httpx", "tools", "tests", "setup.py", "noxfile.py")
 
@@ -46,6 +47,13 @@ def docs(session):
     session.install("--upgrade", "mkdocs", "mkdocs-material", "pymdown-extensions")
 
     session.run("mkdocs", "build")
+
+
+@nox.session(reuse_venv=True)
+def serve(session):
+    session.install("--upgrade", "mkdocs", "mkdocs-material")
+
+    session.run("mkdocs", "serve")
 
 
 @nox.session(python=["3.6", "3.7", "3.8"])


### PR DESCRIPTION
Quick addition to our `nox` setup to allow serving docs using `nox` instead of having to install `mkdocs` and `mkdocs-material` locally.

(Not a fan of the snake_cased command name, but both "docs:watch" and "docs-watch" messed with the unselection of the task when running `$ nox`.)

(Edit: edited to `$ nox -s serve`.)