### PR TITLE
Disable timeouts using timeout=False

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -324,7 +324,28 @@ httpx.get(url, timeout=httpx.TimeoutConfig(connect_timeout=3))
 
 ### Disabling timeouts
 
-Support for disabling timeouts is planned, but not currently supported.
+To disable timeouts, you must pass `False` as a timeout parameter.
+
+For example, none of these calls will time out:
+
+```python
+url = "https://httpbin.org/delay/10"
+
+# Timeouts are disabled for this request.
+httpx.get(url, timeout=False)
+
+# Timeouts are disabled for all requests made with this client.
+with httpx.Client(timeout=False) as client:
+    client.get(url)
+
+with httpx.Client() as client:
+    # Timeouts are disabled for this request only.
+    client.get(url, timeout=False)
+
+# Only read timeout is disabled for this request.
+timeout = httpx.TimeoutConfig(read_timeout=False)
+httpx.get(url, timeout=timeout)
+```
 
 ## Multipart file encoding
 

--- a/httpx/config.py
+++ b/httpx/config.py
@@ -11,7 +11,7 @@ from .utils import get_ca_bundle_from_env, get_logger, normalize_timeout_value
 CertTypes = typing.Union[str, typing.Tuple[str, str], typing.Tuple[str, str, str]]
 VerifyTypes = typing.Union[str, bool, ssl.SSLContext]
 TimeoutTypes = typing.Union[
-    None, float, typing.Tuple[float, float, float], "TimeoutConfig"
+    None, bool, float, typing.Tuple[float, float, float], "TimeoutConfig"
 ]
 HTTPVersionTypes = typing.Union[
     str, typing.List[str], typing.Tuple[str], "HTTPVersionConfig"
@@ -232,9 +232,9 @@ class TimeoutConfig:
         self,
         timeout: TimeoutTypes = None,
         *,
-        connect_timeout: float = None,
-        read_timeout: float = None,
-        write_timeout: float = None,
+        connect_timeout: typing.Union[float, bool] = None,
+        read_timeout: typing.Union[float, bool] = None,
+        write_timeout: typing.Union[float, bool] = None,
     ):
         if timeout is None:
             self.connect_timeout = normalize_timeout_value(
@@ -251,6 +251,13 @@ class TimeoutConfig:
             assert connect_timeout is None
             assert read_timeout is None
             assert write_timeout is None
+
+            if isinstance(timeout, bool):
+                assert timeout is False
+                timeout = TimeoutConfig(
+                    connect_timeout=False, read_timeout=False, write_timeout=False
+                )
+
             if isinstance(timeout, TimeoutConfig):
                 self.connect_timeout = timeout.connect_timeout
                 self.read_timeout = timeout.read_timeout

--- a/httpx/utils.py
+++ b/httpx/utils.py
@@ -36,14 +36,17 @@ def normalize_header_value(value: typing.AnyStr, encoding: str = None) -> bytes:
 
 
 def normalize_timeout_value(
-    value: typing.Optional[float], default: typing.Optional[float]
+    value: typing.Optional[typing.Union[float, bool]], default: typing.Optional[float]
 ) -> typing.Optional[float]:
     """
     Given a timeout value, normalize it so that `None` results in using
-    the default value.
+    the default value, and `False` results in no timeout.
     """
     if value is None:
         return default
+    if isinstance(value, bool):
+        assert value is False
+        return None
     return value
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -195,6 +195,22 @@ def test_timeout_from_one_none_value():
     assert timeout == httpx.TimeoutConfig()
 
 
+def test_timeout_from_false():
+    timeout = httpx.TimeoutConfig(timeout=False)
+    assert timeout.connect_timeout is None
+    assert timeout.read_timeout is None
+    assert timeout.write_timeout is None
+
+
+def test_timeout_from_one_false_timeout():
+    timeout = httpx.TimeoutConfig(read_timeout=False)
+    assert (
+        timeout.connect_timeout == httpx.config.DEFAULT_TIMEOUT_CONFIG.connect_timeout
+    )
+    assert timeout.read_timeout is None
+    assert timeout.write_timeout == httpx.config.DEFAULT_TIMEOUT_CONFIG.write_timeout
+
+
 def test_timeout_from_tuple():
     timeout = httpx.TimeoutConfig(timeout=(5.0, 5.0, 5.0))
     assert timeout == httpx.TimeoutConfig(timeout=5.0)


### PR DESCRIPTION
Fixes #433. Spun up from #490. Based on #492.

**Note**: #492 must get merged first. I'll change the base branch once it gets merged.

This PR adds support for consistently treating `timeout=False` as "disable timeouts".