### PR TITLE
Connection pool refactoring

### DIFF
--- a/httpx/dispatch/connection.py
+++ b/httpx/dispatch/connection.py
@@ -62,15 +62,15 @@ class HTTPConnection(Dispatcher):
             self.num_current_requests += 1
             try:
                 await self.connect(verify=verify, cert=cert, timeout=timeout)
-                assert self.connection is not None
-                if self.connection.is_http2:
-                    self.state = ConnectionState.ACTIVE_HTTP_2
-                else:
-                    self.state = ConnectionState.ACTIVE_HTTP_11
             except BaseException as exc:
                 self.num_current_requests -= 1
                 self.state = ConnectionState.CLOSED
                 raise exc
+            assert self.connection is not None
+            if self.connection.is_http2:
+                self.state = ConnectionState.ACTIVE_HTTP_2
+            else:
+                self.state = ConnectionState.ACTIVE_HTTP_11
         elif self.state == ConnectionState.IDLE_HTTP_11:
             self.num_current_requests += 1
             self.state = ConnectionState.ACTIVE_HTTP_11

--- a/httpx/dispatch/connection.py
+++ b/httpx/dispatch/connection.py
@@ -1,4 +1,4 @@
-import functools
+import enum
 import ssl
 import typing
 
@@ -12,11 +12,19 @@ from .base import Dispatcher, OpenConnection
 from .http2 import HTTP2Connection
 from .http11 import HTTP11Connection
 
-# Callback signature: async def callback(conn: HTTPConnection) -> None
 ReleaseCallback = typing.Callable[["HTTPConnection"], typing.Awaitable[None]]
 
-
 logger = get_logger(__name__)
+
+
+class ConnectionState(enum.IntEnum):
+    PENDING = 0
+    IDLE_HTTP_11 = 1
+    IDLE_HTTP_2 = 2
+    ACTIVE_HTTP_11 = 3
+    ACTIVE_HTTP_2 = 4
+    ACTIVE_HTTP_2_NO_STREAMS = 5
+    CLOSED = 6
 
 
 class HTTPConnection(Dispatcher):
@@ -37,7 +45,8 @@ class HTTPConnection(Dispatcher):
         self.backend = lookup_backend(backend)
         self.release_func = release_func
         self.uds = uds
-        self.open_connection: typing.Optional[OpenConnection] = None
+        self.connection: typing.Optional[OpenConnection] = None
+        self.state = ConnectionState.PENDING
 
     async def send(
         self,
@@ -48,13 +57,32 @@ class HTTPConnection(Dispatcher):
     ) -> Response:
         timeout = Timeout() if timeout is None else timeout
 
-        if self.open_connection is None:
-            await self.connect(verify=verify, cert=cert, timeout=timeout)
+        if self.state == ConnectionState.PENDING:
+            try:
+                await self.connect(verify=verify, cert=cert, timeout=timeout)
+                assert self.connection is not None
+                if self.connection.is_http2:
+                    self.state = ConnectionState.ACTIVE_HTTP_2
+                else:
+                    self.state = ConnectionState.ACTIVE_HTTP_11
+            except BaseException as exc:
+                self.state = ConnectionState.CLOSED
+                raise exc
+        elif self.state == ConnectionState.IDLE_HTTP_11:
+            self.state = ConnectionState.ACTIVE_HTTP_11
+        elif self.state == ConnectionState.IDLE_HTTP_2:
+            self.state = ConnectionState.ACTIVE_HTTP_2
+        # elif self.state == ConnectionState.ACTIVE_HTTP_2:
+        #     pass
+        # else:  # ACTIVE_HTTP_11, ACTIVE_HTTP_2_NO_STREAMS, CLOSED
+        #     raise NewConnectionRequired()
 
