### PR TITLE
Disable timeouts using timeout=False

### DIFF
--- a/httpx/client.py
+++ b/httpx/client.py
@@ -64,7 +64,7 @@ class BaseClient:
         cert: CertTypes = None,
         http_versions: HTTPVersionTypes = None,
         proxies: ProxiesTypes = None,
-        timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
+        timeout: TimeoutTypes = None,
         pool_limits: PoolLimits = DEFAULT_POOL_LIMITS,
         max_redirects: int = DEFAULT_MAX_REDIRECTS,
         base_url: URLTypes = None,

--- a/httpx/dispatch/connection.py
+++ b/httpx/dispatch/connection.py
@@ -5,7 +5,6 @@ import typing
 from ..concurrency.asyncio import AsyncioBackend
 from ..concurrency.base import ConcurrencyBackend
 from ..config import (
-    DEFAULT_TIMEOUT_CONFIG,
     CertTypes,
     HTTPVersionConfig,
     HTTPVersionTypes,
@@ -34,7 +33,7 @@ class HTTPConnection(AsyncDispatcher):
         verify: VerifyTypes = True,
         cert: CertTypes = None,
         trust_env: bool = None,
-        timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
+        timeout: TimeoutTypes = None,
         http_versions: HTTPVersionTypes = None,
         backend: ConcurrencyBackend = None,
         release_func: typing.Optional[ReleaseCallback] = None,

--- a/httpx/dispatch/connection_pool.py
+++ b/httpx/dispatch/connection_pool.py
@@ -4,10 +4,10 @@ from ..concurrency.asyncio import AsyncioBackend
 from ..concurrency.base import ConcurrencyBackend
 from ..config import (
     DEFAULT_POOL_LIMITS,
-    DEFAULT_TIMEOUT_CONFIG,
     CertTypes,
     HTTPVersionTypes,
     PoolLimits,
+    TimeoutConfig,
     TimeoutTypes,
     VerifyTypes,
 )
@@ -85,14 +85,14 @@ class ConnectionPool(AsyncDispatcher):
         verify: VerifyTypes = True,
         cert: CertTypes = None,
         trust_env: bool = None,
-        timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
+        timeout: TimeoutTypes = None,
         pool_limits: PoolLimits = DEFAULT_POOL_LIMITS,
         http_versions: HTTPVersionTypes = None,
         backend: ConcurrencyBackend = None,
     ):
         self.verify = verify
         self.cert = cert
-        self.timeout = timeout
+        self.timeout = TimeoutConfig(timeout)
         self.pool_limits = pool_limits
         self.http_versions = http_versions
         self.is_closed = False

