### PR TITLE
Always treat timeout=None as default timeout

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -294,30 +294,37 @@ resp = httpx.get('http://example.com/api/v1/example', timeout=timeout)
 
 ### Default timeouts
 
-By default all types of timeouts are set to 5 second.
+By default all types of timeouts are set to 5 seconds.
+
+Default timeouts are applied whenever you don't specify a timeout, or you pass `None` as a timeout value.
+
+For example, all the following calls will timeout because default timeouts are applied:
+
+```python
+url = "https://httpbin.org/delay/10"
+
+# No timeout given.
+httpx.get(url)
+
+# Using 'None' does not disable timeouts -- see note below.
+httpx.get(url, timeout=None)
+
+# 'TimeoutConfig()' returns the default timeout configuration.
+httpx.get(url, timeout=httpx.TimeoutConfig())
+
+# Again, passing 'None' as a timeout value does disable timeouts.
+httpx.get(url, timeout=httpx.TimeoutConfig(read_timeout=None))
+
+# 'read_timeout' is not given, so the default value is used.
+httpx.get(url, timeout=httpx.TimeoutConfig(connect_timeout=3))
+```
+
+!!! question
+    The fact that using `timeout=None` results in HTTPX still applying default timeouts may be surprising to you. Indeed, this differs from what most HTTP libraries do. HTTPX does this so that disabling timeouts (as documented in the next section) is always a very explicit decision.
 
 ### Disabling timeouts
 
-To disable timeouts, you can pass `None` as a timeout parameter.
-Note that currently this is not supported by the top-level API.
-
-```python
-url = "http://example.com/api/v1/delay/10"
-
-httpx.get(url, timeout=None)  # Times out after 5s
-
-
-with httpx.Client(timeout=None) as client:
-    client.get(url)  # Does not timeout, returns after 10s
-
-
-timeout = httpx.TimeoutConfig(
-    connect_timeout=5,
-    read_timeout=None,
-    write_timeout=5
-)
-httpx.get(url, timeout=timeout) # Does not timeout, returns after 10s
-```
+Support for disabling timeouts is planned, but not currently supported.
 
 ## Multipart file encoding
 

