### PR TITLE
Drop TimeoutFlag

### DIFF
--- a/httpx/concurrency/base.py
+++ b/httpx/concurrency/base.py
@@ -26,38 +26,6 @@ def lookup_backend(
     raise RuntimeError(f"Unknown or unsupported concurrency backend {backend!r}")
 
 
-class TimeoutFlag:
-    """
-    A timeout flag holds a state of either read-timeout or write-timeout mode.
-
-    We use this so that we can attempt both reads and writes concurrently, while
-    only enforcing timeouts in one direction.
-
-    During a request/response cycle we start in write-timeout mode.
-
-    Once we've sent a request fully, or once we start seeing a response,
-    then we switch to read-timeout mode instead.
-    """
-
-    def __init__(self) -> None:
-        self.raise_on_read_timeout = False
-        self.raise_on_write_timeout = True
-
-    def set_read_timeouts(self) -> None:
-        """
-        Set the flag to read-timeout mode.
-        """
-        self.raise_on_read_timeout = True
-        self.raise_on_write_timeout = False
-
-    def set_write_timeouts(self) -> None:
-        """
-        Set the flag to write-timeout mode.
-        """
-        self.raise_on_read_timeout = False
-        self.raise_on_write_timeout = True
-
-
 class BaseSocketStream:
     """
     A socket stream with read/write operations. Abstracts away any asyncio-specific
@@ -73,7 +41,7 @@ class BaseSocketStream:
     ) -> "BaseSocketStream":
         raise NotImplementedError()  # pragma: no cover
 
-    async def read(self, n: int, timeout: Timeout, flag: typing.Any = None) -> bytes:
+    async def read(self, n: int, timeout: Timeout) -> bytes:
         raise NotImplementedError()  # pragma: no cover
 
     async def write(self, data: bytes, timeout: Timeout) -> None:


### PR DESCRIPTION
Now that we always just "send a request, read the response" rather than any fancy "start sending the request, and start reading a response" we can drop the rather awkward `TimeoutFlag` that allowed us to switch from read timeouts to write timeouts as soon as we started seeing any response data.