### PR TITLE
Refactor debug and trace log tests

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,20 @@
+import contextlib
+import logging
+import os
+
+from httpx import utils
+
+
+@contextlib.contextmanager
+def override_log_level(log_level: str):
+    os.environ["HTTPX_LOG_LEVEL"] = log_level
+
+    # Force a reload on the logging handlers
+    utils._LOGGER_INITIALIZED = False
+    utils.get_logger("httpx")
+
+    try:
+        yield
+    finally:
+        # Reset the logger so we don't have verbose output in all unit tests
+        logging.getLogger("httpx").handlers = []


### PR DESCRIPTION
Spun up from #502 to help reduce its scope - simplify how we test debug logs.