### PR TITLE
Dropped unreliable test cases

### DIFF
--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -173,22 +173,3 @@ def test_merge_url():
 
     assert url.scheme == "https"
     assert url.is_ssl
-
-
-@pytest.mark.asyncio
-async def test_elapsed_delay(server):
-    url = server.url.copy_with(path="/slow_response/100")
-    async with httpx.Client() as client:
-        response = await client.get(url)
-    assert response.elapsed.total_seconds() == pytest.approx(0.1, rel=0.2)
-
-
-@pytest.mark.asyncio
-async def test_elapsed_delay_ignores_read_time(server):
-    url = server.url.copy_with(path="/slow_response/100")
-    async with httpx.Client() as client:
-        async with client.stream("GET", url) as response:
-            sleep(0.2)
-            await response.read()
-
-    assert response.elapsed.total_seconds() == pytest.approx(0.1, rel=0.2)


### PR DESCRIPTION
We've at least already got coverage here, and these two tests are proving too unreliable, so I think the pragmatic option here is just to drop them.