### PR TITLE
Convert debug logs to trace logs

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -11,16 +11,14 @@ There are two ways to set `trust_env` to disable environment variables:
 Here is a list of environment variables that HTTPX recognizes
 and what function they serve:
 
-`HTTPX_DEBUG`
------------
+`HTTPX_LOG_LEVEL`
+-----------------
 
-Valid values: `1`, `true`
+Valid values: `debug`, `trace` (case-insensitive)
 
-If this environment variable is set to a valid value then low-level
-details about the execution of HTTP requests will be logged to `stderr`.
+If set to `trace`, then low-level details about the execution of HTTP requests will be logged to `stderr`. This can help you debug issues and see what's exactly being sent over the wire and to which location.
 
-This can help you debug issues and see what's exactly being sent
-over the wire and to which location.
+The `debug` log level is currently ignored, but is planned to issue high-level logs of HTTP requests.
 
 Example:
 
@@ -33,7 +31,7 @@ with httpx.Client() as client:
 ```
 
 ```console
-user@host:~$ HTTPX_DEBUG=1 python test_script.py
+user@host:~$ HTTPX_LOG_LEVEL=trace python test_script.py
 20:54:17.585 - httpx.dispatch.connection_pool - acquire_connection origin=Origin(scheme='https' host='www.google.com' port=443)
 20:54:17.585 - httpx.dispatch.connection_pool - new_connection connection=HTTPConnection(origin=Origin(scheme='https' host='www.google.com' port=443))
 20:54:17.590 - httpx.dispatch.connection - start_connect host='www.google.com' port=443 timeout=TimeoutConfig(timeout=5.0)

--- a/httpx/config.py
+++ b/httpx/config.py
@@ -94,7 +94,7 @@ class SSLConfig:
     ) -> ssl.SSLContext:
         http_versions = HTTPVersionConfig() if http_versions is None else http_versions
 
