### PR TITLE
Files without a filename should not set a Content-Type in multipart data.

### DIFF
--- a/httpx/models.py
+++ b/httpx/models.py
@@ -84,17 +84,17 @@ RequestData = typing.Union[dict, str, bytes, typing.Iterator[bytes]]
 RequestFiles = typing.Dict[
     str,
     typing.Union[
-        typing.IO[typing.AnyStr],  # file
+        # file
+        typing.Union[typing.IO[typing.AnyStr], typing.AnyStr],
+        # (filename, file (or str))
+        typing.Tuple[
+            typing.Optional[str], typing.Union[typing.IO[typing.AnyStr], typing.AnyStr],
+        ],
+        # (filename, file (or str), content_type)
         typing.Tuple[
             typing.Optional[str],
-            typing.Union[
-                typing.IO[typing.AnyStr], typing.AnyStr
-            ],  # (filename, file (or str))
-            typing.Tuple[
-                typing.Optional[str],
-                typing.Union[typing.IO[typing.AnyStr], typing.AnyStr],
-                typing.Optional[str],
-            ],  # (filename, file (or str), content_type)
+            typing.Union[typing.IO[typing.AnyStr], typing.AnyStr],
+            typing.Optional[str],
         ],
     ],
 ]

--- a/httpx/models.py
+++ b/httpx/models.py
@@ -84,7 +84,7 @@ RequestData = typing.Union[dict, str, bytes, typing.Iterator[bytes]]
 RequestFiles = typing.Dict[
     str,
     typing.Union[
-        # file
+        # file (or str)
         typing.Union[typing.IO[typing.AnyStr], typing.AnyStr],
         # (filename, file (or str))
         typing.Tuple[

--- a/httpx/models.py
+++ b/httpx/models.py
@@ -85,10 +85,17 @@ RequestFiles = typing.Dict[
     str,
     typing.Union[
         typing.IO[typing.AnyStr],  # file
-        typing.Tuple[str, typing.IO[typing.AnyStr]],  # (filename, file)
         typing.Tuple[
-            str, typing.IO[typing.AnyStr], str
-        ],  # (filename, file, content_type)
+            typing.Optional[str],
+            typing.Union[
+                typing.IO[typing.AnyStr], typing.AnyStr
+            ],  # (filename, file (or str))
+            typing.Tuple[
+                typing.Optional[str],
+                typing.Union[typing.IO[typing.AnyStr], typing.AnyStr],
+                typing.Optional[str]
+            ],  # (filename, file (or str), content_type)
+        ],
     ],
 ]
 

--- a/httpx/models.py
+++ b/httpx/models.py
@@ -93,7 +93,7 @@ RequestFiles = typing.Dict[
             typing.Tuple[
                 typing.Optional[str],
                 typing.Union[typing.IO[typing.AnyStr], typing.AnyStr],
-                typing.Optional[str]
+                typing.Optional[str],
             ],  # (filename, file (or str), content_type)
         ],
     ],

--- a/httpx/multipart.py
+++ b/httpx/multipart.py
@@ -69,8 +69,10 @@ class FileField(Field):
         if self.filename:
             filename = _format_param("filename", self.filename)
             parts.extend([b"; ", filename])
-        content_type = self.content_type.encode()
-        parts.extend([b"\r\nContent-Type: ", content_type, b"\r\n\r\n"])
+        if self.content_type is not None:
+            content_type = self.content_type.encode()
+            parts.extend([b"\r\nContent-Type: ", content_type])
+        parts.append(b"\r\n\r\n")
         return b"".join(parts)
 
     def render_data(self) -> bytes:

--- a/httpx/multipart.py
+++ b/httpx/multipart.py
@@ -58,11 +58,11 @@ class FileField(Field):
                 value[2] if len(value) > 2 else self.guess_content_type()
             )
 
-    def guess_content_type(self) -> str:
+    def guess_content_type(self) -> typing.Optional[str]:
         if self.filename:
             return mimetypes.guess_type(self.filename)[0] or "application/octet-stream"
         else:
-            return "application/octet-stream"
+            return None
 
     def render_headers(self) -> bytes:
         parts = [b"Content-Disposition: form-data; ", _format_param("name", self.name)]

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -136,9 +136,8 @@ def test_multipart_encode_files_allows_filenames_as_none():
 
         assert content_type == f"multipart/form-data; boundary={boundary}"
         assert body == (
-            '--{0}\r\nContent-Disposition: form-data; name="file"\r\n'
-            "Content-Type: application/octet-stream\r\n\r\n<file content>\r\n"
-            "--{0}--\r\n"
+            '--{0}\r\nContent-Disposition: form-data; name="file"\r\n\r\n'
+            "<file content>\r\n--{0}--\r\n"
             "".format(boundary).encode("ascii")
         )
 

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -140,6 +140,22 @@ def test_multipart_encode_files_allows_filenames_as_none():
             "<file content>\r\n--{0}--\r\n"
             "".format(boundary).encode("ascii")
         )
