### PR TITLE
Drop write_no_block from backends.

### DIFF
--- a/httpx/concurrency/asyncio.py
+++ b/httpx/concurrency/asyncio.py
@@ -162,9 +162,6 @@ class SocketStream(BaseSocketStream):
 
         return data
 
-    def write_no_block(self, data: bytes) -> None:
-        self.stream_writer.write(data)  # pragma: nocover
-
     async def write(
         self, data: bytes, timeout: Timeout = None, flag: TimeoutFlag = None
     ) -> None:

--- a/httpx/concurrency/base.py
+++ b/httpx/concurrency/base.py
@@ -77,9 +77,6 @@ class BaseSocketStream:
     async def read(self, n: int, timeout: Timeout, flag: typing.Any = None) -> bytes:
         raise NotImplementedError()  # pragma: no cover
 
-    def write_no_block(self, data: bytes) -> None:
-        raise NotImplementedError()  # pragma: no cover
-
     async def write(self, data: bytes, timeout: Timeout) -> None:
         raise NotImplementedError()  # pragma: no cover
 

--- a/httpx/concurrency/trio.py
+++ b/httpx/concurrency/trio.py
@@ -92,9 +92,6 @@ class SocketStream(BaseSocketStream):
         # See: https://github.com/encode/httpx/pull/143#issuecomment-515181778
         return stream.socket.is_readable()
 
-    def write_no_block(self, data: bytes) -> None:
-        self.write_buffer += data  # pragma: no cover
-
     async def write(
         self, data: bytes, timeout: Timeout = None, flag: TimeoutFlag = None
     ) -> None:


### PR DESCRIPTION
A little bit of rationalization of our HTTP/2 handling, so that we can drop the quirky "write_no_block" primitive from our backend API.

I want to follow this up with some more substantial clean ups of our HTTP/2 implementation, but let's do this incrementally. 