### PR TITLE
Refactor BaseEvent

### DIFF
--- a/httpx/concurrency/asyncio.py
+++ b/httpx/concurrency/asyncio.py
@@ -275,4 +275,15 @@ class AsyncioBackend(ConcurrencyBackend):
         return PoolSemaphore(limits)
 
     def create_event(self) -> BaseEvent:
-        return typing.cast(BaseEvent, asyncio.Event())
+        return Event()
+
+
+class Event(BaseEvent):
+    def __init__(self) -> None:
+        self._event = asyncio.Event()
+
+    def set(self) -> None:
+        self._event.set()
+
+    async def wait(self) -> None:
+        await self._event.wait()

--- a/httpx/concurrency/base.py
+++ b/httpx/concurrency/base.py
@@ -62,12 +62,6 @@ class BaseEvent:
     def set(self) -> None:
         raise NotImplementedError()  # pragma: no cover
 
-    def is_set(self) -> bool:
-        raise NotImplementedError()  # pragma: no cover
-
-    def clear(self) -> None:
-        raise NotImplementedError()  # pragma: no cover
-
     async def wait(self) -> None:
         raise NotImplementedError()  # pragma: no cover
 

--- a/httpx/concurrency/trio.py
+++ b/httpx/concurrency/trio.py
@@ -182,13 +182,5 @@ class Event(BaseEvent):
     def set(self) -> None:
         self._event.set()
 
-    def is_set(self) -> bool:
-        return self._event.is_set()
-
     async def wait(self) -> None:
         await self._event.wait()
-
-    def clear(self) -> None:
-        # trio.Event.clear() was deprecated in Trio 0.12.
-        # https://github.com/python-trio/trio/issues/637
-        self._event = trio.Event()


### PR DESCRIPTION
* Drop unused methods from BaseEvent.
* Use an explicit Event class in the asyncio implementation, rather than a lazy cast-and-hope.