### PR TITLE
Minor config cleanup

### DIFF
--- a/httpx/config.py
+++ b/httpx/config.py
@@ -50,6 +50,8 @@ class SSLConfig:
     SSL Configuration.
     """
 
+    DEFAULT_CA_BUNDLE_PATH = Path(certifi.where())
+
     def __init__(
         self,
         *,
@@ -129,7 +131,7 @@ class SSLConfig:
                 self.verify = ca_bundle  # type: ignore
 
         if isinstance(self.verify, bool):
-            ca_bundle_path = DEFAULT_CA_BUNDLE_PATH
+            ca_bundle_path = self.DEFAULT_CA_BUNDLE_PATH
         elif Path(self.verify).exists():
             ca_bundle_path = Path(self.verify)
         else:
@@ -321,8 +323,6 @@ class PoolLimits:
 TimeoutConfig = Timeout  # Synonym for backwards compat
 
 
-DEFAULT_SSL_CONFIG = SSLConfig(cert=None, verify=True)
 DEFAULT_TIMEOUT_CONFIG = Timeout(timeout=5.0)
 DEFAULT_POOL_LIMITS = PoolLimits(soft_limit=10, hard_limit=100)
-DEFAULT_CA_BUNDLE_PATH = Path(certifi.where())
 DEFAULT_MAX_REDIRECTS = 20

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,7 @@ import ssl
 import sys
 from pathlib import Path
 
+import certifi
 import pytest
 
 import httpx
@@ -24,7 +25,7 @@ def test_load_ssl_config_verify_non_existing_path():
 
 
 def test_load_ssl_config_verify_existing_file():
-    ssl_config = SSLConfig(verify=httpx.config.DEFAULT_CA_BUNDLE_PATH)
+    ssl_config = SSLConfig(verify=certifi.where())
     context = ssl_config.load_ssl_context()
     assert context.verify_mode == ssl.VerifyMode.CERT_REQUIRED
     assert context.check_hostname is True
@@ -55,7 +56,7 @@ def test_load_ssl_config_verify_env_file(https_server, ca_cert_pem_file, config)
 
 
 def test_load_ssl_config_verify_directory():
-    path = httpx.config.DEFAULT_CA_BUNDLE_PATH.parent
+    path = Path(certifi.where()).parent
     ssl_config = SSLConfig(verify=path)
     context = ssl_config.load_ssl_context()
     assert context.verify_mode == ssl.VerifyMode.CERT_REQUIRED


### PR DESCRIPTION
* Drop `DEFAULT_SSL_CONFIG` - We're not actually using it anywhere.
* Scope `DEFAULT_CA_BUNDLE_PATH` more tightly.