### PR TITLE
Allow using Client in an async environment

### DIFF
--- a/tests/client/test_client_async.py
+++ b/tests/client/test_client_async.py
@@ -1,0 +1,36 @@
+"""Test the behavior of Client in async environments."""
+
+import threading
+
+import pytest
+
+import httpx
+
+# NOTE: using Client in an async environment is only supported for asyncio, for now.
+
+
+@pytest.mark.asyncio
+async def test_sync_request_in_async_environment(server):
+    with httpx.Client() as client:
+        response = client.get(server.url)
+    assert response.status_code == 200
+    assert response.text == "Hello, world!"
+
+
+@pytest.mark.asyncio
+async def test_sync_request_in_async_environment_with_exception(server):
+    outer_thread = threading.current_thread()
+
+    class FailingDispatcher(httpx.AsyncDispatcher):
+        async def send(self, *args, **kwargs):
+            assert threading.current_thread() != outer_thread
+            # This shouldn't make the shared sub-thread hang.
+            raise ValueError("Failed")
+
+    with pytest.raises(ValueError) as ctx:
+        with httpx.Client(dispatch=FailingDispatcher()) as client:
+            client.get(server.url)
+
+    exc = ctx.value
+    assert isinstance(exc, ValueError)
+    assert str(exc) == "Failed"


### PR DESCRIPTION
Fixes #508 

This is an attempt at handling the situation in which users try to use `httpx.get()` or `httpx.Client()` in an async environment that has a running loop (e.g. in a Jupyter notebook).

I documented several potential caveats in the form of code comments.

I still need to verify this actually solves the Jupyter use case, though the tests give me hope that it does. :-)