### PR TITLE
Add support for unix domain sockets

### DIFF
--- a/httpx/client.py
+++ b/httpx/client.py
@@ -74,6 +74,7 @@ class BaseClient:
         app: typing.Callable = None,
         backend: ConcurrencyBackend = None,
         trust_env: bool = True,
+        uds: str = None,
     ):
         if backend is None:
             backend = AsyncioBackend()
@@ -99,6 +100,7 @@ class BaseClient:
                 pool_limits=pool_limits,
                 backend=backend,
                 trust_env=self.trust_env,
+                uds=uds,
             )
         elif isinstance(dispatch, Dispatcher):
             async_dispatch = ThreadedDispatcher(dispatch, backend)
@@ -721,6 +723,7 @@ class Client(BaseClient):
     async requests.
     * **trust_env** - *(optional)* Enables or disables usage of environment
     variables for configuration.
+    * **uds** - *(optional)* A path to a Unix domain socket to connect through
     """
 
     def check_concurrency_backend(self, backend: ConcurrencyBackend) -> None:

--- a/httpx/client.py
+++ b/httpx/client.py
@@ -723,7 +723,7 @@ class Client(BaseClient):
     async requests.
     * **trust_env** - *(optional)* Enables or disables usage of environment
     variables for configuration.
-    * **uds** - *(optional)* A path to a Unix domain socket to connect through
+    * **uds** - *(optional)* A path to a Unix domain socket to connect through.
     """
 
     def check_concurrency_backend(self, backend: ConcurrencyBackend) -> None:

--- a/httpx/concurrency/base.py
+++ b/httpx/concurrency/base.py
@@ -124,6 +124,15 @@ class ConcurrencyBackend:
     ) -> BaseSocketStream:
         raise NotImplementedError()  # pragma: no cover
 
+    async def open_uds_stream(
+        self,
+        path: str,
+        hostname: typing.Optional[str],
+        ssl_context: typing.Optional[ssl.SSLContext],
+        timeout: TimeoutConfig,
+    ) -> BaseTCPStream:
+        raise NotImplementedError()  # pragma: no cover
+
     def get_semaphore(self, limits: PoolLimits) -> BasePoolSemaphore:
         raise NotImplementedError()  # pragma: no cover
 

--- a/httpx/concurrency/base.py
+++ b/httpx/concurrency/base.py
@@ -130,7 +130,7 @@ class ConcurrencyBackend:
         hostname: typing.Optional[str],
         ssl_context: typing.Optional[ssl.SSLContext],
         timeout: TimeoutConfig,
-    ) -> BaseTCPStream:
+    ) -> BaseSocketStream:
         raise NotImplementedError()  # pragma: no cover
 
     def get_semaphore(self, limits: PoolLimits) -> BasePoolSemaphore:

--- a/httpx/dispatch/connection_pool.py
+++ b/httpx/dispatch/connection_pool.py
@@ -89,6 +89,7 @@ class ConnectionPool(AsyncDispatcher):
         pool_limits: PoolLimits = DEFAULT_POOL_LIMITS,
         http_versions: HTTPVersionTypes = None,
         backend: ConcurrencyBackend = None,
+        uds: typing.Optional[str] = None,
     ):
         self.verify = verify
         self.cert = cert
@@ -97,6 +98,7 @@ class ConnectionPool(AsyncDispatcher):
         self.http_versions = http_versions
         self.is_closed = False
         self.trust_env = trust_env
+        self.uds = uds
 
         self.keepalive_connections = ConnectionStore()
         self.active_connections = ConnectionStore()
@@ -142,6 +144,7 @@ class ConnectionPool(AsyncDispatcher):
                 backend=self.backend,
                 release_func=self.release_connection,
                 trust_env=self.trust_env,
+                uds=self.uds,
             )
             logger.trace(f"new_connection connection={connection!r}")
         else:

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -156,7 +156,4 @@ async def test_uds(uds_server, backend):
         response = await client.get(url)
     assert response.status_code == 200
     assert response.text == "Hello, world!"
-    assert response.http_version == "HTTP/1.1"
-    assert response.headers
-    assert repr(response) == "<Response [200 OK]>"
-    assert response.elapsed > timedelta(seconds=0)
+    assert response.encoding == "iso-8859-1"

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -146,3 +146,17 @@ async def test_100_continue(server, backend):
 
     assert response.status_code == 200
     assert response.content == data
+
+
+async def test_uds(uds_server, backend):
+    url = uds_server.url
+    uds = uds_server.config.uds
+    assert uds is not None
+    async with httpx.AsyncClient(backend=backend, uds=uds) as client:
+        response = await client.get(url)
+    assert response.status_code == 200
+    assert response.text == "Hello, world!"
+    assert response.http_version == "HTTP/1.1"
+    assert response.headers
+    assert repr(response) == "<Response [200 OK]>"
+    assert response.elapsed > timedelta(seconds=0)

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -138,6 +138,25 @@ def test_base_url(server):
     assert response.url == base_url
 
 
+def test_uds(uds_server):
+    url = uds_server.url
+    uds = uds_server.config.uds
+    assert uds is not None
+    with httpx.Client(uds=uds) as http:
+        response = http.get(url)
+    assert response.status_code == 200
+    assert response.url == url
+    assert response.content == b"Hello, world!"
+    assert response.text == "Hello, world!"
+    assert response.http_version == "HTTP/1.1"
+    assert response.encoding == "iso-8859-1"
+    assert response.request.url == url
+    assert response.headers
+    assert response.is_redirect is False
+    assert repr(response) == "<Response [200 OK]>"
+    assert response.elapsed > timedelta(0)
+
+
 def test_merge_url():
     client = httpx.Client(base_url="https://www.paypal.com/")
     url = client.merge_url("http://www.paypal.com")

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -145,16 +145,8 @@ def test_uds(uds_server):
     with httpx.Client(uds=uds) as http:
         response = http.get(url)
     assert response.status_code == 200
