### PR TITLE
Preserve list type query paramaters when merging QueryParams objects

### DIFF
--- a/httpx/models.py
+++ b/httpx/models.py
@@ -351,7 +351,12 @@ class QueryParams(typing.Mapping[str, str]):
 
         params = QueryParams(params)
         for param in params:
-            self[param] = params[param]
+            item, *extras = params.getlist(param)
+            self[param] = item
+            if extras:
+                self._list.extend((param, e) for e in extras)
+                # ensure getter matches merged QueryParams getter
+                self._dict[param] = params[param]
 
     def __getitem__(self, key: typing.Any) -> str:
         return self._dict[key]

--- a/tests/models/test_queryparams.py
+++ b/tests/models/test_queryparams.py
@@ -62,6 +62,9 @@ def test_queryparam_types():
     q = QueryParams({"a": 123})
     assert str(q) == "a=123"
 
+    q = QueryParams({"a": [1, 2]})
+    assert str(q) == "a=1&a=2"
+
 
 def test_queryparam_setters():
     q = QueryParams({"a": 1})
@@ -72,3 +75,10 @@ def test_queryparam_setters():
     q = QueryParams([("a", 1), ("a", 2)])
     q["a"] = "3"
     assert str(q) == "a=3"
+
+    q = QueryParams([("a", 1), ("b", 1)])
+    u = QueryParams([("b", 2), ("b", 3)])
+    q.update(u)
+
+    assert str(q) == "a=1&b=2&b=3"
+    assert q["b"] == u["b"]


### PR DESCRIPTION
Addresses: https://github.com/encode/httpx/issues/546

Attempting to address the issue, whilst keeping the element of surprise low for existing use cases.