+@pytest.mark.parametrize('file_name,expected_content_type',
+                         [('example.json', 'application/json'), ('example.log', 'application/octet-stream')])
+def test_multipart_encode_files_guesses_correct_content_type(file_name, expected_content_type):
+    files = {"file": (file_name, io.BytesIO(b"<file content>"))}
+    with mock.patch("os.urandom", return_value=os.urandom(16)):
+        boundary = binascii.hexlify(os.urandom(16)).decode("ascii")
+
+        body, content_type = multipart.multipart_encode(data={}, files=files)
+
+        assert content_type == f"multipart/form-data; boundary={boundary}"
+        assert body == (
+            '--{0}\r\nContent-Disposition: form-data; name="file"; filename="{2}"\r\n'
+            "Content-Type: {1}\r\n\r\n<file content>\r\n"
+            "--{0}--\r\n"
+            "".format(boundary, expected_content_type, file_name).encode("ascii")
+        )
 
 
 def test_multipart_encode_files_allows_str_content():

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -158,9 +158,8 @@ def test_multipart_encode_files_guesses_correct_content_type(
         assert content_type == f"multipart/form-data; boundary={boundary}"
         assert body == (
             f'--{boundary}\r\nContent-Disposition: form-data; name="file"; '
-            f'filename="{file_name}"\r\n'
-            f"Content-Type: {expected_content_type}\r\n\r\n<file content>\r\n"
-            f"--{boundary}--\r\n"
+            f'filename="{file_name}"\r\nContent-Type: '
+            f'{expected_content_type}\r\n\r\n<file content>\r\n--{boundary}--\r\n'
             "".encode("ascii")
         )
 

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -157,10 +157,10 @@ def test_multipart_encode_files_guesses_correct_content_type(
 
         assert content_type == f"multipart/form-data; boundary={boundary}"
         assert body == (
-            '--{0}\r\nContent-Disposition: form-data; name="file"; filename="{2}"\r\n'
-            "Content-Type: {1}\r\n\r\n<file content>\r\n"
-            "--{0}--\r\n"
-            "".format(boundary, expected_content_type, file_name).encode("ascii")
+            f'--{boundary}\r\nContent-Disposition: form-data; name="file"; filename="{file_name}"\r\n'
+            f"Content-Type: {expected_content_type}\r\n\r\n<file content>\r\n"
+            f"--{boundary}--\r\n"
+            "".encode("ascii")
         )
 
 

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -159,7 +159,7 @@ def test_multipart_encode_files_guesses_correct_content_type(
         assert body == (
             f'--{boundary}\r\nContent-Disposition: form-data; name="file"; '
             f'filename="{file_name}"\r\nContent-Type: '
-            f'{expected_content_type}\r\n\r\n<file content>\r\n--{boundary}--\r\n'
+            f"{expected_content_type}\r\n\r\n<file content>\r\n--{boundary}--\r\n"
             "".encode("ascii")
         )
 

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -140,9 +140,15 @@ def test_multipart_encode_files_allows_filenames_as_none():
             "<file content>\r\n--{0}--\r\n"
             "".format(boundary).encode("ascii")
         )
-@pytest.mark.parametrize('file_name,expected_content_type',
-                         [('example.json', 'application/json'), ('example.log', 'application/octet-stream')])
-def test_multipart_encode_files_guesses_correct_content_type(file_name, expected_content_type):
+
+
+@pytest.mark.parametrize(
+    "file_name,expected_content_type",
+    [("example.json", "application/json"), ("example.log", "application/octet-stream")],
+)
+def test_multipart_encode_files_guesses_correct_content_type(
+    file_name, expected_content_type
+):
     files = {"file": (file_name, io.BytesIO(b"<file content>"))}
     with mock.patch("os.urandom", return_value=os.urandom(16)):
         boundary = binascii.hexlify(os.urandom(16)).decode("ascii")

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -157,7 +157,8 @@ def test_multipart_encode_files_guesses_correct_content_type(
 
         assert content_type == f"multipart/form-data; boundary={boundary}"
         assert body == (
-            f'--{boundary}\r\nContent-Disposition: form-data; name="file"; filename="{file_name}"\r\n'
+            f'--{boundary}\r\nContent-Disposition: form-data; name="file"; '
+            f'filename="{file_name}"\r\n'
             f"Content-Type: {expected_content_type}\r\n\r\n<file content>\r\n"
             f"--{boundary}--\r\n"
             "".encode("ascii")


### PR DESCRIPTION
Fixes #519 