### PR TITLE
Add start_tls to trio backend

### DIFF
--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,21 +1,39 @@
 import sys
 
 import pytest
+import trio
 
 from httpx import AsyncioBackend, HTTPVersionConfig, SSLConfig, TimeoutConfig
+from httpx.concurrency.trio import TrioBackend
 
 
-@pytest.mark.xfail(
-    sys.version_info < (3, 7),
-    reason="Requires Python 3.7+ for AbstractEventLoop.start_tls()",
+@pytest.mark.parametrize(
+    "backend, get_cipher",
+    [
+        pytest.param(
+            AsyncioBackend(),
+            lambda stream: stream.stream_writer.get_extra_info("cipher", default=None),
+            marks=pytest.mark.asyncio,
+        ),
+        pytest.param(
+            TrioBackend(),
+            lambda stream: (
+                stream.stream.cipher()
+                if isinstance(stream.stream, trio.SSLStream)
+                else None
+            ),
+            marks=pytest.mark.trio,
+        ),
+    ],
 )
-@pytest.mark.asyncio
-async def test_start_tls_on_socket_stream(https_server):
+async def test_start_tls_on_socket_stream(https_server, backend, get_cipher):
     """
-    See that the backend can make a connection without TLS then
+    See that the concurrency backend can make a connection without TLS then
     start TLS on an existing connection.
     """
-    backend = AsyncioBackend()
+    if isinstance(backend, AsyncioBackend) and sys.version_info < (3, 7):
+        pytest.xfail(reason="Requires Python 3.7+ for AbstractEventLoop.start_tls()")
+
     ctx = SSLConfig().load_ssl_context_no_verify(HTTPVersionConfig())
     timeout = TimeoutConfig(5)
 
@@ -25,11 +43,11 @@ async def test_start_tls_on_socket_stream(https_server):
 
     try:
         assert stream.is_connection_dropped() is False
-        assert stream.stream_writer.get_extra_info("cipher", default=None) is None
+        assert get_cipher(stream) is None
 
         stream = await backend.start_tls(stream, https_server.url.host, ctx, timeout)
         assert stream.is_connection_dropped() is False
-        assert stream.stream_writer.get_extra_info("cipher", default=None) is not None
+        assert get_cipher(stream) is not None
 
         await stream.write(b"GET / HTTP/1.1\r\n\r\n")
         assert (await stream.read(8192, timeout)).startswith(b"HTTP/1.1 200 OK\r\n")


### PR DESCRIPTION
This PR implements the `start_tls()` method on the `TrioBackend`. This method is used when using HTTP proxies in TUNNEL mode — relevant docs [here](https://www.encode.io/httpx/advanced/#http-proxying).

My live test script is the following:

```python
import asyncio
import trio

import httpx
from httpx.concurrency.asyncio import AsyncioBackend
from httpx.concurrency.trio import TrioBackend


async def main(backend, proxy_url):
    proxy = httpx.HTTPProxy(
        proxy_url=proxy_url, proxy_mode=httpx.HTTPProxyMode.TUNNEL_ONLY, backend=backend
    )
    async with httpx.AsyncClient(backend=backend, proxies=proxy) as client:
        r = await client.get("https://example.com")
        print(r)


PROXY_URL = "..."  # TODO
asyncio.run(main(AsyncioBackend(), PROXY_URL))
trio.run(main, TrioBackend(), PROXY_URL)
```

I haven't found a free proxy supporting HTTPS to try this out though. @sethmlarson Do you know of any? Or is there any way I can spin up such a proxy on localhost?