### PR TITLE
Replace background managers

### DIFF
--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -2,12 +2,7 @@ from .__version__ import __description__, __title__, __version__
 from .api import delete, get, head, options, patch, post, put, request
 from .client import AsyncClient, Client
 from .concurrency.asyncio import AsyncioBackend
-from .concurrency.base import (
-    BaseBackgroundManager,
-    BasePoolSemaphore,
-    BaseSocketStream,
-    ConcurrencyBackend,
-)
+from .concurrency.base import BasePoolSemaphore, BaseSocketStream, ConcurrencyBackend
 from .config import (
     USER_AGENT,
     CertTypes,
@@ -91,7 +86,6 @@ __all__ = [
     "VerifyTypes",
     "HTTPConnection",
     "BasePoolSemaphore",
-    "BaseBackgroundManager",
     "ConnectionPool",
     "HTTPProxy",
     "HTTPProxyMode",

--- a/httpx/compat.py
+++ b/httpx/compat.py
@@ -1,0 +1,14 @@
+import sys
+
+if sys.version_info < (3, 7):
+    try:
+        from async_exit_stack import AsyncExitStack  # type: ignore
+    except ImportError:
+        raise RuntimeError(
+            "AsyncExitStack is not available on Python 3.6, and no backport is "
+            "installed. To install it, run: 'pip install async-exit-stack'."
+        )
+else:
+    from contextlib import AsyncExitStack
+
+__all__ = ["AsyncExitStack"]

--- a/httpx/concurrency/trio.py
+++ b/httpx/concurrency/trio.py
@@ -2,10 +2,10 @@ import functools
 import math
 import ssl
 import typing
-from contextlib import AsyncExitStack
 
 import trio
 
+from ..compat import AsyncExitStack
 from ..config import PoolLimits, TimeoutConfig
 from ..exceptions import ConnectTimeout, PoolTimeout, ReadTimeout, WriteTimeout
 from .base import (

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,7 @@
 -e .
 
 # Optional
+async_exit_stack; python_version < '3.7'
 brotlipy==0.7.*
 
 cryptography

--- a/tests/dispatch/utils.py
+++ b/tests/dispatch/utils.py
@@ -6,6 +6,7 @@ import h2.connection
 import h2.events
 
 from httpx import AsyncioBackend, BaseSocketStream, Request, TimeoutConfig
+from httpx.concurrency.base import TimeoutFlag
 from tests.concurrency import sleep
 
 
@@ -85,7 +86,9 @@ class MockHTTP2Server(BaseSocketStream):
             elif isinstance(event, h2.events.RemoteSettingsChanged):
                 self.settings_changed.append(event)
 
-    async def write(self, data: bytes, timeout) -> None:
+    async def write(
+        self, data: bytes, timeout: TimeoutConfig = None, flag: TimeoutFlag = None
+    ) -> None:
         self.write_no_block(data)
 
     async def close(self) -> None:
@@ -205,7 +208,9 @@ class MockRawSocketStream(BaseSocketStream):
     def write_no_block(self, data: bytes) -> None:
         self.backend.received_data.append(data)
 
-    async def write(self, data: bytes, timeout: TimeoutConfig = None) -> None:
+    async def write(
+        self, data: bytes, timeout: TimeoutConfig = None, flag: TimeoutFlag = None
+    ) -> None:
         if data:
             self.write_no_block(data)
 

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -17,7 +17,7 @@ async def test_read_timeout(server, backend):
 
     async with AsyncClient(timeout=timeout, backend=backend) as client:
         with pytest.raises(ReadTimeout):
-            await client.get(server.url.copy_with(path="/slow_response"))
+            await client.get(server.url.copy_with(path="/slow_response/100"))
 
 
 async def test_write_timeout(server, backend):
@@ -26,7 +26,7 @@ async def test_write_timeout(server, backend):
     async with AsyncClient(timeout=timeout, backend=backend) as client:
         with pytest.raises(WriteTimeout):
             data = b"*" * 1024 * 1024 * 100
-            await client.put(server.url.copy_with(path="/slow_response"), data=data)
+            await client.put(server.url.copy_with(path="/slow_response/200"), data=data)
 
 
 async def test_connect_timeout(server, backend):


### PR DESCRIPTION
*Disclaimer: this PR is dense, and I'm not expecting it to be merged. If the idea seems sound, I'll cut it into 3 pieces (ASGI dispatcher, HTTP/1.1 dispatcher, HTTP/2 dispatcher) that can be reviewed and merged independently.*

---

Currently, the way we send the request and receive the response, in both HTTP/1.1 and HTTP/2 cases, is:

1. Send the request headers and body, *and* receive the response headers concurrently.
1. Receive the response body.

Right now, 1) is achieved via a custom `BackgroundManager` API. This *works*, but it has its own quirks. In particular, we can't always adhere to the context-managed usage, meaning that we *sometimes* have to manually deal with `.__aenter__()` and `__aexit__()` (e.g. in the ASGI dispatcher), which is fiddly and bug-prone. The context manager implementation also makes propagation of exceptions difficult (currently I'm not sure we get that aspect right).

@tomchristie, I think we mentioned several times in the past that the current situation is not ideal. urllib3-async takes a different approach which this PR takes inspiration from (cc @pquentin).

This PR proposes to split the background manager API into several more narrowly-scoped primitives that address the two *actual* use cases we use `BackgroundManager` for:

1. Run coroutines in parallel and wait for them to finish. (Used to send the request and receive the response concurrently, in the h11 and h2 dispatchers.)
1. Start a coroutine in the background while we're doing other things in the foreground. (Used in the ASGI dispatcher.)

Point 1) is solved by two new APIs. First, a writer/reader pair:

- Writer gets bytes from the client code (via a callback defined in the dispatcher), and writes them to the network (via the socket stream).
- Reader reads bytes from the network (via the socket stream), and passes them to the client code (via a callback defined in the dispatcher).

The construction of these coroutines is provided by a single `.build_writer_reader_pair()` implementation in the base backend, which builds on top of `.write()` and `.read()`.

Then we have a `.run_concurrently()` method (implemented by each backend) that runs those coroutines in parallel and waits for them to terminate.

We can then use this API to send the request (headers and body) and receive the response headers. This requires a bit of rejigging to the h11 and h2 dispatchers, as the corresponding methods must be turned into (async) iterators, whose yielded chunks of data are fed into the writer/reader pair. (Hopefully the code is more clear than I can be in prose.)

Finally, to solve 2), a new `.start_in_background()` method is introduced. It returns an opaque callback that we can call to properly terminate the coroutine.

Still to do:

- [x] Use the `AsyncExitStack` backport on 3.6. (Require users to install it, because it's only used to make the trio implementation more robust.)

---

I'll admit it's not immediately obvious why this is an interesting change, as the resulting code is not the most natural. So happy to read feedback on this!