### PR TITLE
Refactor netrc handling

### DIFF
--- a/httpx/client.py
+++ b/httpx/client.py
@@ -46,7 +46,7 @@ from .models import (
     URLTypes,
 )
 from .status_codes import codes
-from .utils import ElapsedTimer, get_environment_proxies, get_logger, NetRCInfo
+from .utils import ElapsedTimer, NetRCInfo, get_environment_proxies, get_logger
 
 logger = get_logger(__name__)
 

--- a/httpx/client.py
+++ b/httpx/client.py
@@ -1,5 +1,4 @@
 import functools
-import netrc
 import typing
 from types import TracebackType
 
@@ -47,7 +46,7 @@ from .models import (
     URLTypes,
 )
 from .status_codes import codes
-from .utils import ElapsedTimer, get_environment_proxies, get_logger, get_netrc
+from .utils import ElapsedTimer, get_environment_proxies, get_logger, NetRCInfo
 
 logger = get_logger(__name__)
 
@@ -158,6 +157,7 @@ class Client:
         self.trust_env = trust_env
         self.dispatch = dispatch
         self.concurrency_backend = backend
+        self.netrc = NetRCInfo()
 
         if proxies is None and trust_env:
             proxies = typing.cast(ProxiesTypes, get_environment_proxies())
@@ -385,13 +385,10 @@ class Client:
             return auth(request)
 
         if trust_env:
-            netrc_info = self._get_netrc()
-            if netrc_info is not None:
-                netrc_login = netrc_info.authenticators(request.url.authority)
-                netrc_username, _, netrc_password = netrc_login or ("", None, None)
-                if netrc_password is not None:
-                    auth = BasicAuth(username=netrc_username, password=netrc_password)
-                    return auth(request)
+            credentials = self.netrc.get_credentials(request.url.authority)
+            if credentials is not None:
+                auth = BasicAuth(username=credentials[0], password=credentials[1])
+                return auth(request)
 
         return request
 
@@ -562,10 +559,6 @@ class Client:
         logger.debug(f'HTTP Request: {request.method} {request.url} "{response_line}"')
 
         return response
-
-    @functools.lru_cache(1)
-    def _get_netrc(self) -> typing.Optional[netrc.netrc]:
-        return get_netrc()
 
     def _dispatcher_for_request(
         self, request: Request, proxies: typing.Dict[str, Dispatcher]

--- a/httpx/utils.py
+++ b/httpx/utils.py
@@ -104,7 +104,7 @@ class NetRCInfo:
 
     @property
     def netrc_info(self) -> typing.Optional[netrc.netrc]:
-        if not hasattr(self, '_netrc_info'):
+        if not hasattr(self, "_netrc_info"):
             self._netrc_info = None
             for file_path in self.netrc_files:
                 expanded_path = Path(file_path).expanduser()
@@ -113,7 +113,9 @@ class NetRCInfo:
                     break
         return self._netrc_info
 
-    def get_credentials(self, authority: str) -> typing.Optional[typing.Tuple[str, str]]:
+    def get_credentials(
+        self, authority: str
+    ) -> typing.Optional[typing.Tuple[str, str]]:
         if self.netrc_info is None:
             return None
 

--- a/httpx/utils.py
+++ b/httpx/utils.py
@@ -96,22 +96,31 @@ def guess_json_utf(data: bytes) -> typing.Optional[str]:
     return None
 
 
-NETRC_STATIC_FILES = (Path("~/.netrc"), Path("~/_netrc"))
+class NetRCInfo:
+    def __init__(self, files: typing.Optional[typing.List[str]] = None) -> None:
+        if files is None:
+            files = [os.getenv("NETRC", ""), "~/.netrc", "~/_netrc"]
+        self.netrc_files = files
 
+    @property
+    def netrc_info(self) -> typing.Optional[netrc.netrc]:
+        if not hasattr(self, '_netrc_info'):
+            self._netrc_info = None
+            for file_path in self.netrc_files:
+                expanded_path = Path(file_path).expanduser()
+                if expanded_path.is_file():
+                    self._netrc_info = netrc.netrc(str(expanded_path))
+                    break
+        return self._netrc_info
 
-def get_netrc() -> typing.Optional[netrc.netrc]:
-    NETRC_FILES = (Path(os.getenv("NETRC", "")),) + NETRC_STATIC_FILES
-    netrc_path = None
+    def get_credentials(self, authority: str) -> typing.Optional[typing.Tuple[str, str]]:
+        if self.netrc_info is None:
+            return None
 
-    for file_path in NETRC_FILES:
-        expanded_path = file_path.expanduser()
-        if expanded_path.is_file():
-            netrc_path = expanded_path
-            break
-
-    if netrc_path is None:
-        return None
-    return netrc.netrc(str(netrc_path))
+        auth_info = self.netrc_info.authenticators(authority)
+        if auth_info is None or auth_info[2] is None:
+            return None
+        return (auth_info[0], auth_info[2])
 
 
 def get_ca_bundle_from_env() -> typing.Optional[str]:
@@ -182,7 +191,7 @@ TRACE_LOG_LEVEL = 5
 class Logger(logging.Logger):
     # Stub for type checkers.
     def trace(self, message: str, *args: typing.Any, **kwargs: typing.Any) -> None:
-        ...
+        ...  # pragma: nocover
 
 
 def get_logger(name: str) -> Logger:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,7 +12,7 @@ from httpx.utils import (
     obfuscate_sensitive_headers,
     parse_header_links,
     should_not_be_proxied,
-    NetRCInfo
+    NetRCInfo,
 )
 from tests.utils import override_log_level
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,13 +6,13 @@ import pytest
 import httpx
 from httpx.utils import (
     ElapsedTimer,
+    NetRCInfo,
     get_ca_bundle_from_env,
     get_environment_proxies,
     guess_json_utf,
     obfuscate_sensitive_headers,
     parse_header_links,
     should_not_be_proxied,
-    NetRCInfo,
 )
 from tests.utils import override_log_level
 


### PR DESCRIPTION
I'm not wild about our `@functools.lru_cache(1)` on a method in the client.

I've refactored the netrc handling, in a way that I think is a little clearer about where we're holding onto state.

At the moment I've used `self.netrc = NetRCInfo()` on the client instance. We're looking up the netrc file on a per-client basis, and changes to the environment are reflected if you instantiate a new client.

If we really wanted we *could* potentially switch to a global `NETRC = NetRCInfo()` instead, and only ever make a single lookup, but I think scoping to the client is probably the sensible thing to do.