### PR TITLE
Add timeout fine-tunning advanced docs section

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -165,43 +165,58 @@ client.get("http://example.com")
 
 
 ## Timeout fine-tuning
-HTTPX library offers many request timeout management options. HTTPX distinguish three types of timeouts: **connect** timeouts, 
+HTTPX offers various request timeout management options. Three types of timeouts are available: **connect** timeouts, 
 **write** timeouts and **read** timeouts.
 
-* Connect timeout specify time period within which a connection between a client and a server must be established.
-* Write timeout specify the maximum duration before timing out writes of the response.
-* Read timeout specify the maximum duration for reading the entire request.
+* The **connect timeout** specifies the maximum amount of time to wait until a connection to the requested host is established.   
+If HTTPX is unable to connect within this time frame, a `ConnectTimeout` exception is raised.
+* The **write timeout** specifies the maximum duration to wait for a chunk of data to be sent (for example, a chunk of the request body).   
+If HTTPX is unable to send data within this time frame, a `WriteTimeout` exception is raised.
+* The **read timeout** specifies the maximum duration to wait for a chunk of data to be received (for example, a chunk of the response body).  
+If HTTPX is unable to receive data within this time frame, a `ReadTimeout` exception is raised.
 
-HTTPX allows you to manage timeout policy freely. You can set timeout parameter at client creation phase or pass it on every request.  
-In a nutshell, user can manage timeouts on three different levels of abstraction:
+### Setting timeouts
+You can set timeouts on two levels:
 
-**Request level:**
+- For a given request:
+
 ```python
+# Using top-level API
 httpx.get('http://example.com/api/v1/example', timeout=5)
+
+# Or, with a client:
+client = httpx.Client()
+client.get("http://example.com/api/v1/example", timeout=5)
 ```
 
-**Client level:**
+- On a client instance, which results in the given `timeout` being used as a default for requests made with this client:
+
 ```python
 client = httpx.Client(timeout=5)
 client.get('http://example.com/api/v1/example')
 ```
 
-**TimeoutConfig level:**  
-Unlike request and client level configuration, TimeoutConfig object gives the ability to configure
-every distinct timeout type separately.
+Besides, you can pass timeouts in two forms:
+
+- A number, which sets the read, write and connect timeouts to the same value, as in the examples above.  
+- A `TimeoutConfig` instance, which allows to define the read, write and connect timeouts independently:
+
 ```python
 timeout = httpx.TimeoutConfig(
     connect_timeout=5, 
-    read_timeout=5, 
-    write_timeout=5
+    read_timeout=10, 
+    write_timeout=15
 )
 
 resp = httpx.get('http://example.com/api/v1/example', timeout=timeout)
 ```
 
-By default all types of timeouts are set to 5 second, in order to **disable** them you have to pass ``None`` as timeout parameter.
-Unfortunately, at the moment timeout disabling works only with Client and TimeoutConfig configuration setup.
-
+### Default timeouts
+By default all types of timeouts are set to 5 second.
+ 
+### Disabling timeouts
+To disable timeouts, you can pass `None` as a timeout parameter.  
+Note that currently this is not supported by the top-level API.
 
 ```python
 url = "http://example.com/api/v1/delay/10"

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -162,3 +162,61 @@ client = httpx.Client(proxies=proxy)
 # This request will be tunneled instead of forwarded.
 client.get("http://example.com")
 ```
+
+
+## Timeout fine-tuning
+HTTPX library offers many request timeout management options. HTTPX distinguish three types of timeouts: **connect** timeouts, 
+**write** timeouts and **read** timeouts.
+
+* Connect timeout specify time period within which a connection between a client and a server must be established.
+* Write timeout specify the maximum duration before timing out writes of the response.
+* Read timeout specify the maximum duration for reading the entire request.
+
+HTTPX allows you to manage timeout policy freely. You can set timeout parameter at client creation phase or pass it on every request.  
+In a nutshell, user can manage timeouts on three different levels of abstraction:
+
+**Request level:**
+```python
+httpx.get('http://example.com/api/v1/example', timeout=5)
+```
+
+**Client level:**
+```python
+client = httpx.Client(timeout=5)
+client.get('http://example.com/api/v1/example')
+```
+
+**TimeoutConfig level:**  
+Unlike request and client level configuration, TimeoutConfig object gives the ability to configure
+every distinct timeout type separately.
+```python
+timeout = httpx.TimeoutConfig(
+    connect_timeout=5, 
+    read_timeout=5, 
+    write_timeout=5
+)
+
+resp = httpx.get('http://example.com/api/v1/example', timeout=timeout)
+```
+
+By default all types of timeouts are set to 5 second, in order to **disable** them you have to pass ``None`` as timeout parameter.
+Unfortunately, at the moment timeout disabling works only with Client and TimeoutConfig configuration setup.
+
+
+```python
+url = "http://example.com/api/v1/delay/10"
+
+httpx.get(url, timeout=None)  # Times out after 5s
+
+
+client = httpx.Client(timeout=None)
+client.get(url)  # Does not timeout, returns after 10s
+
+
+timeout = httpx.TimeoutConfig(
+    connect_timeout=5, 
+    read_timeout=None, 
+    write_timeout=5
+)
+httpx.get(url, timeout=timeout) # Does not timeout, returns after 10s
+```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -380,8 +380,7 @@ value to be more or less strict:
 >>> httpx.get('https://github.com/', timeout=0.001)
 ```
 
-For advanced timeout management check
-[Timeout fine-tuning](https://www.encode.io/httpx/advanced/#timeout-fine-tuning) section.
+For advanced timeout management, see [Timeout fine-tuning](https://www.encode.io/httpx/advanced/#timeout-fine-tuning).
 
 ## Authentication
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -380,6 +380,9 @@ value to be more or less strict:
 >>> httpx.get('https://github.com/', timeout=0.001)
 ```
 
+For advanced timeout management check
+[Timeout fine-tuning](https://www.encode.io/httpx/advanced/#timeout-fine-tuning) section.
+
 ## Authentication
 
 HTTPX supports Basic and Digest HTTP authentication.


### PR DESCRIPTION
Reference issue #434 

I've added a small intro to HTTPX timeouts, sections with examples (plain request, client, timeout config object) and a paragraph about disabling timeouts.

btw, I apologize for any grammar mistakes, English is my second language.