### PR TITLE
Remove pin on uvloop in test-requirements

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -17,6 +17,3 @@ pytest-cov
 trio
 trustme
 uvicorn
-
-# https://github.com/MagicStack/uvloop/issues/266
-uvloop<0.13; sys_platform != 'win32' and sys_platform != 'cygwin' and platform_python_implementation != 'pypy'


### PR DESCRIPTION
uvloop has shipped a 0.14 release candidate which uvicorn now uses, so the temporary fix from #323 should not be necessary anymore.