### PR TITLE
Drop 'fork'

### DIFF
--- a/httpx/concurrency/asyncio.py
+++ b/httpx/concurrency/asyncio.py
@@ -299,28 +299,6 @@ class AsyncioBackend(ConcurrencyBackend):
         finally:
             self._loop = loop
 
-    async def fork(
-        self,
-        coroutine1: typing.Callable,
-        args1: typing.Sequence,
-        coroutine2: typing.Callable,
-        args2: typing.Sequence,
-    ) -> None:
-        task1 = self.loop.create_task(coroutine1(*args1))
-        task2 = self.loop.create_task(coroutine2(*args2))
-
-        try:
-            await asyncio.gather(task1, task2)
-        finally:
-            pending: typing.Set[asyncio.Future[typing.Any]]  # Please mypy.
-            _, pending = await asyncio.wait({task1, task2}, timeout=0)
-            for task in pending:
-                task.cancel()
-                try:
-                    await task
-                except asyncio.CancelledError:
-                    pass
-
     def get_semaphore(self, limits: PoolLimits) -> BasePoolSemaphore:
         return PoolSemaphore(limits)
 

--- a/httpx/concurrency/auto.py
+++ b/httpx/concurrency/auto.py
@@ -51,12 +51,3 @@ class AutoBackend(ConcurrencyBackend):
 
     def create_event(self) -> BaseEvent:
         return self.backend.create_event()
-
-    async def fork(
-        self,
-        coroutine1: typing.Callable,
-        args1: typing.Sequence,
-        coroutine2: typing.Callable,
-        args2: typing.Sequence,
-    ) -> None:
-        return await self.backend.fork(coroutine1, args1, coroutine2, args2)

--- a/httpx/concurrency/base.py
+++ b/httpx/concurrency/base.py
@@ -152,21 +152,3 @@ class ConcurrencyBackend:
 
     def create_event(self) -> BaseEvent:
         raise NotImplementedError()  # pragma: no cover
-
-    async def fork(
-        self,
-        coroutine1: typing.Callable,
-        args1: typing.Sequence,
-        coroutine2: typing.Callable,
-        args2: typing.Sequence,
-    ) -> None:
-        """
-        Run two coroutines concurrently.
-
-        This should start 'coroutine1' with '*args1' and 'coroutine2' with '*args2',
-        and wait for them to finish.
-
-        In case one of the coroutines raises an exception, cancel the other one then
-        raise. If the other coroutine had also raised an exception, ignore it.
-        """
-        raise NotImplementedError()  # pragma: no cover

--- a/httpx/concurrency/trio.py
+++ b/httpx/concurrency/trio.py
@@ -193,22 +193,6 @@ class TrioBackend(ConcurrencyBackend):
             functools.partial(coroutine, **kwargs) if kwargs else coroutine, *args
         )
 
-    async def fork(
-        self,
-        coroutine1: typing.Callable,
-        args1: typing.Sequence,
-        coroutine2: typing.Callable,
-        args2: typing.Sequence,
-    ) -> None:
-        try:
-            async with trio.open_nursery() as nursery:
-                nursery.start_soon(coroutine1, *args1)
-                nursery.start_soon(coroutine2, *args2)
-        except trio.MultiError as exc:
-            # In practice, we don't actually care about raising both
-            # exceptions, so let's raise either indeterminantly.
-            raise exc.exceptions[0]
-
     def get_semaphore(self, limits: PoolLimits) -> BasePoolSemaphore:
         return PoolSemaphore(limits)
 


### PR DESCRIPTION
Turns out that neither of our HTTP/1.1 or HTTP/2 implementations actually require any backgrounding. I'm curious if there's any performance implications to this wrt. HTTP/2 that backgrounded writes would deal with, but if that *is* the case, then we can always bring fork back in. Right now we just don't need it, which is 👍.