### PR TITLE
Automatically request review via CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# For docs on code owners, see:
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+* @encode/httpx-maintainers


### PR DESCRIPTION
Something I mentioned in our Keybase chat, is experimenting with adding a `CODEOWNERS` file ([docs](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners)) so that a review from maintainers is automatically requested.

The goal is to reduce a bit of the PR triaging burden as well as showing the intent to contributors that we will be looking into their PR soon.

If all goes well, `@encode/httpx-maintainers` should be requested for review on this one. 💯 