### PR TITLE
Removed lowercased environment variables test cases from the proxies tests.

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -175,17 +175,10 @@ async def test_elapsed_timer():
         ({}, {}),
         ({"HTTP_PROXY": "http://127.0.0.1"}, {"http": "http://127.0.0.1"}),
         (
-            {"https_proxy": "http://127.0.0.1", "HTTP_PROXY": "https://127.0.0.1"},
-            {"https": "http://127.0.0.1", "http": "https://127.0.0.1"},
+            {"HTTPS_PROXY": "http://127.0.0.1", "HTTP_PROXY": "https://127.0.0.2"},
+            {"https": "http://127.0.0.1", "http": "https://127.0.0.2"},
         ),
-        (
-            {"all_proxy": "http://127.0.0.1", "ALL_PROXY": "https://1.1.1.1"},
-            {"all": "http://127.0.0.1"},
-        ),
-        (
-            {"https_proxy": "http://127.0.0.1", "HTTPS_PROXY": "https://1.1.1.1"},
-            {"https": "http://127.0.0.1"},
-        ),
+        ({"ALL_PROXY": "http://127.0.0.1"}, {"all": "http://127.0.0.1"}),
         ({"TRAVIS_APT_PROXY": "http://127.0.0.1"}, {}),
     ],
 )


### PR DESCRIPTION
as per comment in #402 , separated PR for lowercased environment variables