-    assert response.url == url
-    assert response.content == b"Hello, world!"
     assert response.text == "Hello, world!"
-    assert response.http_version == "HTTP/1.1"
     assert response.encoding == "iso-8859-1"
-    assert response.request.url == url
-    assert response.headers
-    assert response.is_redirect is False
-    assert repr(response) == "<Response [200 OK]>"
-    assert response.elapsed > timedelta(0)
 
 
 def test_merge_url():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -301,3 +301,17 @@ def https_server(cert_pem_file, cert_private_key_file):
     )
     server = TestServer(config=config)
     yield from serve_in_thread(server)
+
+
+@pytest.fixture(scope=SERVER_SCOPE)
+def https_uds_server(cert_pem_file, cert_private_key_file):
+    config = Config(
+        app=app,
+        lifespan="off",
+        ssl_certfile=cert_pem_file,
+        ssl_keyfile=cert_private_key_file,
+        uds="https_test_server.sock",
+        loop="asyncio",
+    )
+    server = TestServer(config=config)
+    yield from serve_in_thread(server)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -289,6 +289,15 @@ def server():
 
 
 @pytest.fixture(scope=SERVER_SCOPE)
+def uds_server():
+    uds = "test_server.sock"
+    config = Config(app=app, lifespan="off", loop="asyncio", uds=uds)
+    server = TestServer(config=config)
+    yield from serve_in_thread(server)
+    os.remove(uds)
+
+
+@pytest.fixture(scope=SERVER_SCOPE)
 def https_server(cert_pem_file, cert_private_key_file):
     config = Config(
         app=app,
@@ -305,13 +314,15 @@ def https_server(cert_pem_file, cert_private_key_file):
 
 @pytest.fixture(scope=SERVER_SCOPE)
 def https_uds_server(cert_pem_file, cert_private_key_file):
+    uds = "https_test_server.sock"
     config = Config(
         app=app,
         lifespan="off",
         ssl_certfile=cert_pem_file,
         ssl_keyfile=cert_private_key_file,
-        uds="https_test_server.sock",
+        uds=uds,
         loop="asyncio",
     )
     server = TestServer(config=config)
     yield from serve_in_thread(server)
+    os.remove(uds)

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -5,26 +5,30 @@ from httpx import AsyncioBackend, HTTPVersionConfig, SSLConfig, TimeoutConfig
 from httpx.concurrency.trio import TrioBackend
 
 
+def get_asyncio_cipher(stream):
+    return stream.stream_writer.get_extra_info("cipher", default=None)
+
+
+def get_trio_cipher(stream):
+    return stream.stream.cipher() if isinstance(stream.stream, trio.SSLStream) else None
+
+
 @pytest.mark.parametrize(
-    "backend, get_cipher",
+    "backend, test_uds, get_cipher",
     [
         pytest.param(
-            AsyncioBackend(),
-            lambda stream: stream.stream_writer.get_extra_info("cipher", default=None),
-            marks=pytest.mark.asyncio,
+            AsyncioBackend(), False, get_asyncio_cipher, marks=pytest.mark.asyncio
         ),
         pytest.param(
-            TrioBackend(),
-            lambda stream: (
-                stream.stream.cipher()
-                if isinstance(stream.stream, trio.SSLStream)
-                else None
-            ),
-            marks=pytest.mark.trio,
+            AsyncioBackend(), True, get_asyncio_cipher, marks=pytest.mark.asyncio
         ),
+        pytest.param(TrioBackend(), False, get_trio_cipher, marks=pytest.mark.trio),
+        pytest.param(TrioBackend(), True, get_trio_cipher, marks=pytest.mark.trio),
     ],
 )
-async def test_start_tls_on_socket_stream(https_server, backend, get_cipher):
+async def test_start_tls_on_socket_stream(
+    https_server, https_uds_server, backend, test_uds, get_cipher
+):
     """
     See that the concurrency backend can make a connection without TLS then
     start TLS on an existing connection.
@@ -32,9 +36,15 @@ async def test_start_tls_on_socket_stream(https_server, backend, get_cipher):
     ctx = SSLConfig().load_ssl_context_no_verify(HTTPVersionConfig())
     timeout = TimeoutConfig(5)
 
-    stream = await backend.open_tcp_stream(
-        https_server.url.host, https_server.url.port, None, timeout
-    )
+    if test_uds:
+        assert https_uds_server.config.uds is not None
+        stream = await backend.open_uds_stream(
+            https_uds_server.config.uds, https_uds_server.url.host, None, timeout
+        )
+    else:
+        stream = await backend.open_tcp_stream(
+            https_server.url.host, https_server.url.port, None, timeout
+        )
 
     try:
         assert stream.is_connection_dropped() is False


### PR DESCRIPTION
This PR adds support for connecting through unix domain sockets.

New client argument `uds` is added to define unix domain socket path to use.

**Usage:**
```py
async with httpx.AsyncClient(uds="/var/run/docker.sock") as client:
    # This request will connect through the socket file
    r = await client.get("http://docker/version")
```

Solves previously discussed topic in #133 