### PR TITLE
should-b-proxied: logic whether url to be proxied

### DIFF
--- a/httpx/utils.py
+++ b/httpx/utils.py
@@ -213,20 +213,17 @@ def kv_format(**kwargs: typing.Any) -> str:
     return " ".join(f"{key}={value!r}" for key, value in kwargs.items())
 
 
-def get_environment_no_proxy() -> typing.List[str]:
-    """ Gets value of NO_PROXY environment value as a list"""
-    no_proxy = get_environ_lower_and_upper("NO_PROXY")
-    return [proxy.strip() for proxy in no_proxy.split(",")] if no_proxy else []
-
-
-def should_be_proxied(url: "URL") -> bool:
+def should_not_be_proxied(url: "URL") -> bool:
     """ Return True if url should be proxied,
     return False otherwise.
     """
-    no_proxy_list = get_environment_no_proxy()
-    if no_proxy_list and no_proxy_list[0] == "*":
+    no_proxy = getproxies().get("no")
+    if not no_proxy:
         return False
+    no_proxy_list = [host.strip() for host in no_proxy.split(",")]
     for name in no_proxy_list:
+        if name == "*":
+            return True
         if name:
             name = name.lstrip(".")  # ignore leading dots
             name = re.escape(name)
@@ -234,8 +231,8 @@ def should_be_proxied(url: "URL") -> bool:
             if re.match(pattern, url.host, re.I) or re.match(
                 pattern, url.authority, re.I
             ):
-                return False
-    return True
+                return True
+    return False
 
 
 def get_environment_proxies() -> typing.Dict[str, str]:

--- a/httpx/utils.py
+++ b/httpx/utils.py
@@ -14,6 +14,7 @@ from urllib.request import getproxies
 
 if typing.TYPE_CHECKING:  # pragma: no cover
     from .models import PrimitiveData
+    from .models import URL
 
 
 def normalize_header_key(value: typing.AnyStr, encoding: str = None) -> bytes:
@@ -210,6 +211,24 @@ def kv_format(**kwargs: typing.Any) -> str:
     "x=1 name='Bob'"
     """
     return " ".join(f"{key}={value!r}" for key, value in kwargs.items())
+
+
+def get_environment_no_proxy() -> typing.List[str]:
+    """ Gets value of NO_PROXY environment value as a list"""
+    no_proxy = get_environ_lower_and_upper("NO_PROXY")
+    return no_proxy.split(",") if no_proxy else []
+
+
+def should_be_proxied(url: "URL") -> bool:
+    """ Return True if url should be proxied,
+    return False otherwise.
+    """
+    no_proxy_list = get_environment_no_proxy()
+    for exempt_url in no_proxy_list:
+        if exempt_url and url.host.endswith(exempt_url):
+            # This URL should be exempted from going through proxy
+            return False
+    return True
 
 
 def get_environment_proxies() -> typing.Dict[str, str]:

--- a/httpx/utils.py
+++ b/httpx/utils.py
@@ -214,7 +214,7 @@ def kv_format(**kwargs: typing.Any) -> str:
 
 
 def should_not_be_proxied(url: "URL") -> bool:
-    """ Return True if url should be proxied,
+    """ Return True if url should not be proxied,
     return False otherwise.
     """
     no_proxy = getproxies().get("no")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -176,7 +176,6 @@ async def test_elapsed_timer():
     [
         ({}, []),
         ({"NO_PROXY": ""}, []),
-        ({"NO_PROXY": "http://127.0.0.1"}, ["http://127.0.0.1"]),
         ({"NO_PROXY": "127.0.0.1"}, ["127.0.0.1"]),
         ({"NO_PROXY": "127.0.0.1,1.1.1.1"}, ["127.0.0.1", "1.1.1.1"]),
     ],
@@ -237,6 +236,10 @@ def test_obfuscate_sensitive_headers(headers, output):
         ("https://mit.edu.info", {"NO_PROXY": "mit.edu"}, True),
         ("https://mit.edu.info", {"NO_PROXY": "mit.edu,edu.info"}, False),
         ("https://mit.edu.info", {"NO_PROXY": "mit.edu,mit.info"}, True),
