### PR TITLE
Handle h11.Connection.next_event() RemoteProtocolException

### DIFF
--- a/httpx/exceptions.py
+++ b/httpx/exceptions.py
@@ -150,6 +150,12 @@ class InvalidURL(HTTPError):
     """
 
 
+class ConnectionClosed(HTTPError):
+    """
+    Expected more data from peer, but connection was closed.
+    """
+
+
 class CookieConflict(HTTPError):
     """
     Attempted to lookup a cookie by name, but multiple cookies existed.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,8 @@ async def app(scope, receive, send):
     assert scope["type"] == "http"
     if scope["path"].startswith("/slow_response"):
         await slow_response(scope, receive, send)
+    elif scope["path"].startswith("/premature_close"):
+        await premature_close(scope, receive, send)
     elif scope["path"].startswith("/status"):
         await status_code(scope, receive, send)
     elif scope["path"].startswith("/echo_body"):
@@ -101,6 +103,16 @@ async def slow_response(scope, receive, send):
         }
     )
     await send({"type": "http.response.body", "body": b"Hello, world!"})
+
+
+async def premature_close(scope, receive, send):
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [[b"content-type", b"text/plain"]],
+        }
+    )
 
 
 async def status_code(scope, receive, send):

--- a/tests/dispatch/test_connections.py
+++ b/tests/dispatch/test_connections.py
@@ -1,4 +1,6 @@
-from httpx import HTTPConnection
+import pytest
+
+from httpx import HTTPConnection, exceptions
 
 
 async def test_get(server, backend):
@@ -13,6 +15,15 @@ async def test_post(server, backend):
     async with HTTPConnection(origin=server.url, backend=backend) as conn:
         response = await conn.request("GET", server.url, data=b"Hello, world!")
         assert response.status_code == 200
+
+
+async def test_premature_close(server, backend):
+    with pytest.raises(exceptions.ConnectionClosed):
+        async with HTTPConnection(origin=server.url, backend=backend) as conn:
+            response = await conn.request(
+                "GET", server.url.copy_with(path="/premature_close")
+            )
+            await response.read()
 
 
 async def test_https_get_with_ssl_defaults(https_server, ca_cert_pem_file, backend):


### PR DESCRIPTION
here is a proposed fix.  I wasn't too clear on the test suite (as usual :), but I was able to make a case that triggers the failure mode and test that the fix works as expected.

Addresses github issue #96

Fixes #96 