### PR TITLE
Fix redirect cookie behavior

### DIFF
--- a/httpx/middleware/redirect.py
+++ b/httpx/middleware/redirect.py
@@ -115,6 +115,11 @@ class RedirectMiddleware(BaseMiddleware):
             # are only relevant to the request body.
             headers.pop("Content-Length", None)
             headers.pop("Transfer-Encoding", None)
+
+        # We should use the client cookie store to determine any cookie header,
+        # rather than whatever was on the original outgoing request.
+        headers.pop("Cookie", None)
+
         return headers
 
     def redirect_content(self, request: AsyncRequest, method: str) -> bytes:

--- a/httpx/middleware/redirect.py
+++ b/httpx/middleware/redirect.py
@@ -51,7 +51,6 @@ class RedirectMiddleware(BaseMiddleware):
         headers = self.redirect_headers(request, url, method)  # TODO: merge headers?
         content = self.redirect_content(request, method)
         cookies = Cookies(self.cookies)
-        cookies.update(request.cookies)
         return AsyncRequest(
             method=method, url=url, headers=headers, data=content, cookies=cookies
         )

--- a/noxfile.py
+++ b/noxfile.py
@@ -24,13 +24,7 @@ def lint(session):
 @nox.session
 def check(session):
     session.install(
-        "--upgrade",
-        "black",
-        "flake8",
-        "flake8-bugbear",
-        "flake8-pie",
-        "isort",
-        "mypy",
+        "--upgrade", "black", "flake8", "flake8-bugbear", "flake8-pie", "isort", "mypy"
     )
 
     session.run("black", "--check", "--diff", "--target-version=py36", *source_files)

--- a/noxfile.py
+++ b/noxfile.py
@@ -28,7 +28,6 @@ def check(session):
         "black",
         "flake8",
         "flake8-bugbear",
-        "flake8-comprehensions",
         "flake8-pie",
         "isort",
         "mypy",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,7 +6,6 @@ brotlipy==0.7.*
 cryptography
 flake8
 flake8-bugbear
-flake8-comprehensions
 flake8-pie
 isort
 mypy

--- a/tests/client/test_redirects.py
+++ b/tests/client/test_redirects.py
@@ -301,7 +301,6 @@ class MockCookieDispatch(AsyncDispatcher):
         timeout: TimeoutTypes = None,
     ) -> AsyncResponse:
         if request.url.path == "/":
-            print(request.headers)
             if "cookie" in request.headers:
                 content = b"Logged in"
             else:

--- a/tests/client/test_redirects.py
+++ b/tests/client/test_redirects.py
@@ -312,7 +312,10 @@ class MockCookieDispatch(AsyncDispatcher):
             status_code = codes.SEE_OTHER
             headers = {
                 "location": "/",
-                "set-cookie": "session=eyJ1c2VybmFtZSI6ICJ0b21; path=/; Max-Age=1209600; httponly; samesite=lax",
+                "set-cookie": (
+                    "session=eyJ1c2VybmFtZSI6ICJ0b21; path=/; Max-Age=1209600; "
+                    "httponly; samesite=lax"
+                ),
             }
 
             return AsyncResponse(status_code, headers=headers, request=request)
@@ -321,7 +324,10 @@ class MockCookieDispatch(AsyncDispatcher):
             status_code = codes.SEE_OTHER
             headers = {
                 "location": "/",
-                "set-cookie": "session=null; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; httponly; samesite=lax",
+                "set-cookie": (
+                    "session=null; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; "
+                    "httponly; samesite=lax"
+                ),
             }
             return AsyncResponse(status_code, headers=headers, request=request)
 

--- a/tests/client/test_redirects.py
+++ b/tests/client/test_redirects.py
@@ -302,17 +302,17 @@ class MockCookieDispatch(AsyncDispatcher):
     ) -> AsyncResponse:
         if request.url.path == "/":
             print(request.headers)
-            if 'cookie' in request.headers:
-                content = b'Logged in'
+            if "cookie" in request.headers:
+                content = b"Logged in"
             else:
-                content = b'Not logged in'
+                content = b"Not logged in"
             return AsyncResponse(codes.OK, content=content, request=request)
 
         elif request.url.path == "/login":
             status_code = codes.SEE_OTHER
             headers = {
                 "location": "/",
-                "set-cookie": 'session=eyJ1c2VybmFtZSI6ICJ0b21; path=/; Max-Age=1209600; httponly; samesite=lax'
+                "set-cookie": "session=eyJ1c2VybmFtZSI6ICJ0b21; path=/; Max-Age=1209600; httponly; samesite=lax",
             }
 
             return AsyncResponse(status_code, headers=headers, request=request)
@@ -321,7 +321,7 @@ class MockCookieDispatch(AsyncDispatcher):
             status_code = codes.SEE_OTHER
             headers = {
                 "location": "/",
-                "set-cookie": 'session=null; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; httponly; samesite=lax'
+                "set-cookie": "session=null; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; httponly; samesite=lax",
             }
             return AsyncResponse(status_code, headers=headers, request=request)
 
@@ -332,24 +332,24 @@ async def test_redirect_cookie_behavior(backend):
     # The client is not logged in.
     response = await client.get("https://example.com/")
     assert response.url == "https://example.com/"
-    assert response.text == 'Not logged in'
+    assert response.text == "Not logged in"
 
     # Login redirects to the homepage, setting a session cookie.
     response = await client.post("https://example.com/login")
     assert response.url == "https://example.com/"
-    assert response.text == 'Logged in'
+    assert response.text == "Logged in"
 
     # The client is logged in.
     response = await client.get("https://example.com/")
     assert response.url == "https://example.com/"
-    assert response.text == 'Logged in'
+    assert response.text == "Logged in"
 
     # Logout redirects to the homepage, expiring the session cookie.
     response = await client.post("https://example.com/logout")
     assert response.url == "https://example.com/"
-    assert response.text == 'Not logged in'
+    assert response.text == "Not logged in"
 
     # The client is not logged in.
     response = await client.get("https://example.com/")
     assert response.url == "https://example.com/"
-    assert response.text == 'Not logged in'
+    assert response.text == "Not logged in"


### PR DESCRIPTION
Cookies are not being properly handled by redirect responses.
(Specifically, expired cookies in a response, are still included in any redirect request)
