### PR TITLE
Consistent suite of `stream_*` methods

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -63,8 +63,10 @@
 * `def .raise_for_status()` - **None**
 * `def .json()` - **Any**
 * `def .read()` - **bytes**
-* `def .stream()` - **bytes iterator**
-* `def .raw()` - **bytes iterator**
+* `def .stream_raw()` - **async bytes iterator**
+* `def .stream_bytes()` - **async bytes iterator**
+* `def .stream_text()` - **async text iterator**
+* `def .stream_lines()` - **async text iterator**
 * `def .close()` - **None**
 * `def .next()` - **Response**
 

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -71,7 +71,7 @@ async def test_stream_iterator(server):
         response = await client.get(server.url, stream=True)
     assert response.status_code == 200
     body = b""
-    async for chunk in response.stream():
+    async for chunk in response.stream_bytes():
         body += chunk
     assert body == b"Hello, world!"
 
@@ -82,7 +82,7 @@ async def test_raw_iterator(server):
         response = await client.get(server.url, stream=True)
     assert response.status_code == 200
     body = b""
-    async for chunk in response.raw():
+    async for chunk in response.stream_raw():
         body += chunk
     assert body == b"Hello, world!"
     await response.close()

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -137,7 +137,7 @@ async def test_raw_interface():
     response = httpx.Response(200, content=b"Hello, world!")
 
     raw = b""
-    async for part in response.raw():
+    async for part in response.stream_raw():
         raw += part
     assert raw == b"Hello, world!"
 
@@ -147,7 +147,7 @@ async def test_stream_interface():
     response = httpx.Response(200, content=b"Hello, world!")
 
     content = b""
-    async for part in response.stream():
+    async for part in response.stream_bytes():
         content += part
     assert content == b"Hello, world!"
 
@@ -183,7 +183,7 @@ async def test_stream_interface_after_read():
     await response.read()
 
     content = b""
-    async for part in response.stream():
+    async for part in response.stream_bytes():
         content += part
     assert content == b"Hello, world!"
 
@@ -207,7 +207,7 @@ async def test_cannot_read_after_stream_consumed():
     response = httpx.Response(200, content=async_streaming_body())
 
     content = b""
-    async for part in response.stream():
+    async for part in response.stream_bytes():
         content += part
 
     with pytest.raises(httpx.StreamConsumed):


### PR DESCRIPTION
Renames `.raw()` to `.stream_raw()`, and renames `.stream()` to `.stream_bytes()`, so that we have a nice consistent suite of streaming operations...

* `response.stream_raw()`
* `response.stream_bytes)`
* `response.stream_text()`
* `response.stream_lines()`

Plus also...

* `response.read()`, `response.close()`

The existing `.raw` and `.stream` methods remain for compat, but issue warnings.

This is the first part of #588

We don't yet have any streaming docs. We might want to wait until we also address the second part of this work, and add the documentation as part of *that* pull request rather than *this* one, since we've got some new API that we want to add there.