### PR TITLE
WIP: Add PoolLimitTypes

### DIFF
--- a/httpx/client.py
+++ b/httpx/client.py
@@ -13,7 +13,7 @@ from .config import (
     DEFAULT_TIMEOUT_CONFIG,
     CertTypes,
     HTTPVersionTypes,
-    PoolLimits,
+    PoolLimitTypes,
     TimeoutTypes,
     VerifyTypes,
 )
@@ -114,7 +114,7 @@ class Client:
         http_versions: HTTPVersionTypes = None,
         proxies: ProxiesTypes = None,
         timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
-        pool_limits: PoolLimits = DEFAULT_POOL_LIMITS,
+        pool_limits: PoolLimitTypes = DEFAULT_POOL_LIMITS,
         max_redirects: int = DEFAULT_MAX_REDIRECTS,
         base_url: URLTypes = None,
         dispatch: Dispatcher = None,


### PR DESCRIPTION
Support setting the pool limits as an integer, or as an integer pair.

Usage:

```python
client = Client(pool_limits=100)  # Max 100 connections in the pool.
```

```python
client = Client(pool_limits=(10, 100))  # Hold up to 10 connections idle. Max 100 connections in the pool.
```