--- a/httpx/client.py
+++ b/httpx/client.py
@@ -11,7 +11,6 @@ from .concurrency.base import ConcurrencyBackend
 from .config import (
     DEFAULT_MAX_REDIRECTS,
     DEFAULT_POOL_LIMITS,
-    DEFAULT_TIMEOUT_CONFIG,
     CertTypes,
     HTTPVersionTypes,
     PoolLimits,
@@ -64,7 +63,7 @@ class BaseClient:
         cert: CertTypes = None,
         http_versions: HTTPVersionTypes = None,
         proxies: ProxiesTypes = None,
-        timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
+        timeout: TimeoutTypes = None,
         pool_limits: PoolLimits = DEFAULT_POOL_LIMITS,
         max_redirects: int = DEFAULT_MAX_REDIRECTS,
         base_url: URLTypes = None,

--- a/httpx/dispatch/connection.py
+++ b/httpx/dispatch/connection.py
@@ -5,7 +5,6 @@ import typing
 from ..concurrency.asyncio import AsyncioBackend
 from ..concurrency.base import ConcurrencyBackend
 from ..config import (
-    DEFAULT_TIMEOUT_CONFIG,
     CertTypes,
     HTTPVersionConfig,
     HTTPVersionTypes,
@@ -34,7 +33,7 @@ class HTTPConnection(AsyncDispatcher):
         verify: VerifyTypes = True,
         cert: CertTypes = None,
         trust_env: bool = None,
-        timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
+        timeout: TimeoutTypes = None,
         http_versions: HTTPVersionTypes = None,
         backend: ConcurrencyBackend = None,
         release_func: typing.Optional[ReleaseCallback] = None,

--- a/httpx/dispatch/connection_pool.py
+++ b/httpx/dispatch/connection_pool.py
@@ -4,10 +4,10 @@ from ..concurrency.asyncio import AsyncioBackend
 from ..concurrency.base import ConcurrencyBackend
 from ..config import (
     DEFAULT_POOL_LIMITS,
-    DEFAULT_TIMEOUT_CONFIG,
     CertTypes,
     HTTPVersionTypes,
     PoolLimits,
+    TimeoutConfig,
     TimeoutTypes,
     VerifyTypes,
 )
@@ -85,14 +85,14 @@ class ConnectionPool(AsyncDispatcher):
         verify: VerifyTypes = True,
         cert: CertTypes = None,
         trust_env: bool = None,
-        timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
+        timeout: TimeoutTypes = None,
         pool_limits: PoolLimits = DEFAULT_POOL_LIMITS,
         http_versions: HTTPVersionTypes = None,
         backend: ConcurrencyBackend = None,
     ):
         self.verify = verify
         self.cert = cert
-        self.timeout = timeout
+        self.timeout = TimeoutConfig(timeout)
         self.pool_limits = pool_limits
         self.http_versions = http_versions
         self.is_closed = False

--- a/httpx/dispatch/proxy_http.py
+++ b/httpx/dispatch/proxy_http.py
@@ -5,7 +5,6 @@ import h11
 from ..concurrency.base import ConcurrencyBackend
 from ..config import (
     DEFAULT_POOL_LIMITS,
-    DEFAULT_TIMEOUT_CONFIG,
     CertTypes,
     HTTPVersionTypes,
     PoolLimits,
@@ -53,7 +52,7 @@ class HTTPProxy(ConnectionPool):
         verify: VerifyTypes = True,
         cert: CertTypes = None,
         trust_env: bool = None,
-        timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
+        timeout: TimeoutTypes = None,
         pool_limits: PoolLimits = DEFAULT_POOL_LIMITS,
         http_versions: HTTPVersionTypes = None,
         backend: ConcurrencyBackend = None,

--- a/httpx/utils.py
+++ b/httpx/utils.py
@@ -35,6 +35,18 @@ def normalize_header_value(value: typing.AnyStr, encoding: str = None) -> bytes:
     return value.encode(encoding or "ascii")
 
 
+def normalize_timeout_value(
+    value: typing.Optional[float], default: typing.Optional[float]
+) -> typing.Optional[float]:
+    """
+    Given a timeout value, normalize it so that `None` results in using
+    the default value.
+    """
+    if value is None:
+        return default
+    return value
+
+
 def str_query_param(value: "PrimitiveData") -> str:
     """
     Coerce a primitive data type into a string value for query params.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -182,9 +182,7 @@ def test_timeout_eq():
 
 def test_timeout_from_nothing():
     timeout = httpx.TimeoutConfig()
-    assert timeout.connect_timeout is None
-    assert timeout.read_timeout is None
-    assert timeout.write_timeout is None
+    assert timeout == httpx.config.DEFAULT_TIMEOUT_CONFIG
 
 
 def test_timeout_from_none():
@@ -211,10 +209,10 @@ def test_timeout_repr():
     timeout = httpx.TimeoutConfig(timeout=5.0)
     assert repr(timeout) == "TimeoutConfig(timeout=5.0)"
 
-    timeout = httpx.TimeoutConfig(read_timeout=5.0)
+    timeout = httpx.TimeoutConfig(read_timeout=3.0)
     assert (
         repr(timeout)
-        == "TimeoutConfig(connect_timeout=None, read_timeout=5.0, write_timeout=None)"
+        == "TimeoutConfig(connect_timeout=5.0, read_timeout=3.0, write_timeout=5.0)"
     )
 
 


### PR DESCRIPTION
Spun up from #490. Refs #433.

**Note**: this is based on #491, so #491 *must* be merged first. Will change base branch once it gets merged.

As a result of this PR:

- `timeout=None` **always** means "use the defaults". This applies to our users, but also components in our code (clients and dispatchers in particular).
- The logic for "how to apply default timeouts" is contained in `config.py` only. (And `DEFAULT_TIMEOUT_CONFIG` is only used there, and in some of the tests.)
- Support for disabling timeouts is (temporarily) removed, but it will be added again by #490.