--- a/httpx/dispatch/proxy_http.py
+++ b/httpx/dispatch/proxy_http.py
@@ -5,7 +5,6 @@ import h11
 from ..concurrency.base import ConcurrencyBackend
 from ..config import (
     DEFAULT_POOL_LIMITS,
-    DEFAULT_TIMEOUT_CONFIG,
     CertTypes,
     HTTPVersionTypes,
     PoolLimits,
@@ -53,7 +52,7 @@ class HTTPProxy(ConnectionPool):
         verify: VerifyTypes = True,
         cert: CertTypes = None,
         trust_env: bool = None,
-        timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
+        timeout: TimeoutTypes = None,
         pool_limits: PoolLimits = DEFAULT_POOL_LIMITS,
         http_versions: HTTPVersionTypes = None,
         backend: ConcurrencyBackend = None,

--- a/httpx/utils.py
+++ b/httpx/utils.py
@@ -35,6 +35,19 @@ def normalize_header_value(value: typing.AnyStr, encoding: str = None) -> bytes:
     return value.encode(encoding or "ascii")
 
 
+def normalize_timeout_value(
+    value: typing.Optional[typing.Union[float, bool]], default: typing.Optional[float]
+) -> typing.Optional[float]:
+    """
+    Given a timeout value that may also be a bool, coerce it to a float or `None`.
+    """
+    if value is False:
+        return None
+    elif value is True or value is None:
+        return default
+    return value
+
+
 def str_query_param(value: "PrimitiveData") -> str:
     """
     Coerce a primitive data type into a string value for query params.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -158,17 +158,6 @@ def test_empty_http_version():
         httpx.HTTPVersionConfig([])
 
 
-def test_timeout_repr():
-    timeout = httpx.TimeoutConfig(timeout=5.0)
-    assert repr(timeout) == "TimeoutConfig(timeout=5.0)"
-
-    timeout = httpx.TimeoutConfig(read_timeout=5.0)
-    assert (
-        repr(timeout)
-        == "TimeoutConfig(connect_timeout=None, read_timeout=5.0, write_timeout=None)"
-    )
-
-
 def test_limits_repr():
     limits = httpx.PoolLimits(hard_limit=100)
     assert (
@@ -181,14 +170,50 @@ def test_ssl_eq():
     assert ssl == httpx.SSLConfig(verify=False)
 
 
+def test_limits_eq():
+    limits = httpx.PoolLimits(hard_limit=100)
+    assert limits == httpx.PoolLimits(hard_limit=100)
+
+
 def test_timeout_eq():
     timeout = httpx.TimeoutConfig(timeout=5.0)
     assert timeout == httpx.TimeoutConfig(timeout=5.0)
 
 
-def test_limits_eq():
-    limits = httpx.PoolLimits(hard_limit=100)
-    assert limits == httpx.PoolLimits(hard_limit=100)
+def test_timeout_from_defaults():
+    timeout = httpx.TimeoutConfig()
+    assert timeout == httpx.config.DEFAULT_TIMEOUT_CONFIG
+
+
+def test_timeout_from_none():
+    timeout = httpx.TimeoutConfig(timeout=None)
+    assert timeout == httpx.config.DEFAULT_TIMEOUT_CONFIG
+
+
+def test_timeout_from_one_none_value():
+    timeout = httpx.TimeoutConfig(read_timeout=None)
+    assert timeout == httpx.config.DEFAULT_TIMEOUT_CONFIG
+
+
+def test_timeout_from_true():
+    timeout = httpx.TimeoutConfig(timeout=True)
+    assert timeout == httpx.config.DEFAULT_TIMEOUT_CONFIG
+
+
+def test_timeout_from_false():
+    timeout = httpx.TimeoutConfig(timeout=False)
+    assert timeout.connect_timeout is None
+    assert timeout.read_timeout is None
+    assert timeout.write_timeout is None
+
+
+def test_timeout_from_one_false_timeout():
+    timeout = httpx.TimeoutConfig(read_timeout=False)
+    assert (
+        timeout.connect_timeout == httpx.config.DEFAULT_TIMEOUT_CONFIG.connect_timeout
+    )
+    assert timeout.read_timeout is None
+    assert timeout.write_timeout == httpx.config.DEFAULT_TIMEOUT_CONFIG.write_timeout
 
 
 def test_timeout_from_tuple():
@@ -199,6 +224,17 @@ def test_timeout_from_tuple():
 def test_timeout_from_config_instance():
     timeout = httpx.TimeoutConfig(timeout=5.0)
     assert httpx.TimeoutConfig(timeout) == httpx.TimeoutConfig(timeout=5.0)
+
+
+def test_timeout_repr():
+    timeout = httpx.TimeoutConfig(timeout=5.0)
+    assert repr(timeout) == "TimeoutConfig(timeout=5.0)"
+
+    timeout = httpx.TimeoutConfig(read_timeout=1.0)
+    assert (
+        repr(timeout)
+        == "TimeoutConfig(connect_timeout=5.0, read_timeout=1.0, write_timeout=5.0)"
+    )
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Fixes #433, alternative for #463 (cc @jcugat).

Essentially, this PR proposes the following behaviors:

- `timeout=None` (or not passing a `timeout`) uses the default timeout, *always*. (This is a breaking change compared to the current situation in which e.g. `Client(timeout=None)` disables timeouts.)
- `timeout=False` disables timeouts, *always*.

This leads us to have a consistent behavior for timeout values across entrypoints and clients. This also allows us to keep the footprint of the change minimal (as opposed to #463).

I updated the docs to be very explicit and illustrative on all these cases.

I do believe that `timeout=None` is not the most intuitive API to expose to our users, but my logic here is that using `timeout=False` (as in "Don't timeout!") is merely a matter of getting used to it.