### PR TITLE
Drop `iterate_in_threadpool` and `iterate`

### DIFF
--- a/httpx/concurrency/base.py
+++ b/httpx/concurrency/base.py
@@ -134,13 +134,6 @@ class ConcurrencyBackend:
     ) -> typing.Any:
         raise NotImplementedError()  # pragma: no cover
 
-    def iterate(self, async_iterator):  # type: ignore
-        while True:
-            try:
-                yield self.run(async_iterator.__anext__)
-            except StopAsyncIteration:
-                break
-
     def create_event(self) -> BaseEvent:
         raise NotImplementedError()  # pragma: no cover
 

--- a/httpx/concurrency/base.py
+++ b/httpx/concurrency/base.py
@@ -129,22 +129,6 @@ class ConcurrencyBackend:
     ) -> typing.Any:
         raise NotImplementedError()  # pragma: no cover
 
-    async def iterate_in_threadpool(self, iterator):  # type: ignore
-        class IterationComplete(Exception):
-            pass
-
-        def next_wrapper(iterator):  # type: ignore
-            try:
-                return next(iterator)
-            except StopIteration:
-                raise IterationComplete()
-
-        while True:
-            try:
-                yield await self.run_in_threadpool(next_wrapper, iterator)
-            except IterationComplete:
-                break
-
     def run(
         self, coroutine: typing.Callable, *args: typing.Any, **kwargs: typing.Any
     ) -> typing.Any:


### PR DESCRIPTION
Drop unneccessary `iterate_in_threadpool` and `iterate` from concurrency backends.