### PR TITLE
Proposal: Make start_tls a method on streams & return a new stream

### DIFF
--- a/httpx/concurrency/base.py
+++ b/httpx/concurrency/base.py
@@ -47,6 +47,11 @@ class BaseTCPStream:
     def get_http_version(self) -> str:
         raise NotImplementedError()  # pragma: no cover
 
+    async def start_tls(
+        self, hostname: str, ssl_context: ssl.SSLContext, timeout: TimeoutConfig
+    ) -> "BaseTCPStream":
+        raise NotImplementedError()  # pragma: no cover
+
     async def read(
         self, n: int, timeout: TimeoutConfig = None, flag: typing.Any = None
     ) -> bytes:
@@ -115,15 +120,6 @@ class ConcurrencyBackend:
         hostname: str,
         port: int,
         ssl_context: typing.Optional[ssl.SSLContext],
-        timeout: TimeoutConfig,
-    ) -> BaseTCPStream:
-        raise NotImplementedError()  # pragma: no cover
-
-    async def start_tls(
-        self,
-        stream: BaseTCPStream,
-        hostname: str,
-        ssl_context: ssl.SSLContext,
         timeout: TimeoutConfig,
     ) -> BaseTCPStream:
         raise NotImplementedError()  # pragma: no cover

--- a/httpx/dispatch/proxy_http.py
+++ b/httpx/dispatch/proxy_http.py
@@ -192,11 +192,8 @@ class HTTPProxy(ConnectionPool):
                 f"proxy_url={self.proxy_url!r} "
                 f"origin={origin!r}"
             )
-            stream = await self.backend.start_tls(
-                stream=stream,
-                hostname=origin.host,
-                ssl_context=ssl_context,
-                timeout=timeout,
+            stream = await stream.start_tls(
+                hostname=origin.host, ssl_context=ssl_context, timeout=timeout
             )
             http_version = stream.get_http_version()
             logger.debug(

--- a/tests/dispatch/utils.py
+++ b/tests/dispatch/utils.py
@@ -184,16 +184,6 @@ class MockRawSocketBackend:
         )
         return self.stream
 
-    async def start_tls(
-        self,
-        stream: BaseTCPStream,
-        hostname: str,
-        ssl_context: ssl.SSLContext,
-        timeout: TimeoutConfig,
-    ) -> BaseTCPStream:
-        self.received_data.append(b"--- START_TLS(%s) ---" % hostname.encode())
-        return self.stream
-
     # Defer all other attributes and methods to the underlying backend.
     def __getattr__(self, name: str) -> typing.Any:
         return getattr(self.backend, name)
@@ -202,6 +192,12 @@ class MockRawSocketBackend:
 class MockRawSocketStream(BaseTCPStream):
     def __init__(self, backend: MockRawSocketBackend):
         self.backend = backend
+
+    async def start_tls(
+        self, hostname: str, ssl_context: ssl.SSLContext, timeout: TimeoutConfig
+    ) -> BaseTCPStream:
+        self.backend.received_data.append(b"--- START_TLS(%s) ---" % hostname.encode())
+        return MockRawSocketStream(self.backend)
 
     def get_http_version(self) -> str:
         return "HTTP/1.1"

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -45,7 +45,7 @@ async def test_start_tls_on_socket_stream(https_server, backend, get_cipher):
         assert stream.is_connection_dropped() is False
         assert get_cipher(stream) is None
 
-        stream = await backend.start_tls(stream, https_server.url.host, ctx, timeout)
+        stream = await stream.start_tls(https_server.url.host, ctx, timeout)
         assert stream.is_connection_dropped() is False
         assert get_cipher(stream) is not None
 


### PR DESCRIPTION
Fixes Python 3.8.0 TLS issue (see second commit & #477)

I like this approach better than mutating the insides of a `TCPStream` when switching to TLS. Instead, a new `TCPStream` instance is returned. This pattern better matches the way Trio abstracts streams which also seems to be the way asyncio is headed for Python 3._next_.

Fixing the Python 3.8 issue does not require this refactor, but this makes the fix a lot cleaner.