### PR TITLE
Backport start_tls() support for Python 3.6

### DIFF
--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,5 +1,3 @@
-import sys
-
 import pytest
 import trio
 
@@ -31,9 +29,6 @@ async def test_start_tls_on_socket_stream(https_server, backend, get_cipher):
     See that the concurrency backend can make a connection without TLS then
     start TLS on an existing connection.
     """
-    if isinstance(backend, AsyncioBackend) and sys.version_info < (3, 7):
-        pytest.xfail(reason="Requires Python 3.7+ for AbstractEventLoop.start_tls()")
-
     ctx = SSLConfig().load_ssl_context_no_verify(HTTPVersionConfig())
     timeout = TimeoutConfig(5)
 


### PR DESCRIPTION
This adds support for proxy tunnels for Python 3.6 + asyncio.
Based almost entirely on this comment: https://github.com/urllib3/urllib3/issues/1323#issuecomment-362494839 Massive thanks to @florimondmanca for finding this!

Closes #515.