-        logger.debug(
+        logger.trace(
             f"load_ssl_context "
             f"verify={self.verify!r} "
             f"cert={self.cert!r} "
@@ -163,10 +163,10 @@ class SSLConfig:
             pass
 
         if ca_bundle_path.is_file():
-            logger.debug(f"load_verify_locations cafile={ca_bundle_path!s}")
+            logger.trace(f"load_verify_locations cafile={ca_bundle_path!s}")
             context.load_verify_locations(cafile=str(ca_bundle_path))
         elif ca_bundle_path.is_dir():
-            logger.debug(f"load_verify_locations capath={ca_bundle_path!s}")
+            logger.trace(f"load_verify_locations capath={ca_bundle_path!s}")
             context.load_verify_locations(capath=str(ca_bundle_path))
 
         self._load_client_certs(context)

--- a/httpx/dispatch/connection.py
+++ b/httpx/dispatch/connection.py
@@ -84,10 +84,10 @@ class HTTPConnection(AsyncDispatcher):
         else:
             on_release = functools.partial(self.release_func, self)
 
-        logger.debug(f"start_connect host={host!r} port={port!r} timeout={timeout!r}")
+        logger.trace(f"start_connect host={host!r} port={port!r} timeout={timeout!r}")
         stream = await self.backend.open_tcp_stream(host, port, ssl_context, timeout)
         http_version = stream.get_http_version()
-        logger.debug(f"connected http_version={http_version!r}")
+        logger.trace(f"connected http_version={http_version!r}")
 
         if http_version == "HTTP/2":
             self.h2_connection = HTTP2Connection(
@@ -109,7 +109,7 @@ class HTTPConnection(AsyncDispatcher):
         )
 
     async def close(self) -> None:
-        logger.debug("close_connection")
+        logger.trace("close_connection")
         if self.h2_connection is not None:
             await self.h2_connection.close()
         elif self.h11_connection is not None:

--- a/httpx/dispatch/connection_pool.py
+++ b/httpx/dispatch/connection_pool.py
@@ -128,7 +128,7 @@ class ConnectionPool(AsyncDispatcher):
         return response
 
     async def acquire_connection(self, origin: Origin) -> HTTPConnection:
-        logger.debug(f"acquire_connection origin={origin!r}")
+        logger.trace(f"acquire_connection origin={origin!r}")
         connection = self.pop_connection(origin)
 
         if connection is None:
@@ -143,16 +143,16 @@ class ConnectionPool(AsyncDispatcher):
                 release_func=self.release_connection,
                 trust_env=self.trust_env,
             )
-            logger.debug(f"new_connection connection={connection!r}")
+            logger.trace(f"new_connection connection={connection!r}")
         else:
-            logger.debug(f"reuse_connection connection={connection!r}")
+            logger.trace(f"reuse_connection connection={connection!r}")
 
         self.active_connections.add(connection)
 
         return connection
 
     async def release_connection(self, connection: HTTPConnection) -> None:
-        logger.debug(f"release_connection connection={connection!r}")
+        logger.trace(f"release_connection connection={connection!r}")
         if connection.is_closed:
             self.active_connections.remove(connection)
             self.max_connections.release()

--- a/httpx/dispatch/http11.py
+++ b/httpx/dispatch/http11.py
@@ -65,7 +65,7 @@ class HTTP11Connection:
     async def close(self) -> None:
         event = h11.ConnectionClosed()
         try:
-            logger.debug(f"send_event event={event!r}")
+            logger.trace(f"send_event event={event!r}")
             self.h11_state.send(event)
         except h11.LocalProtocolError:  # pragma: no cover
             # Premature client disconnect
@@ -78,7 +78,7 @@ class HTTP11Connection:
         """
         Send the request method, URL, and headers to the network.
         """
-        logger.debug(
+        logger.trace(
             f"send_headers method={request.method!r} "
             f"target={request.url.full_path!r} "
             f"headers={request.headers!r}"
@@ -99,7 +99,7 @@ class HTTP11Connection:
         try:
             # Send the request body.
             async for chunk in data:
-                logger.debug(f"send_data data=Data(<{len(chunk)} bytes>)")
+                logger.trace(f"send_data data=Data(<{len(chunk)} bytes>)")
                 event = h11.Data(data=chunk)
                 await self._send_event(event, timeout)
 
@@ -164,9 +164,9 @@ class HTTP11Connection:
             event = self.h11_state.next_event()
 
             if isinstance(event, h11.Data):
-                logger.debug(f"receive_event event=Data(<{len(event.data)} bytes>)")
+                logger.trace(f"receive_event event=Data(<{len(event.data)} bytes>)")
             else:
-                logger.debug(f"receive_event event={event!r}")
+                logger.trace(f"receive_event event={event!r}")
 
             if event is h11.NEED_DATA:
                 try:
@@ -182,7 +182,7 @@ class HTTP11Connection:
         return event
 
     async def response_closed(self) -> None:
-        logger.debug(
+        logger.trace(
             f"response_closed "
             f"our_state={self.h11_state.our_state!r} "
             f"their_state={self.h11_state.their_state}"

--- a/httpx/dispatch/http2.py
+++ b/httpx/dispatch/http2.py
@@ -104,7 +104,7 @@ class HTTP2Connection:
             (b":path", request.url.full_path.encode("ascii")),
         ] + [(k, v) for k, v in request.headers.raw if k != b"host"]
 
-        logger.debug(
+        logger.trace(
             f"send_headers "
             f"stream_id={stream_id} "
             f"method={request.method!r} "
@@ -156,7 +156,7 @@ class HTTP2Connection:
                 await self.stream.write(data_to_send, timeout)
 
     async def end_stream(self, stream_id: int, timeout: TimeoutConfig = None) -> None:
-        logger.debug(f"end_stream stream_id={stream_id}")
+        logger.trace(f"end_stream stream_id={stream_id}")
         self.h2_state.end_stream(stream_id)
         data_to_send = self.h2_state.data_to_send()
         await self.stream.write(data_to_send, timeout)
@@ -207,7 +207,7 @@ class HTTP2Connection:
             events = self.h2_state.receive_data(data)
             for event in events:
                 event_stream_id = getattr(event, "stream_id", 0)
-                logger.debug(
+                logger.trace(
                     f"receive_event stream_id={event_stream_id} event={event!r}"
                 )
 

--- a/httpx/dispatch/proxy_http.py
+++ b/httpx/dispatch/proxy_http.py
@@ -86,12 +86,12 @@ class HTTPProxy(ConnectionPool):
 
     async def acquire_connection(self, origin: Origin) -> HTTPConnection:
         if self.should_forward_origin(origin):
-            logger.debug(
+            logger.trace(
                 f"forward_connection proxy_url={self.proxy_url!r} origin={origin!r}"
             )
             return await super().acquire_connection(self.proxy_url.origin)
         else:
-            logger.debug(
+            logger.trace(
                 f"tunnel_connection proxy_url={self.proxy_url!r} origin={origin!r}"
             )
             return await self.tunnel_connection(origin)
@@ -143,7 +143,7 @@ class HTTPProxy(ConnectionPool):
 
         # See if our tunnel has been opened successfully
         proxy_response = await connection.send(proxy_request)
-        logger.debug(
+        logger.trace(
             f"tunnel_response "
             f"proxy_url={self.proxy_url!r} "
             f"origin={origin!r} "
@@ -187,7 +187,7 @@ class HTTPProxy(ConnectionPool):
             ssl_context = await connection.get_ssl_context(ssl_config)
             assert ssl_context is not None
 
-            logger.debug(
+            logger.trace(
                 f"tunnel_start_tls "
                 f"proxy_url={self.proxy_url!r} "
                 f"origin={origin!r}"
@@ -196,7 +196,7 @@ class HTTPProxy(ConnectionPool):
                 hostname=origin.host, ssl_context=ssl_context, timeout=timeout
             )
             http_version = stream.get_http_version()
-            logger.debug(
+            logger.trace(
                 f"tunnel_tls_complete "
                 f"proxy_url={self.proxy_url!r} "
                 f"origin={origin!r} "

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -103,9 +103,9 @@ def test_parse_header_links(value, expected):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("httpx_debug", ["0", "1", "True", "False"])
-async def test_httpx_debug_enabled_stderr_logging(server, capsys, httpx_debug):
-    os.environ["HTTPX_DEBUG"] = httpx_debug
+@pytest.mark.parametrize("httpx_log_level", ["trace", "debug"])
+async def test_httpx_log_level_enabled_stderr_logging(server, capsys, httpx_log_level):
+    os.environ["HTTPX_LOG_LEVEL"] = httpx_log_level
 
     # Force a reload on the logging handlers
     utils._LOGGER_INITIALIZED = False
@@ -114,7 +114,7 @@ async def test_httpx_debug_enabled_stderr_logging(server, capsys, httpx_debug):
     async with httpx.AsyncClient() as client:
         await client.get(server.url)
 
-    if httpx_debug in ("1", "True"):
+    if httpx_log_level == "trace":
         assert "httpx.dispatch.connection_pool" in capsys.readouterr().err
     else:
         assert "httpx.dispatch.connection_pool" not in capsys.readouterr().err


### PR DESCRIPTION
Refs #495 

This PR converts existing `DEBUG` logs to the `TRACE` level, and renames `HTTPX_DEBUG` to `HTTPX_LOG_LEVEL`.

Example in a Uvicorn setting:

```python
from starlette.applications import Starlette
from starlette.responses import JSONResponse
import httpx

app = Starlette()
client = httpx.AsyncClient()
app.add_event_handler("shutdown", client.close)


@app.route("/")
async def home(request):
    resp = await client.get("https://httpbin.org/headers")
    return JSONResponse(resp.json())
```

![Screenshot 2019-11-02 at 13 06 15](https://user-images.githubusercontent.com/15911462/68070681-938af500-fd71-11e9-8fe3-78c2e7255244.png)

Still to do in future PRs:

- Add logging of requests into `DEBUG` log lines will be added in a subsequent PR.
- Colour logs based on the log-level (Uvicorn overrides this, but right now HTTPX does not do colouring on its own). Could take a similar approach to https://github.com/encode/databases/pull/156 (use `click` for colouring if available).