### PR TITLE
pass on cert, verify, timeout, trust_env to Client

### DIFF
--- a/httpx/api.py
+++ b/httpx/api.py
@@ -80,7 +80,13 @@ def request(
     <Response [200 OK]>
     ```
     """
-    with Client(http_versions=["HTTP/1.1"]) as client:
+    with Client(
+        http_versions=["HTTP/1.1"],
+        cert=cert,
+        verify=verify,
+        timeout=timeout,
+        trust_env=trust_env,
+    ) as client:
         return client.request(
             method=method,
             url=url,

--- a/httpx/api.py
+++ b/httpx/api.py
@@ -1,7 +1,7 @@
 import typing
 
 from .client import Client
-from .config import CertTypes, TimeoutTypes, VerifyTypes, DEFAULT_TIMEOUT_CONFIG
+from .config import DEFAULT_TIMEOUT_CONFIG, CertTypes, TimeoutTypes, VerifyTypes
 from .models import (
     AuthTypes,
     CookieTypes,

--- a/httpx/api.py
+++ b/httpx/api.py
@@ -1,7 +1,7 @@
 import typing
 
 from .client import Client
-from .config import CertTypes, TimeoutTypes, VerifyTypes
+from .config import CertTypes, TimeoutTypes, VerifyTypes, DEFAULT_TIMEOUT_CONFIG
 from .models import (
     AuthTypes,
     CookieTypes,
@@ -25,12 +25,12 @@ def request(
     headers: HeaderTypes = None,
     cookies: CookieTypes = None,
     auth: AuthTypes = None,
-    timeout: TimeoutTypes = None,
+    timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
     allow_redirects: bool = True,
     verify: VerifyTypes = True,
     cert: CertTypes = None,
     stream: bool = False,
-    trust_env: bool = None,
+    trust_env: bool = True,
 ) -> Response:
     """
     Sends an HTTP request.
@@ -117,8 +117,8 @@ def get(
     allow_redirects: bool = True,
     cert: CertTypes = None,
     verify: VerifyTypes = True,
-    timeout: TimeoutTypes = None,
-    trust_env: bool = None,
+    timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
+    trust_env: bool = True,
 ) -> Response:
     """
     Sends a `GET` request.
@@ -155,8 +155,8 @@ def options(
     allow_redirects: bool = True,
     cert: CertTypes = None,
     verify: VerifyTypes = True,
-    timeout: TimeoutTypes = None,
-    trust_env: bool = None,
+    timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
+    trust_env: bool = True,
 ) -> Response:
     """
     Sends an `OPTIONS` request.
@@ -193,8 +193,8 @@ def head(
     allow_redirects: bool = False,  #  Note: Differs to usual default.
     cert: CertTypes = None,
     verify: VerifyTypes = True,
-    timeout: TimeoutTypes = None,
-    trust_env: bool = None,
+    timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
+    trust_env: bool = True,
 ) -> Response:
     """
     Sends a `HEAD` request.
@@ -236,8 +236,8 @@ def post(
     allow_redirects: bool = True,
     cert: CertTypes = None,
     verify: VerifyTypes = True,
-    timeout: TimeoutTypes = None,
-    trust_env: bool = None,
+    timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
+    trust_env: bool = True,
 ) -> Response:
     """
     Sends a `POST` request.
@@ -277,8 +277,8 @@ def put(
     allow_redirects: bool = True,
     cert: CertTypes = None,
     verify: VerifyTypes = True,
-    timeout: TimeoutTypes = None,
-    trust_env: bool = None,
+    timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
+    trust_env: bool = True,
 ) -> Response:
     """
     Sends a `PUT` request.
@@ -318,8 +318,8 @@ def patch(
     allow_redirects: bool = True,
     cert: CertTypes = None,
     verify: VerifyTypes = True,
-    timeout: TimeoutTypes = None,
-    trust_env: bool = None,
+    timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
+    trust_env: bool = True,
 ) -> Response:
     """
     Sends a `PATCH` request.
@@ -356,8 +356,8 @@ def delete(
     allow_redirects: bool = True,
     cert: CertTypes = None,
     verify: VerifyTypes = True,
-    timeout: TimeoutTypes = None,
-    trust_env: bool = None,
+    timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
+    trust_env: bool = True,
 ) -> Response:
     """
     Sends a `DELETE` request.


### PR DESCRIPTION
Think this is what's needed for #505

I'd love to add a test for it but couldn't think of any sensible way of doing. Tried messing around with mocking the Client object and seeing the attributes that were set in the request function call but didn't pan out as hoped.

Any suggestions for tests?

I'd be happy to add one.

Let me know if I should remove timeout, cert, verify and leave only trust_env.