### PR TITLE
Rename TCPStream to SocketStream

### DIFF
--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -5,7 +5,7 @@ from .concurrency.asyncio import AsyncioBackend
 from .concurrency.base import (
     BaseBackgroundManager,
     BasePoolSemaphore,
-    BaseTCPStream,
+    BaseSocketStream,
     ConcurrencyBackend,
 )
 from .config import (
@@ -114,7 +114,7 @@ __all__ = [
     "TooManyRedirects",
     "WriteTimeout",
     "AsyncDispatcher",
-    "BaseTCPStream",
+    "BaseSocketStream",
     "ConcurrencyBackend",
     "Dispatcher",
     "URL",

--- a/httpx/concurrency/base.py
+++ b/httpx/concurrency/base.py
@@ -37,9 +37,9 @@ class TimeoutFlag:
         self.raise_on_write_timeout = True
 
 
-class BaseTCPStream:
+class BaseSocketStream:
     """
-    A TCP stream with read/write operations. Abstracts away any asyncio-specific
+    A socket stream with read/write operations. Abstracts away any asyncio-specific
     interfaces into a more generic base class, that we can use with alternate
     backends, or for stand-alone test cases.
     """
@@ -49,7 +49,7 @@ class BaseTCPStream:
 
     async def start_tls(
         self, hostname: str, ssl_context: ssl.SSLContext, timeout: TimeoutConfig
-    ) -> "BaseTCPStream":
+    ) -> "BaseSocketStream":
         raise NotImplementedError()  # pragma: no cover
 
     async def read(
@@ -121,7 +121,7 @@ class ConcurrencyBackend:
         port: int,
         ssl_context: typing.Optional[ssl.SSLContext],
         timeout: TimeoutConfig,
-    ) -> BaseTCPStream:
+    ) -> BaseSocketStream:
         raise NotImplementedError()  # pragma: no cover
 
     def get_semaphore(self, limits: PoolLimits) -> BasePoolSemaphore:

--- a/httpx/dispatch/http11.py
+++ b/httpx/dispatch/http11.py
@@ -2,7 +2,7 @@ import typing
 
 import h11
 
-from ..concurrency.base import BaseTCPStream, ConcurrencyBackend, TimeoutFlag
+from ..concurrency.base import BaseSocketStream, ConcurrencyBackend, TimeoutFlag
 from ..config import TimeoutConfig, TimeoutTypes
 from ..models import AsyncRequest, AsyncResponse
 from ..utils import get_logger
@@ -31,7 +31,7 @@ class HTTP11Connection:
 
     def __init__(
         self,
-        stream: BaseTCPStream,
+        stream: BaseSocketStream,
         backend: ConcurrencyBackend,
         on_release: typing.Optional[OnReleaseCallback] = None,
     ):

--- a/httpx/dispatch/http2.py
+++ b/httpx/dispatch/http2.py
@@ -5,7 +5,12 @@ import h2.connection
 import h2.events
 from h2.settings import SettingCodes, Settings
 
-from ..concurrency.base import BaseEvent, BaseTCPStream, ConcurrencyBackend, TimeoutFlag
+from ..concurrency.base import (
+    BaseEvent,
+    BaseSocketStream,
+    ConcurrencyBackend,
+    TimeoutFlag,
+)
 from ..config import TimeoutConfig, TimeoutTypes
 from ..exceptions import ProtocolError
 from ..models import AsyncRequest, AsyncResponse
@@ -19,7 +24,7 @@ class HTTP2Connection:
 
     def __init__(
         self,
-        stream: BaseTCPStream,
+        stream: BaseSocketStream,
         backend: ConcurrencyBackend,
         on_release: typing.Callable = None,
     ):

--- a/httpx/dispatch/proxy_http.py
+++ b/httpx/dispatch/proxy_http.py
@@ -179,7 +179,7 @@ class HTTPProxy(ConnectionPool):
         stream = http_connection.stream
 
         # If we need to start TLS again for the target server
-        # we need to pull the TCP stream off the internal
+        # we need to pull the socket stream off the internal
         # HTTP connection object and run start_tls()
         if origin.is_ssl:
             ssl_config = SSLConfig(cert=self.cert, verify=self.verify)

--- a/tests/dispatch/utils.py
+++ b/tests/dispatch/utils.py
@@ -5,7 +5,7 @@ import h2.config
 import h2.connection
 import h2.events
 
-from httpx import AsyncioBackend, BaseTCPStream, Request, TimeoutConfig
+from httpx import AsyncioBackend, BaseSocketStream, Request, TimeoutConfig
 from tests.concurrency import sleep
 
 
@@ -21,7 +21,7 @@ class MockHTTP2Backend:
         port: int,
         ssl_context: typing.Optional[ssl.SSLContext],
         timeout: TimeoutConfig,
-    ) -> BaseTCPStream:
+    ) -> BaseSocketStream:
         self.server = MockHTTP2Server(self.app, backend=self.backend)
         return self.server
 
@@ -30,7 +30,7 @@ class MockHTTP2Backend:
         return getattr(self.backend, name)
 
 
-class MockHTTP2Server(BaseTCPStream):
+class MockHTTP2Server(BaseSocketStream):
     def __init__(self, app, backend):
         config = h2.config.H2Configuration(client_side=False)
         self.conn = h2.connection.H2Connection(config=config)
@@ -43,7 +43,7 @@ class MockHTTP2Server(BaseTCPStream):
         self.returning = {}
         self.settings_changed = []
 
-    # TCP stream interface
+    # Socket stream interface
 
     def get_http_version(self) -> str:
         return "HTTP/2"
@@ -178,7 +178,7 @@ class MockRawSocketBackend:
         port: int,
         ssl_context: typing.Optional[ssl.SSLContext],
         timeout: TimeoutConfig,
-    ) -> BaseTCPStream:
+    ) -> BaseSocketStream:
         self.received_data.append(
             b"--- CONNECT(%s, %d) ---" % (hostname.encode(), port)
         )
@@ -189,13 +189,13 @@ class MockRawSocketBackend:
         return getattr(self.backend, name)
 
 
-class MockRawSocketStream(BaseTCPStream):
+class MockRawSocketStream(BaseSocketStream):
     def __init__(self, backend: MockRawSocketBackend):
         self.backend = backend
 
     async def start_tls(
         self, hostname: str, ssl_context: ssl.SSLContext, timeout: TimeoutConfig
-    ) -> BaseTCPStream:
+    ) -> BaseSocketStream:
         self.backend.received_data.append(b"--- START_TLS(%s) ---" % hostname.encode())
         return MockRawSocketStream(self.backend)
 


### PR DESCRIPTION
This PR renames `BaseTCPStream`, backend subclasses `asyncio.TCPStream` and `trio.TCPStream`, to `BaseSocketStream` / `SocketStream`, to not limit name/usage to TCP specific streams.

Related to #511 