### PR TITLE
Add `OpenedConnection` base class.

### DIFF
--- a/httpx/dispatch/base.py
+++ b/httpx/dispatch/base.py
@@ -1,6 +1,7 @@
 import typing
 from types import TracebackType
 
+from ..concurrency.base import BaseSocketStream, ConcurrencyBackend
 from ..config import CertTypes, Timeout, VerifyTypes
 from ..models import (
     HeaderTypes,
@@ -58,3 +59,30 @@ class Dispatcher:
         traceback: TracebackType = None,
     ) -> None:
         await self.close()
+
+
+class OpenedHTTPConnection:
+    """
+    An HTTP connection that has already been established.
+    """
+
+    def __init__(
+        self,
+        socket: BaseSocketStream,
+        backend: typing.Union[str, ConcurrencyBackend] = "auto",
+        on_release: typing.Callable = None,
+    ):
+        raise NotImplementedError()  # pragma: nocover
+
+    async def send(self, request: Request, timeout: Timeout = None) -> Response:
+        raise NotImplementedError()  # pragma: nocover
+
+    async def close(self) -> None:
+        raise NotImplementedError()  # pragma: nocover
+
+    @property
+    def is_closed(self) -> bool:
+        raise NotImplementedError()  # pragma: nocover
+
+    def is_connection_dropped(self) -> bool:
+        raise NotImplementedError()  # pragma: nocover

--- a/httpx/dispatch/connection.py
+++ b/httpx/dispatch/connection.py
@@ -6,7 +6,7 @@ from ..concurrency.base import ConcurrencyBackend, lookup_backend
 from ..config import CertTypes, SSLConfig, Timeout, VerifyTypes
 from ..models import Origin, Request, Response
 from ..utils import get_logger
-from .base import Dispatcher
+from .base import Dispatcher, OpenedHTTPConnection
 from .http2 import HTTP2Connection
 from .http11 import HTTP11Connection
 
@@ -35,8 +35,8 @@ class HTTPConnection(Dispatcher):
         self.backend = lookup_backend(backend)
         self.release_func = release_func
         self.uds = uds
-        self.h11_connection = None  # type: typing.Optional[HTTP11Connection]
-        self.h2_connection = None  # type: typing.Optional[HTTP2Connection]
+        self.h11_connection = None  # type: typing.Optional[OpenedHTTPConnection]
+        self.h2_connection = None  # type: typing.Optional[OpenedHTTPConnection]
 
     async def send(
         self,

--- a/httpx/dispatch/http11.py
+++ b/httpx/dispatch/http11.py
@@ -7,6 +7,7 @@ from ..config import Timeout
 from ..exceptions import ConnectionClosed, ProtocolError
 from ..models import Request, Response
 from ..utils import get_logger
+from .base import OpenedHTTPConnection
 
 H11Event = typing.Union[
     h11.Request,
@@ -27,7 +28,7 @@ OnReleaseCallback = typing.Callable[[], typing.Awaitable[None]]
 logger = get_logger(__name__)
 
 
-class HTTP11Connection:
+class HTTP11Connection(OpenedHTTPConnection):
     READ_NUM_BYTES = 4096
 
     def __init__(

--- a/httpx/dispatch/http2.py
+++ b/httpx/dispatch/http2.py
@@ -16,11 +16,12 @@ from ..config import Timeout
 from ..exceptions import ProtocolError
 from ..models import Request, Response
 from ..utils import get_logger
+from .base import OpenedHTTPConnection
 
 logger = get_logger(__name__)
 
 
-class HTTP2Connection:
+class HTTP2Connection(OpenedHTTPConnection):
     READ_NUM_BYTES = 4096
 
     def __init__(


### PR DESCRIPTION
Establish a common interface that both `HTTP11Connection` and `HTTP2Connection` implement.

This would make it possible for `HTTPConnection` to hold a single `connection = typing.Optional[OpenedConnection]` rather than having specific instances for each of the H11 and H2 cases.

That'd also then allow us to switch to conditional imports of HTTP2Connection, only if `h2` is installed.

The blocker here right now is that `http_proxy` currently reaches into the H11 implementation.
