### PR TITLE
asyncio: Wait for the stream to close when closing

### DIFF
--- a/httpx/concurrency/asyncio.py
+++ b/httpx/concurrency/asyncio.py
@@ -1,6 +1,7 @@
 import asyncio
 import functools
 import ssl
+import sys
 import typing
 from types import TracebackType
 
@@ -170,6 +171,8 @@ class TCPStream(BaseTCPStream):
 
     async def close(self) -> None:
         self.stream_writer.close()
+        if sys.version_info >= (3, 7):
+            await self.stream_writer.wait_closed()
 
 
 class PoolSemaphore(BasePoolSemaphore):


### PR DESCRIPTION
We discussed calling `wait_closed()` on the `StreamWriter` in #369, but never implemented it due to a transient issue with SSL connections ([comment](https://github.com/encode/httpx/pull/369#discussion_r327187795)).

I now better understand the issue and have written a [lengthy explanation](https://github.com/aio-libs/aiohttp/issues/3535#issuecomment-544279431) on the related aiohttp issue (since that seems to have the most visibility).

The error makes sense if you think about it, and it's clear why it was showing up in our test--because we weren't making sure we consumed the entire response before closing the connection.

I'm not sure if we need to handle this error--I think in most cases the entire response should be consumed before we close a stream. My thinking was we try this and see if it shows up as an issue for users. But I'm happy to change that if people would like.