### PR TITLE
Release 0.7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.7.8 (November 17, 2019)
+
+### Added
+
+- Add support for proxy tunnels for Python 3.6 + asyncio. (Pull #521)
+
 ## 0.7.7 (November 15, 2019)
 
 ### Fixed

--- a/httpx/__version__.py
+++ b/httpx/__version__.py
@@ -1,3 +1,3 @@
 __title__ = "httpx"
 __description__ = "A next generation HTTP client, for Python 3."
-__version__ = "0.7.7"
+__version__ = "0.7.8"


### PR DESCRIPTION
Figured 3.6 proxy tunnel support (ref #515) was important enough to be worth a release already. :-)