### PR TITLE
First pass at autodoc support

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -8,6 +8,9 @@
     enable HTTP/2 and connection pooling for more efficient and
     long-lived connections.
 
+::: httpx.request
+    :docstring:
+
 * `get(url, [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout], [proxies])`
 * `options(url, [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout], [proxies])`
 * `head(url, [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout], [proxies])`
@@ -15,8 +18,6 @@
 * `put(url, [data], [files], [json], [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout], [proxies])`
 * `patch(url, [data], [files], [json], [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout], [proxies])`
 * `delete(url, [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout], [proxies])`
-* `request(method, url, [data], [files], [params], [headers], [cookies], [auth], [stream], [allow_redirects], [verify], [cert], [timeout], [proxies])`
-* `build_request(method, url, [data], [files], [json], [params], [headers], [cookies])`
 
 ## `Client`
 

--- a/httpx/api.py
+++ b/httpx/api.py
@@ -34,6 +34,43 @@ def request(
     trust_env: bool = None,
     proxies: ProxiesTypes = None,
 ) -> Response:
+    """
+    Constructs and sends a `Request`.
+
+    **Parameters:**
+
+    * **method** - HTTP method for the new `Request` object: `GET`, `OPTIONS`, `HEAD`,
+    `POST`, `PUT`, `PATCH`, or `DELETE`.
+    * **url** - URL for the new `Request` object.
+    * **params** - *(optional)* Query parameters to include in the URL, as a string, dictionary,
+    or list of two-tuples.
+    * **data** - *(optional)* Data to include in the body of the request, as a dictionary
+    * **files** - *(optional)* A dictionary of upload files to include in the body of the request.
+    * **json** - *(optional)* A JSON serializable object to include in the body of the request.
+    * **headers** - *(optional)* Dictionary of HTTP headers to include on the request.
+    * **cookies** - *(optional)* Dictionary of Cookie items to include in the request.
+    * **auth** - *(optional)* An authentication class to use when sending the request.
+    * **timeout** - *(optional)* The timeout configuration to use when sending the request.
+    * **allow_redirects** - *(optional)* Enables or disables HTTP redirects.
+    * **cert** - *(optional)* Either a path to an SSL certificate file, or two-tuple of
+    (certificate file, key file), or a three-tuple of (certificate file, key
+    file, password).
+    * **verify** - *(optional)* Enables or disables SSL verification.
+    * **trust_env** - *(optional)* Enables or disables usage of environment variables for
+    configuration.
+    * **proxies** - *(optional)* A dictionary mapping HTTP protocols to proxy URLs.
+
+    **Returns:** `Response`
+
+    Usage:
+
+    ```
+    >>> import httpx
+    >>> response = httpx.request('GET', 'https://httpbin.org/get')
+    >>> response
+    <Response [200]>
+    ```
+    """
     with Client(http_versions=["HTTP/1.1"]) as client:
         return client.request(
             method=method,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,3 +22,4 @@ nav:
 markdown_extensions:
   - admonition
   - codehilite
+  - mkautodoc


### PR DESCRIPTION
I've started working on [an autodoc extension](https://github.com/tomchristie/mkautodoc) for use with mkdocs.

This pull request demonstrates using it with the `httpx.request` function, just for visibility of where I think we need to go here.

Bits to do:

- Nested code blocks in the docstring are not rendering. (I tried installing the `pymdownx.superfences` extension, which didn't appear to resolve the issue, either. *Any help with resolving this would be much appreciated.**)
- Need to look at rendering classes, not just functions. More complicated. There's some limited support for this, but will need work.
- I'm using a `dd` element as a bit of a styling hack, as it gives me a nicely indented block for the docstring. Probably ought to be a div with an appropriate class, or some other appropriate block element, with styling applied ideally by mkdocs-material, rather than having to add custom styling for it.
- It'd be really nice to keep the typing information out of the main display, but have contextual information pop up against parameters. We can treat this as a nice-to-have-later.

![Screen Shot 2019-10-09 at 11 45 39](https://user-images.githubusercontent.com/647359/66475022-67d66100-ea8a-11e9-8402-ca9b9ee91685.png)


