### PR TITLE
Add `Response.is_error`

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -14,6 +14,7 @@ to the API in our own documentation. The following exceptions apply:
 but also provide lower-cased versions for API compatibility with `requests`.
 * `stream=True`. - Streaming responses provide the `.stream()` and `.raw()` byte iterator interfaces, rather than the `.iter_content()` method and the `.raw` socket interface.
 * `.get`, `.delete`, `.head`, `.options` -  These methods do not support `files`, `data`, or `json` arguments. Use `.request` if you need to need to send data using these http methods.
+* We don't support `response.is_ok` since the naming is ambiguous there, and might incorrectly imply an equivalence to `response.status_code == codes.OK`. Instead we provide an `.is_error` property.
 
 ## Advanced Usage
 

--- a/httpx/models.py
+++ b/httpx/models.py
@@ -847,6 +847,10 @@ class Response:
         return self._decoder
 
     @property
+    def is_error(self) -> bool:
+        return StatusCode.is_error(self.status_code)
+
+    @property
     def is_redirect(self) -> bool:
         return StatusCode.is_redirect(self.status_code) and "location" in self.headers
 
@@ -861,11 +865,9 @@ class Response:
 
         if StatusCode.is_client_error(self.status_code):
             message = message.format(self, error_type="Client Error")
+            raise HTTPError(message, response=self)
         elif StatusCode.is_server_error(self.status_code):
             message = message.format(self, error_type="Server Error")
-        else:
-            message = ""
-        if message:
             raise HTTPError(message, response=self)
 
     def json(self, **kwargs: typing.Any) -> typing.Union[dict, list]:

--- a/httpx/status_codes.py
+++ b/httpx/status_codes.py
@@ -50,6 +50,10 @@ class StatusCode(IntEnum):
         )
 
     @classmethod
+    def is_error(cls, value: int) -> bool:
+        return 400 <= value <= 599
+
+    @classmethod
     def is_client_error(cls, value: int) -> bool:
         return 400 <= value <= 499
 

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -23,6 +23,7 @@ def test_response():
     assert response.reason_phrase == "OK"
     assert response.text == "Hello, world!"
     assert response.elapsed == datetime.timedelta(0)
+    assert not response.is_error
 
 
 def test_response_repr():


### PR DESCRIPTION
Adds a `response.is_error` property, which closes #543

Our section in the requests compat docs details httpx's usage of `response.is_error` vs. requests' usage of `response.is_ok`...

> We don't support `response.is_ok` since the naming is ambiguous there, and might incorrectly imply an equivalence to `response.status_code == codes.OK`. Instead we provide an `.is_error` property.

What do we think?