### PR TITLE
Using charset_normalizer instead of chardet in models.py and decoder.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The httpx project relies on these excellent libraries:
 * `h2` - HTTP/2 support.
 * `h11` - HTTP/1.1 support.
 * `certifi` - SSL certificates.
-* `chardet` - Fallback auto-detection for response encoding.
+* `charset_normalizer` - Fallback auto-detection for response encoding.
 * `hstspreload` - determines whether IDNA-encoded host should be only accessed via HTTPS.
 * `idna` - Internationalized domain name support.
 * `rfc3986` - URL parsing & normalization.

--- a/docs/index.md
+++ b/docs/index.md
@@ -111,7 +111,7 @@ The HTTPX project relies on these excellent libraries:
 * `h2` - HTTP/2 support.
 * `h11` - HTTP/1.1 support.
 * `certifi` - SSL certificates.
-* `chardet` - Fallback auto-detection for response encoding.
+* `charset_normalizer` - Fallback auto-detection for response encoding.
 * `hstspreload` - determines whether IDNA-encoded host should be only accessed via HTTPS.
 * `idna` - Internationalized domain name support.
 * `rfc3986` - URL parsing & normalization.

--- a/httpx/models.py
+++ b/httpx/models.py
@@ -9,7 +9,7 @@ from collections.abc import MutableMapping
 from http.cookiejar import Cookie, CookieJar
 from urllib.parse import parse_qsl, urlencode
 
-import chardet
+from charset_normalizer import CharsetDetector
 import rfc3986
 
 from .config import USER_AGENT
@@ -827,7 +827,11 @@ class Response:
         """
         Return the encoding, as it appears to autodetection.
         """
-        return chardet.detect(self.content)["encoding"]
+        detection = CharsetDetector.from_bytes(
+            self.content
+        ).best().first()
+
+        return detection.encoding if detection else None
 
     @property
     def decoder(self) -> Decoder:

--- a/httpx/models.py
+++ b/httpx/models.py
@@ -9,8 +9,8 @@ from collections.abc import MutableMapping
 from http.cookiejar import Cookie, CookieJar
 from urllib.parse import parse_qsl, urlencode
 
-from charset_normalizer import CharsetDetector
 import rfc3986
+from charset_normalizer import CharsetDetector
 
 from .config import USER_AGENT
 from .decoders import (
@@ -827,9 +827,7 @@ class Response:
         """
         Return the encoding, as it appears to autodetection.
         """
-        detection = CharsetDetector.from_bytes(
-            self.content
-        ).best().first()
+        detection = CharsetDetector.from_bytes(self.content).best().first()
 
         return detection.encoding if detection else None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,5 +22,8 @@ trio
 trustme
 uvicorn
 seed-isort-config
+rfc3986
+certifi
+h2
 
 attrs>=19.2  # See: https://github.com/encode/httpx/pull/566#issuecomment-559862665

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ trio
 trustme
 uvicorn
 seed-isort-config
+charset_normalizer>=1.3,<2
 rfc3986
 certifi
 h2

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,8 +23,5 @@ trustme
 uvicorn
 seed-isort-config
 charset_normalizer>=1.3,<2
-rfc3986
-certifi
-h2
 
 attrs>=19.2  # See: https://github.com/encode/httpx/pull/566#issuecomment-559862665

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ combine_as_imports = True
 force_grid_wrap = 0
 include_trailing_comma = True
 known_first_party = httpx,httpxprof,tests
-known_third_party = brotli,certifi,chardet,click,cryptography,h11,h2,hstspreload,pytest,rfc3986,setuptools,sniffio,tqdm,trio,trustme,uvicorn
+known_third_party = brotli,certifi,charset_normalizer,click,cryptography,h11,h2,hstspreload,pytest,rfc3986,setuptools,sniffio,tqdm,trio,trustme,uvicorn
 line_length = 88
 multi_line_output = 3
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     install_requires=[
         "certifi",
         "hstspreload",
-        "chardet==3.*",
+        "charset_normalizer>=1.3,<2",
         "h11==0.8.*",
         "h2==3.*",
         "idna==2.*",

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -125,8 +125,8 @@ def test_decoding_errors(header_value):
             "cp1251",
         ),
         (
-            (b"\xa5\xa6\xa5\xa7\xa5\xd6\xa4\xce\xb9\xf1\xba\xdd\xb2\xbd",) * 512,
-            "euc-jp",
+            (b"\xa5\xa6\xa5\xa7\xa5\xd6\xa4\xce\xb9\xf1\xba\xdd\xb2\xbd\x20",) * 512,
+            "euc_jis_2004",
         ),
     ],
 )

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -122,7 +122,7 @@ def test_decoding_errors(header_value):
         ((b"\x83g\x83\x89\x83x\x83\x8b\x20",) * 600, "cp932"),
         (
             (b"\xcb\xee\xf0\xe5\xec \xe8\xef\xf1\xf3\xec \xe4\xee\xeb\xee\xf0",) * 64,
-            "MacCyrillic",
+            "cp1251",
         ),
         (
             (b"\xa5\xa6\xa5\xa7\xa5\xd6\xa4\xce\xb9\xf1\xba\xdd\xb2\xbd",) * 512,

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -118,8 +118,8 @@ def test_decoding_errors(header_value):
     [
         ((b"Hello,", b" world!"), "ascii"),
         ((b"\xe3\x83", b"\x88\xe3\x83\xa9", b"\xe3", b"\x83\x99\xe3\x83\xab"), "utf-8"),
-        ((b"\x83g\x83\x89\x83x\x83\x8b",) * 64, "shift-jis"),
-        ((b"\x83g\x83\x89\x83x\x83\x8b",) * 600, "shift-jis"),
+        ((b"\x83g\x83\x89\x83x\x83\x8b\x20",) * 64, "cp932"),
+        ((b"\x83g\x83\x89\x83x\x83\x8b\x20",) * 600, "cp932"),
         (
             (b"\xcb\xee\xf0\xe5\xec \xe8\xef\xf1\xf3\xec \xe4\xee\xeb\xee\xf0",) * 64,
             "MacCyrillic",


### PR DESCRIPTION
Hi,

With this PR I am proposing to replace chardet by charset_normalizer.
This new package is MIT licensed and support more encoding, also young. But it is slower for now. (not by much)

Complete details are available at : https://github.com/Ousret/charset_normalizer

charset_normalizer is still an ongoing project, so there is still maintenance as of now. (by me, mostly)

If anyone is willing to give it a try and send feedbacks, I would be thrilled to listen.
