### PR TITLE
Add test script

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -100,6 +100,14 @@ You can also run a single test script like this:
 $ nox -s test -- tests/test_multipart.py
 ```
 
+Lastly, to ensure you're on track to pass the CI build, run:
+
+```shell
+$ scripts/test
+```
+
+This command is a light wrapper around `nox` that will run code style checks and test the code against all installed Python versions.
+
 ## Documenting
 
 Documentation pages are located under the `docs/` folder.

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+set -x
+
+nox -s check
+nox -s test


### PR DESCRIPTION
Prompted by https://github.com/encode/httpx/pull/399#discussion_r329471921

Running

```bash
$ scripts/test
```

runs the test suite and runs the `check` session.

I made it so that the test suite only for the current Python version is run (e.g. 3.7), but we could also run `$ nox -s test` so that all available Python versions are tested (e.g. all of 3.6, 3.7 and 3.8 if they're detected as available by `nox`). This is mostly because running tests against all Python versions can get very long, esp. because virtualenvs aren't reused. Thoughts?