### PR TITLE
Tighten up top-level API to only expose public API

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -243,7 +243,7 @@ Proxies can be configured to have different behavior such as forwarding or tunne
 ```python
 proxy = httpx.HTTPProxy(
     proxy_url="https://127.0.0.1",
-    proxy_mode=httpx.HTTPProxyMode.TUNNEL_ONLY
+    proxy_mode="TUNNEL_ONLY"  # May be "TUNNEL_ONLY" or "FORWARD_ONLY". Defaults to "DEFAULT".
 )
 async with httpx.Client(proxies=proxy) as client:
     # This request will be tunneled instead of forwarded.

--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -4,7 +4,7 @@ from .auth import BasicAuth, DigestAuth
 from .client import Client
 from .config import TimeoutConfig  # For 0.8 backwards compat.
 from .config import PoolLimits, Timeout
-from .dispatch.proxy_http import HTTPProxy
+from .dispatch.proxy_http import HTTPProxy, HTTPProxyMode
 from .exceptions import (
     ConnectionClosed,
     ConnectTimeout,
@@ -51,6 +51,7 @@ __all__ = [
     "Timeout",
     "TimeoutConfig",  # For 0.8 backwards compat.
     "HTTPProxy",
+    "HTTPProxyMode",  # For 0.8 backwards compat.
     "ConnectTimeout",
     "CookieConflict",
     "ConnectionClosed",

--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -2,23 +2,11 @@ from .__version__ import __description__, __title__, __version__
 from .api import delete, get, head, options, patch, post, put, request, stream
 from .auth import BasicAuth, DigestAuth
 from .client import Client
-from .concurrency.asyncio import AsyncioBackend
-from .concurrency.base import BasePoolSemaphore, BaseSocketStream, ConcurrencyBackend
-from .config import (
-    USER_AGENT,
-    CertTypes,
-    PoolLimits,
-    SSLConfig,
-    Timeout,
-    TimeoutConfig,
-    TimeoutTypes,
-    VerifyTypes,
-)
-from .dispatch.base import Dispatcher
-from .dispatch.connection import HTTPConnection
-from .dispatch.connection_pool import ConnectionPool
-from .dispatch.proxy_http import HTTPProxy, HTTPProxyMode
+from .config import TimeoutConfig  # For 0.8 backwards compat.
+from .config import PoolLimits, Timeout
+from .dispatch.proxy_http import HTTPProxy
 from .exceptions import (
+    ConnectionClosed,
     ConnectTimeout,
     CookieConflict,
     DecodingError,
@@ -38,23 +26,7 @@ from .exceptions import (
     TooManyRedirects,
     WriteTimeout,
 )
-from .models import (
-    URL,
-    AuthTypes,
-    Cookies,
-    CookieTypes,
-    Headers,
-    HeaderTypes,
-    Origin,
-    QueryParams,
-    QueryParamTypes,
-    Request,
-    RequestData,
-    RequestFiles,
-    Response,
-    ResponseContent,
-    URLTypes,
-)
+from .models import URL, Cookies, Headers, Origin, QueryParams, Request, Response
 from .status_codes import StatusCode, codes
 
 __all__ = [
@@ -71,24 +43,17 @@ __all__ = [
     "put",
     "request",
     "stream",
+    "codes",
     "BasicAuth",
     "Client",
     "DigestAuth",
-    "AsyncioBackend",
-    "USER_AGENT",
-    "CertTypes",
     "PoolLimits",
-    "SSLConfig",
     "Timeout",
-    "TimeoutConfig",
-    "VerifyTypes",
-    "HTTPConnection",
-    "BasePoolSemaphore",
-    "ConnectionPool",
+    "TimeoutConfig",  # For 0.8 backwards compat.
     "HTTPProxy",
-    "HTTPProxyMode",
     "ConnectTimeout",
     "CookieConflict",
+    "ConnectionClosed",
     "DecodingError",
     "HTTPError",
     "InvalidURL",
@@ -106,25 +71,14 @@ __all__ = [
     "WriteTimeout",
     "BaseSocketStream",
     "ConcurrencyBackend",
-    "Dispatcher",
     "URL",
-    "URLTypes",
     "StatusCode",
-    "codes",
-    "TimeoutTypes",
-    "AuthTypes",
     "Cookies",
-    "CookieTypes",
     "Headers",
-    "HeaderTypes",
     "Origin",
     "QueryParams",
-    "QueryParamTypes",
     "Request",
-    "RequestData",
     "TimeoutException",
     "Response",
-    "ResponseContent",
-    "RequestFiles",
     "DigestAuth",
 ]

--- a/httpx/dispatch/proxy_http.py
+++ b/httpx/dispatch/proxy_http.py
@@ -1,4 +1,3 @@
-import enum
 import typing
 from base64 import b64encode
 
@@ -24,10 +23,9 @@ from .http11 import HTTP11Connection
 logger = get_logger(__name__)
 
 
-class HTTPProxyMode(enum.Enum):
-    DEFAULT = "DEFAULT"
-    FORWARD_ONLY = "FORWARD_ONLY"
-    TUNNEL_ONLY = "TUNNEL_ONLY"
+DEFAULT_MODE = "DEFAULT"
+FORWARD_ONLY = "FORWARD_ONLY"
+TUNNEL_ONLY = "TUNNEL_ONLY"
 
 
 class HTTPProxy(ConnectionPool):
@@ -40,7 +38,7 @@ class HTTPProxy(ConnectionPool):
         proxy_url: URLTypes,
         *,
         proxy_headers: HeaderTypes = None,
-        proxy_mode: HTTPProxyMode = HTTPProxyMode.DEFAULT,
+        proxy_mode: str = "DEFAULT",
         verify: VerifyTypes = True,
         cert: CertTypes = None,
         trust_env: bool = None,
@@ -48,6 +46,8 @@ class HTTPProxy(ConnectionPool):
         http2: bool = False,
         backend: typing.Union[str, ConcurrencyBackend] = "auto",
     ):
+
+        assert proxy_mode in ("DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY")
 
         super(HTTPProxy, self).__init__(
             verify=verify,
@@ -216,8 +216,8 @@ class HTTPProxy(ConnectionPool):
         tunnel all 'HTTPS' requests.
         """
         return (
-            self.proxy_mode == HTTPProxyMode.DEFAULT and not origin.is_ssl
-        ) or self.proxy_mode == HTTPProxyMode.FORWARD_ONLY
+            self.proxy_mode == DEFAULT_MODE and not origin.is_ssl
+        ) or self.proxy_mode == FORWARD_ONLY
 
     async def send(
         self,

--- a/httpx/dispatch/proxy_http.py
+++ b/httpx/dispatch/proxy_http.py
@@ -1,4 +1,5 @@
 import typing
+import warnings
 from base64 import b64encode
 
 import h11
@@ -21,6 +22,14 @@ from .http2 import HTTP2Connection
 from .http11 import HTTP11Connection
 
 logger = get_logger(__name__)
+
+
+class HTTPProxyMode(enum.Enum):
+    # This enum is pending deprecation in order to reduce API surface area,
+    # but is currently still around for 0.8 backwards compat.
+    DEFAULT = "DEFAULT"
+    FORWARD_ONLY = "FORWARD_ONLY"
+    TUNNEL_ONLY = "TUNNEL_ONLY"
 
 
 DEFAULT_MODE = "DEFAULT"
@@ -47,6 +56,13 @@ class HTTPProxy(ConnectionPool):
         backend: typing.Union[str, ConcurrencyBackend] = "auto",
     ):
 
+        if isinstance(proxy_mode, HTTPProxyMode):
+            warnings.warn(
+                "The 'HTTPProxyMode' enum is pending deprecation. "
+                "Use a plain string instead. proxy_mode='FORWARD_ONLY', or "
+                "proxy_mode='TUNNEL_ONLY'."
+            )
+            proxy_mode = proxy_mode.value
         assert proxy_mode in ("DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY")
 
         super(HTTPProxy, self).__init__(

--- a/httpx/dispatch/proxy_http.py
+++ b/httpx/dispatch/proxy_http.py
@@ -1,3 +1,4 @@
+import enum
 import typing
 import warnings
 from base64 import b64encode

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -4,18 +4,9 @@ import os
 
 import pytest
 
-from httpx import (
-    URL,
-    CertTypes,
-    Client,
-    DigestAuth,
-    Dispatcher,
-    ProtocolError,
-    Request,
-    Response,
-    TimeoutTypes,
-    VerifyTypes,
-)
+from httpx import URL, Client, DigestAuth, ProtocolError, Request, Response
+from httpx.config import CertTypes, TimeoutTypes, VerifyTypes
+from httpx.dispatch.base import Dispatcher
 
 
 class MockDispatch(Dispatcher):

--- a/tests/client/test_cookies.py
+++ b/tests/client/test_cookies.py
@@ -3,16 +3,9 @@ from http.cookiejar import Cookie, CookieJar
 
 import pytest
 
-from httpx import (
-    CertTypes,
-    Client,
-    Cookies,
-    Dispatcher,
-    Request,
-    Response,
-    TimeoutTypes,
-    VerifyTypes,
-)
+from httpx import Client, Cookies, Request, Response
+from httpx.config import CertTypes, TimeoutTypes, VerifyTypes
+from httpx.dispatch.base import Dispatcher
 
 
 class MockDispatch(Dispatcher):

--- a/tests/client/test_headers.py
+++ b/tests/client/test_headers.py
@@ -4,17 +4,9 @@ import json
 
 import pytest
 
-from httpx import (
-    CertTypes,
-    Client,
-    Dispatcher,
-    Request,
-    Response,
-    TimeoutTypes,
-    VerifyTypes,
-    __version__,
-    models,
-)
+from httpx import Client, Headers, Request, Response, __version__
+from httpx.config import CertTypes, TimeoutTypes, VerifyTypes
+from httpx.dispatch.base import Dispatcher
 
 
 class MockDispatch(Dispatcher):
@@ -132,7 +124,7 @@ async def test_header_update():
 
 
 def test_header_does_not_exist():
-    headers = models.Headers({"foo": "bar"})
+    headers = Headers({"foo": "bar"})
     with pytest.raises(KeyError):
         del headers["baz"]
 

--- a/tests/client/test_proxies.py
+++ b/tests/client/test_proxies.py
@@ -40,7 +40,6 @@ def test_proxies_has_same_properties_as_dispatch():
     pool = client.dispatch
     proxy = client.proxies["all"]
 
-    assert isinstance(pool, httpx.ConnectionPool)
     assert isinstance(proxy, httpx.HTTPProxy)
 
     for prop in [
@@ -101,7 +100,6 @@ def test_dispatcher_for_request(url, proxies, expected):
     dispatcher = client.dispatcher_for_url(httpx.URL(url))
 
     if expected is None:
-        assert isinstance(dispatcher, httpx.ConnectionPool)
         assert dispatcher is client.dispatch
     else:
         assert isinstance(dispatcher, httpx.HTTPProxy)

--- a/tests/client/test_queryparams.py
+++ b/tests/client/test_queryparams.py
@@ -2,17 +2,9 @@ import json
 
 import pytest
 
-from httpx import (
-    CertTypes,
-    Client,
-    Dispatcher,
-    QueryParams,
-    Request,
-    Response,
-    TimeoutTypes,
-    VerifyTypes,
-)
-from httpx.models import URL
+from httpx import URL, Client, QueryParams, Request, Response
+from httpx.config import CertTypes, TimeoutTypes, VerifyTypes
+from httpx.dispatch.base import Dispatcher
 
 
 class MockDispatch(Dispatcher):

--- a/tests/client/test_redirects.py
+++ b/tests/client/test_redirects.py
@@ -5,19 +5,17 @@ import pytest
 
 from httpx import (
     URL,
-    CertTypes,
     Client,
-    Dispatcher,
     NotRedirectResponse,
     RedirectBodyUnavailable,
     RedirectLoop,
     Request,
     Response,
-    TimeoutTypes,
     TooManyRedirects,
-    VerifyTypes,
     codes,
 )
+from httpx.config import CertTypes, TimeoutTypes, VerifyTypes
+from httpx.dispatch.base import Dispatcher
 
 
 class MockDispatch(Dispatcher):

--- a/tests/concurrency.py
+++ b/tests/concurrency.py
@@ -9,7 +9,7 @@ import typing
 
 import trio
 
-from httpx import AsyncioBackend
+from httpx.concurrency.asyncio import AsyncioBackend
 from httpx.concurrency.trio import TrioBackend
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,8 @@ from cryptography.hazmat.primitives.serialization import (
 from uvicorn.config import Config
 from uvicorn.main import Server
 
-from httpx import URL, AsyncioBackend
+from httpx import URL
+from httpx.concurrency.asyncio import AsyncioBackend
 from httpx.concurrency.trio import TrioBackend
 
 ENVIRONMENT_VARIABLES = {

--- a/tests/dispatch/test_connections.py
+++ b/tests/dispatch/test_connections.py
@@ -1,6 +1,7 @@
 import pytest
 
-from httpx import HTTPConnection, exceptions
+import httpx
+from httpx.dispatch.connection import HTTPConnection
 
 
 async def test_get(server, backend):
@@ -18,7 +19,7 @@ async def test_post(server, backend):
 
 
 async def test_premature_close(server, backend):
-    with pytest.raises(exceptions.ConnectionClosed):
+    with pytest.raises(httpx.ConnectionClosed):
         async with HTTPConnection(origin=server.url, backend=backend) as conn:
             response = await conn.request(
                 "GET", server.url.copy_with(path="/premature_close")

--- a/tests/dispatch/test_proxy_http.py
+++ b/tests/dispatch/test_proxy_http.py
@@ -22,9 +22,7 @@ async def test_proxy_tunnel_success(backend):
         backend=backend,
     )
     async with httpx.HTTPProxy(
-        proxy_url="http://127.0.0.1:8000",
-        backend=raw_io,
-        proxy_mode=httpx.HTTPProxyMode.TUNNEL_ONLY,
+        proxy_url="http://127.0.0.1:8000", backend=raw_io, proxy_mode="TUNNEL_ONLY",
     ) as proxy:
         response = await proxy.request("GET", "http://example.com")
 
@@ -60,9 +58,7 @@ async def test_proxy_tunnel_non_2xx_response(backend, status_code):
 
     with pytest.raises(httpx.ProxyError) as e:
         async with httpx.HTTPProxy(
-            proxy_url="http://127.0.0.1:8000",
-            backend=raw_io,
-            proxy_mode=httpx.HTTPProxyMode.TUNNEL_ONLY,
+            proxy_url="http://127.0.0.1:8000", backend=raw_io, proxy_mode="TUNNEL_ONLY",
         ) as proxy:
             await proxy.request("GET", "http://example.com")
 
@@ -112,9 +108,7 @@ async def test_proxy_tunnel_start_tls(backend):
         backend=backend,
     )
     async with httpx.HTTPProxy(
-        proxy_url="http://127.0.0.1:8000",
-        backend=raw_io,
-        proxy_mode=httpx.HTTPProxyMode.TUNNEL_ONLY,
+        proxy_url="http://127.0.0.1:8000", backend=raw_io, proxy_mode="TUNNEL_ONLY",
     ) as proxy:
         resp = await proxy.request("GET", "https://example.com")
 
@@ -150,9 +144,7 @@ async def test_proxy_tunnel_start_tls(backend):
     assert recv[4].startswith(b"GET /target HTTP/1.1\r\nhost: example.com\r\n")
 
 
-@pytest.mark.parametrize(
-    "proxy_mode", [httpx.HTTPProxyMode.FORWARD_ONLY, httpx.HTTPProxyMode.DEFAULT]
-)
+@pytest.mark.parametrize("proxy_mode", ["FORWARD_ONLY", "DEFAULT"])
 async def test_proxy_forwarding(backend, proxy_mode):
     raw_io = MockRawSocketBackend(
         data_to_send=(
@@ -204,11 +196,11 @@ def test_proxy_repr():
     proxy = httpx.HTTPProxy(
         "http://127.0.0.1:1080",
         proxy_headers={"Custom": "Header"},
-        proxy_mode=httpx.HTTPProxyMode.DEFAULT,
+        proxy_mode="DEFAULT",
     )
 
     assert repr(proxy) == (
         "HTTPProxy(proxy_url=URL('http://127.0.0.1:1080') "
         "proxy_headers=Headers({'custom': 'Header'}) "
-        "proxy_mode=<HTTPProxyMode.DEFAULT: 'DEFAULT'>)"
+        "proxy_mode='DEFAULT')"
     )

--- a/tests/dispatch/utils.py
+++ b/tests/dispatch/utils.py
@@ -5,7 +5,9 @@ import h2.config
 import h2.connection
 import h2.events
 
-from httpx import AsyncioBackend, BaseSocketStream, Request, Timeout
+from httpx import Request, Timeout
+from httpx.concurrency.asyncio import AsyncioBackend
+from httpx.concurrency.base import BaseSocketStream
 from tests.concurrency import sleep
 
 

--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -1,7 +1,6 @@
 import pytest
 
-from httpx import URL, Origin
-from httpx.exceptions import InvalidURL
+from httpx import URL, InvalidURL, Origin
 
 
 @pytest.mark.parametrize(

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,8 +1,10 @@
 import pytest
 import trio
 
-from httpx import AsyncioBackend, SSLConfig, Timeout
+from httpx import Timeout
+from httpx.concurrency.asyncio import AsyncioBackend
 from httpx.concurrency.trio import TrioBackend
+from httpx.config import SSLConfig
 from tests.concurrency import run_concurrently, sleep
 
 

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -108,7 +108,7 @@ def test_decoding_errors(header_value):
     headers = [(b"Content-Encoding", header_value)]
     body = b"test 123"
     compressed_body = brotli.compress(body)[3:]
-    with pytest.raises(httpx.exceptions.DecodingError):
+    with pytest.raises(httpx.DecodingError):
         response = httpx.Response(200, headers=headers, content=compressed_body)
         response.content
 

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -1,49 +1,41 @@
 import pytest
 
-from httpx import (
-    Client,
-    ConnectTimeout,
-    PoolLimits,
-    PoolTimeout,
-    ReadTimeout,
-    Timeout,
-    WriteTimeout,
-)
+import httpx
 
 
 async def test_read_timeout(server, backend):
-    timeout = Timeout(read_timeout=1e-6)
+    timeout = httpx.Timeout(read_timeout=1e-6)
 
-    async with Client(timeout=timeout, backend=backend) as client:
-        with pytest.raises(ReadTimeout):
+    async with httpx.Client(timeout=timeout, backend=backend) as client:
+        with pytest.raises(httpx.ReadTimeout):
             await client.get(server.url.copy_with(path="/slow_response"))
 
 
 async def test_write_timeout(server, backend):
-    timeout = Timeout(write_timeout=1e-6)
+    timeout = httpx.Timeout(write_timeout=1e-6)
 
-    async with Client(timeout=timeout, backend=backend) as client:
-        with pytest.raises(WriteTimeout):
+    async with httpx.Client(timeout=timeout, backend=backend) as client:
+        with pytest.raises(httpx.WriteTimeout):
             data = b"*" * 1024 * 1024 * 100
             await client.put(server.url.copy_with(path="/slow_response"), data=data)
 
 
 async def test_connect_timeout(server, backend):
-    timeout = Timeout(connect_timeout=1e-6)
+    timeout = httpx.Timeout(connect_timeout=1e-6)
 
-    async with Client(timeout=timeout, backend=backend) as client:
-        with pytest.raises(ConnectTimeout):
+    async with httpx.Client(timeout=timeout, backend=backend) as client:
+        with pytest.raises(httpx.ConnectTimeout):
             # See https://stackoverflow.com/questions/100841/
             await client.get("http://10.255.255.1/")
 
 
 async def test_pool_timeout(server, backend):
-    pool_limits = PoolLimits(hard_limit=1)
-    timeout = Timeout(pool_timeout=1e-4)
+    pool_limits = httpx.PoolLimits(hard_limit=1)
+    timeout = httpx.Timeout(pool_timeout=1e-4)
 
-    async with Client(
+    async with httpx.Client(
         pool_limits=pool_limits, timeout=timeout, backend=backend
     ) as client:
         async with client.stream("GET", server.url):
-            with pytest.raises(PoolTimeout):
+            with pytest.raises(httpx.PoolTimeout):
                 await client.get("http://localhost:8000/")


### PR DESCRIPTION
Drops various private API from the top-level API.

We should recommend that our users *only* import the top-level `httpx` package, rather than importing sub-modules, in order to help guide them towards public API only.

Eg.

✅ Approved usage:

```python
import httpx
httpx.URL(...)
```

⚠️ Uh-oh:
```python
from httpx.models import URL
URL(...)
```

Refs #606