### PR TITLE
Change python 3.8-dev to python 3.8 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
       env: NOX_SESSION=test-3.6
     - python: 3.7
       env: NOX_SESSION=test-3.7
-    - python: 3.8-dev
+    - python: 3.8
       env: NOX_SESSION=test-3.8
       dist: bionic # Required to get OpenSSL 1.1.1+
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,6 @@ matrix:
     # FIX
     # Some tests not yet resolved for Windows. (In progress)
     - os: windows
-    # Allow builds to fail when using '-dev' Python versions.
-    # We should still investigate failures periodically for new APIs.
-    - python: 3.8
 
 install:
   - pip install --upgrade nox

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
     - os: windows
     # Allow builds to fail when using '-dev' Python versions.
     # We should still investigate failures periodically for new APIs.
-    - python: 3.8-dev
+    - python: 3.8
 
 install:
   - pip install --upgrade nox


### PR DESCRIPTION
Change python 3.8-dev to python 3.8 in Travis as python 3.8 is officially released 