### PR TITLE
Version 0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Master
+## 0.9.0 (December 6th, 2019)
+
+The 0.9 releases brings some major new features, including:
+
+* A new streaming API.
+* Autodetection of either asyncio or trio.
+* Nicer timeout configuration.
+* HTTP/2 support off by default, but can be enabled.
 
 ### Added
 
@@ -22,8 +29,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Added `httpx.stream()` API. Using `stream=True` now results in a warning. (Pull #600)
 - HTTP/2 support is switched to "off by default", but can be enabled explicitly. (Pull #584)
 - Switched to `Client(http2=True)` API from `Client(http_versions=["HTTP/1.1", "HTTP/2"])`. (Pull #586)
+- The SSL configuration settings of `verify`, `cert`, and `trust_env` now raise warnings if used per-request when using a Client instance. They should always be set on the Client instance itself. (Pull #597)
 - Pool timeouts are now on the timeout configuration, not the pool limits configuration. (Pull #563)
 - The timeout configuration is now named `httpx.Timeout(...)`, not `httpx.TimeoutConfig(...)`. The old version currently remains as a synonym for backwards compatability.  (Pull #591)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ The 0.9 releases brings some major new features, including:
 * Nicer timeout configuration.
 * HTTP/2 support off by default, but can be enabled.
 
+We've also removed all private types from the top-level package export.
+
+In order to ensure you are only ever working with public API you should make
+sure to only import the top-level package eg. `import httpx`, rather than
+importing modules within the package.
+
 ### Added
 
 - Added concurrency backend autodetection. (Pull #585)
@@ -29,10 +35,12 @@ The 0.9 releases brings some major new features, including:
 
 ### Changed
 
-- Added `httpx.stream()` API. Using `stream=True` now results in a warning. (Pull #600)
+- Added `httpx.stream()` API. Using `stream=True` now results in a warning. (Pull #600, #610)
 - HTTP/2 support is switched to "off by default", but can be enabled explicitly. (Pull #584)
 - Switched to `Client(http2=True)` API from `Client(http_versions=["HTTP/1.1", "HTTP/2"])`. (Pull #586)
+- Removed all private types from the top-level package export. (Pull #608)
 - The SSL configuration settings of `verify`, `cert`, and `trust_env` now raise warnings if used per-request when using a Client instance. They should always be set on the Client instance itself. (Pull #597)
+- Use plain strings "TUNNEL_ONLY" or "FORWARD_ONLY" on the HTTPProxy `proxy_mode` argument. The `HTTPProxyMode` enum still exists, but its usage will raise warnings. (#610)
 - Pool timeouts are now on the timeout configuration, not the pool limits configuration. (Pull #563)
 - The timeout configuration is now named `httpx.Timeout(...)`, not `httpx.TimeoutConfig(...)`. The old version currently remains as a synonym for backwards compatability.  (Pull #591)
 

--- a/httpx/__version__.py
+++ b/httpx/__version__.py
@@ -1,3 +1,3 @@
 __title__ = "httpx"
 __description__ = "A next generation HTTP client, for Python 3."
-__version__ = "0.8.0"
+__version__ = "0.9.0"


### PR DESCRIPTION
I think we're about ready to go here.

Final bits to decide:

- [x] Should we use `.aiter_content()`, `.aiter_text()`, `.aiter_lines()`, `.aiter_raw()` instead of `.stream_content()` etc?... #610
- [x] Should we drop the type annotations out of the top-level exports? #608