+        ("https://foo.example.com", {"NO_PROXY": "www.example.com"}, True),
+        ("https://www.example1.com", {"NO_PROXY": ".example1.com"}, False),
+        ("https://www.example2.com", {"NO_PROXY": "ample2.com"}, True),
+        ("https://www.example3.com", {"NO_PROXY": "*"}, False),
     ],
 )
 def test_should_be_proxied(url, no_proxy, expected):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -207,19 +207,71 @@ def test_obfuscate_sensitive_headers(headers, output):
 @pytest.mark.parametrize(
     ["url", "no_proxy", "expected"],
     [
-        ("http://127.0.0.1", {"NO_PROXY": ""}, False),
-        ("http://127.0.0.1", {"NO_PROXY": "127.0.0.1"}, True),
-        ("http://127.0.0.1", {"NO_PROXY": "https://127.0.0.1"}, False),
-        ("http://127.0.0.1", {"NO_PROXY": "1.1.1.1"}, False),
-        ("http://courses.mit.edu", {"NO_PROXY": "mit.edu"}, True),
-        ("https://mit.edu.info", {"NO_PROXY": "mit.edu"}, False),
-        ("https://mit.edu.info", {"NO_PROXY": "mit.edu,edu.info"}, True),
-        ("https://mit.edu.info", {"NO_PROXY": "mit.edu, edu.info"}, True),
-        ("https://mit.edu.info", {"NO_PROXY": "mit.edu,mit.info"}, False),
-        ("https://foo.example.com", {"NO_PROXY": "www.example.com"}, False),
-        ("https://www.example1.com", {"NO_PROXY": ".example1.com"}, True),
-        ("https://www.example2.com", {"NO_PROXY": "ample2.com"}, False),
-        ("https://www.example3.com", {"NO_PROXY": "*"}, True),
+        (
+            "http://127.0.0.1",
+            {"NO_PROXY": ""},
+            False,
+        ),  # everything proxied when no_proxy is empty/unset
+        (
+            "http://127.0.0.1",
+            {"NO_PROXY": "127.0.0.1"},
+            True,
+        ),  # no_proxy as ip case is matched
+        (
+            "http://127.0.0.1",
+            {"NO_PROXY": "https://127.0.0.1"},
+            False,
+        ),  # no_proxy with scheme is ignored
+        (
+            "http://127.0.0.1",
+            {"NO_PROXY": "1.1.1.1"},
+            False,
+        ),  # different no_proxy means its proxied
+        (
+            "http://courses.mit.edu",
+            {"NO_PROXY": "mit.edu"},
+            True,
+        ),  # no_proxy for sub-domain matches
+        (
+            "https://mit.edu.info",
+            {"NO_PROXY": "mit.edu"},
+            False,
+        ),  # domain is actually edu.info, so should be proxied
+        (
+            "https://mit.edu.info",
+            {"NO_PROXY": "mit.edu,edu.info"},
+            True,
+        ),  # list in no_proxy, matches second domain
+        (
+            "https://mit.edu.info",
+            {"NO_PROXY": "mit.edu, edu.info"},
+            True,
+        ),  # list with spaces in no_proxy
+        (
+            "https://mit.edu.info",
+            {"NO_PROXY": "mit.edu,mit.info"},
+            False,
+        ),  # list in no_proxy, without any domain matching
+        (
+            "https://foo.example.com",
+            {"NO_PROXY": "www.example.com"},
+            False,
+        ),  # different subdomains foo vs www means we still proxy
+        (
+            "https://www.example1.com",
+            {"NO_PROXY": ".example1.com"},
+            True,
+        ),  # no_proxy starting with dot
+        (
+            "https://www.example2.com",
+            {"NO_PROXY": "ample2.com"},
+            False,
+        ),  # whole-domain matching
+        (
+            "https://www.example3.com",
+            {"NO_PROXY": "*"},
+            True,
+        ),  # wildcard * means nothing proxied
     ],
 )
 def test_should_not_be_proxied(url, no_proxy, expected):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -220,7 +220,7 @@ def test_obfuscate_sensitive_headers(headers, output):
         ("https://www.example3.com", {"NO_PROXY": "*"}, True),
     ],
 )
-def test_should_be_proxied(url, no_proxy, expected):
+def test_should_not_be_proxied(url, no_proxy, expected):
     os.environ.update(no_proxy)
     parsed_url = httpx.models.URL(url)
     assert should_not_be_proxied(parsed_url) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -209,10 +209,12 @@ def test_obfuscate_sensitive_headers(headers, output):
     [
         ("http://127.0.0.1", {"NO_PROXY": ""}, False),
         ("http://127.0.0.1", {"NO_PROXY": "127.0.0.1"}, True),
+        ("http://127.0.0.1", {"NO_PROXY": "https://127.0.0.1"}, False),
         ("http://127.0.0.1", {"NO_PROXY": "1.1.1.1"}, False),
         ("http://courses.mit.edu", {"NO_PROXY": "mit.edu"}, True),
         ("https://mit.edu.info", {"NO_PROXY": "mit.edu"}, False),
         ("https://mit.edu.info", {"NO_PROXY": "mit.edu,edu.info"}, True),
+        ("https://mit.edu.info", {"NO_PROXY": "mit.edu, edu.info"}, True),
         ("https://mit.edu.info", {"NO_PROXY": "mit.edu,mit.info"}, False),
         ("https://foo.example.com", {"NO_PROXY": "www.example.com"}, False),
         ("https://www.example1.com", {"NO_PROXY": ".example1.com"}, True),


### PR DESCRIPTION
This PR implements logic requested in https://github.com/encode/httpx/pull/462#issuecomment-539971761

This method could be moved if utils is not a good place, maybe in HTTPProxy.
If you wanted something else, please let me know.