### PR TITLE
Remove redundant proxy settings

### DIFF
--- a/httpx/utils.py
+++ b/httpx/utils.py
@@ -219,10 +219,11 @@ def get_environment_proxies() -> typing.Dict[str, str]:
     # Registry and Config for proxies on Windows and macOS.
     # We don't want to propagate non-HTTP proxies into
     # our configuration such as 'TRAVIS_APT_PROXY'.
+    SUPPORTED_PROXY_PROTOCOLS = ("http", "https", "all")
     return {
         key: val
         for key, val in getproxies().items()
-        if ("://" in key or key in ("http", "https"))
+        if ("://" in key or key in SUPPORTED_PROXY_PROTOCOLS)
     }
 
 

--- a/httpx/utils.py
+++ b/httpx/utils.py
@@ -219,11 +219,11 @@ def get_environment_proxies() -> typing.Dict[str, str]:
     # Registry and Config for proxies on Windows and macOS.
     # We don't want to propagate non-HTTP proxies into
     # our configuration such as 'TRAVIS_APT_PROXY'.
-    SUPPORTED_PROXY_PROTOCOLS = ("http", "https", "all")
+    supported_proxy_schemes = ("http", "https", "all")
     return {
         key: val
         for key, val in getproxies().items()
-        if ("://" in key or key in SUPPORTED_PROXY_PROTOCOLS)
+        if ("://" in key or key in supported_proxy_schemes)
     }
 
 

--- a/httpx/utils.py
+++ b/httpx/utils.py
@@ -219,29 +219,11 @@ def get_environment_proxies() -> typing.Dict[str, str]:
     # Registry and Config for proxies on Windows and macOS.
     # We don't want to propagate non-HTTP proxies into
     # our configuration such as 'TRAVIS_APT_PROXY'.
-    proxies = {
+    return {
         key: val
         for key, val in getproxies().items()
         if ("://" in key or key in ("http", "https"))
     }
-
-    # Favor lowercase environment variables over uppercase.
-    all_proxy = get_environ_lower_and_upper("ALL_PROXY")
-    if all_proxy is not None:
-        proxies["all"] = all_proxy
-
-    return proxies
-
-
-def get_environ_lower_and_upper(key: str) -> typing.Optional[str]:
-    """Gets a value from os.environ with both the lowercase and uppercase
-    environment variable. Prioritizes the lowercase environment variable.
-    """
-    for key in (key.lower(), key.upper()):
-        value = os.environ.get(key, None)
-        if value is not None and isinstance(value, str):
-            return value
-    return None
 
 
 def to_bytes(value: typing.Union[str, bytes], encoding: str = "utf-8") -> bytes:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -178,14 +178,7 @@ async def test_elapsed_timer():
             {"https_proxy": "http://127.0.0.1", "HTTP_PROXY": "https://127.0.0.1"},
             {"https": "http://127.0.0.1", "http": "https://127.0.0.1"},
         ),
-        (
-            {"all_proxy": "http://127.0.0.1", "ALL_PROXY": "https://1.1.1.1"},
-            {"all": "http://127.0.0.1"},
-        ),
-        (
-            {"https_proxy": "http://127.0.0.1", "HTTPS_PROXY": "https://1.1.1.1"},
-            {"https": "http://127.0.0.1"},
-        ),
+        ({"all_proxy": "http://127.0.0.1"}, {"all": "http://127.0.0.1"}),
         ({"TRAVIS_APT_PROXY": "http://127.0.0.1"}, {}),
     ],
 )


### PR DESCRIPTION
1. Our `get_environment_proxies()` relies on the standard library function [urllib.request.getproxies_environment()](https://github.com/python/cpython/blob/f5ed41c1ae9a575e965d55c6a5e86fb59181eee8/Lib/urllib/request.py#L2456) to do the parsing work, which already prefers lower case envvars. So we only need to filter out protocols which we don't support.
2. As such, we only need to test if the filtering works as intended. (Resolves #456)
---
Additional thoughts:
1. I can't figure out the intention of `"://" in key`  in httpx/utils.py, L226. It looks unnecessary
2. [urllib.request.proxy_bypass](https://github.com/python/cpython/blob/f5ed41c1ae9a575e965d55c6a5e86fb59181eee8/Lib/urllib/request.py#L2737) looks like a robust implementation of 'NO_PROXY'。 #360
3. On Windows and macOS, `get_environment_proxies()` falls back on Registry and SystemConfiguration if no envvar ended with `_proxy` is specified. Should we document this behavior?