-        assert self.open_connection is not None
-        response = await self.open_connection.send(request, timeout=timeout)
-
-        return response
+        assert self.connection is not None
+        try:
+            return await self.connection.send(request, timeout=timeout)
+        except BaseException as exc:
+            self.state = ConnectionState.CLOSED
+            raise exc from None
 
     async def connect(
         self, timeout: Timeout, verify: VerifyTypes = None, cert: CertTypes = None,
@@ -65,30 +93,16 @@ class HTTPConnection(Dispatcher):
         port = self.origin.port
         ssl_context = await self.get_ssl_context(ssl)
 
-        if self.release_func is None:
-            on_release = None
-        else:
-            on_release = functools.partial(self.release_func, self)
-
         if self.uds is None:
-            logger.trace(
-                f"start_connect tcp host={host!r} port={port!r} timeout={timeout!r}"
-            )
             stream = await self.backend.open_tcp_stream(
                 host, port, ssl_context, timeout
             )
         else:
-            logger.trace(
-                f"start_connect uds path={self.uds!r} host={host!r} timeout={timeout!r}"
-            )
             stream = await self.backend.open_uds_stream(
                 self.uds, host, ssl_context, timeout
             )
 
-        http_version = stream.get_http_version()
-        logger.trace(f"connected http_version={http_version!r}")
-
-        self.set_open_connection(http_version, socket=stream, on_release=on_release)
+        self.connection = self.new_connection(stream)
 
     async def tunnel_start_tls(
         self,
@@ -105,8 +119,8 @@ class HTTPConnection(Dispatcher):
 
         # First, check that we are in the correct state to start TLS, i.e. we've
         # just agreed to switch protocols with the server via HTTP/1.1.
-        assert isinstance(self.open_connection, HTTP11Connection)
-        h11_connection = self.open_connection
+        assert isinstance(self.connection, HTTP11Connection)
+        h11_connection = self.connection
         assert h11_connection is not None
         assert h11_connection.h11_state.our_state == h11.SWITCHED_PROTOCOL
 
@@ -114,48 +128,28 @@ class HTTPConnection(Dispatcher):
         # it to the new internal connection object after
         # the old one goes to 'SWITCHED_PROTOCOL'.
         # Note that the negotiated 'http_version' may change after the TLS upgrade.
-        http_version = "HTTP/1.1"
         socket = h11_connection.socket
-        on_release = h11_connection.on_release
 
-        if origin.is_ssl:
-            # Pull the socket stream off the internal HTTP connection object,
-            # and run start_tls().
-            ssl_config = SSLConfig(cert=cert, verify=verify)
-            ssl_context = await self.get_ssl_context(ssl_config)
-            assert ssl_context is not None
+        if not origin.is_ssl:
+            self.connection = self.new_connection(socket)
+            return
 
-            logger.trace(f"tunnel_start_tls proxy_url={proxy_url!r} origin={origin!r}")
-            socket = await socket.start_tls(
-                hostname=origin.host, ssl_context=ssl_context, timeout=timeout
-            )
-            http_version = socket.get_http_version()
-            logger.trace(
-                f"tunnel_tls_complete "
-                f"proxy_url={proxy_url!r} "
-                f"origin={origin!r} "
-                f"http_version={http_version!r}"
-            )
-        else:
-            # User requested the use of a tunnel, but they're performing a plain-text
-            # HTTP request. Don't try to upgrade to TLS in this case.
-            pass
+        # Pull the socket stream off the internal HTTP connection object,
+        # and run start_tls().
+        ssl_config = SSLConfig(cert=cert, verify=verify)
+        ssl_context = await self.get_ssl_context(ssl_config)
+        assert ssl_context is not None
 
-        self.set_open_connection(http_version, socket=socket, on_release=on_release)
+        socket = await socket.start_tls(
+            hostname=origin.host, ssl_context=ssl_context, timeout=timeout
+        )
+        self.connection = self.new_connection(socket)
 
-    def set_open_connection(
-        self,
-        http_version: str,
-        socket: BaseSocketStream,
-        on_release: typing.Optional[typing.Callable],
-    ) -> None:
+    def new_connection(self, socket: BaseSocketStream) -> OpenConnection:
+        http_version = socket.get_http_version()
         if http_version == "HTTP/2":
-            self.open_connection = HTTP2Connection(
-                socket, self.backend, on_release=on_release
-            )
-        else:
-            assert http_version == "HTTP/1.1"
-            self.open_connection = HTTP11Connection(socket, on_release=on_release)
+            return HTTP2Connection(socket, self.backend, on_release=self.release)
+        return HTTP11Connection(socket, on_release=self.release)
 
     async def get_ssl_context(self, ssl: SSLConfig) -> typing.Optional[ssl.SSLContext]:
         if not self.origin.is_ssl:
@@ -164,25 +158,36 @@ class HTTPConnection(Dispatcher):
         # Run the SSL loading in a threadpool, since it may make disk accesses.
         return await self.backend.run_in_threadpool(ssl.load_ssl_context, self.http2)
 
+    async def release(self) -> None:
+        logger.trace("Connection released")
+        if self.state == ConnectionState.ACTIVE_HTTP_11:
+            self.state = ConnectionState.IDLE_HTTP_11
+        elif self.state == ConnectionState.ACTIVE_HTTP_2:
+            self.state = ConnectionState.IDLE_HTTP_2
+        elif self.state == ConnectionState.ACTIVE_HTTP_2_NO_STREAMS:
+            self.state = ConnectionState.CLOSED
+
+        if self.release_func is not None:
+            await self.release_func(self)
+
+    def __repr__(self) -> str:
+        return f"<Connection [{self.origin!r} {self.state.name}]>"
+
     async def close(self) -> None:
         logger.trace("close_connection")
-        if self.open_connection is not None:
-            await self.open_connection.close()
+        if self.connection is not None:
+            await self.connection.close()
 
     @property
     def is_http2(self) -> bool:
-        assert self.open_connection is not None
-        return self.open_connection.is_http2
+        assert self.connection is not None
+        return self.connection.is_http2
 
     @property
     def is_closed(self) -> bool:
-        assert self.open_connection is not None
-        return self.open_connection.is_closed
+        assert self.connection is not None
+        return self.connection.is_closed
 
     def is_connection_dropped(self) -> bool:
-        assert self.open_connection is not None
-        return self.open_connection.is_connection_dropped()
-
-    def __repr__(self) -> str:
-        class_name = self.__class__.__name__
-        return f"{class_name}(origin={self.origin!r})"
+        assert self.connection is not None
+        return self.connection.is_connection_dropped()

--- a/httpx/dispatch/http2.py
+++ b/httpx/dispatch/http2.py
@@ -167,7 +167,7 @@ class HTTP2Connection(OpenConnection):
         del self.streams[stream_id]
         del self.events[stream_id]
 
-        if not self.streams and self.on_release is not None:
+        if self.on_release is not None:
             await self.on_release()
 
 


### PR DESCRIPTION
Starting some work on connection pool refactoring, to more tightly manage the state of the connection, aimed at allowing us to eventually deal with awkward cases such as...

* Multiple concurrent requests made to a new origin.
* The first should start making the connection.
* Others should pause waiting for the connection.
* If an HTTP/2 connection is established, then the other requests should stream on that.
* If an HTTP/1.1 connection is established, then the other requests should each acquire new connections.