### PR TITLE
Added RequestContent

### DIFF
--- a/httpx/client.py
+++ b/httpx/client.py
@@ -577,7 +577,7 @@ class Client:
         """
         if method != request.method and method == "GET":
             return RequestContent()
-        if not request.content.can_rewind():
+        if not request.content.can_replay():
             raise RedirectBodyUnavailable()
         return request.content
 

--- a/httpx/content.py
+++ b/httpx/content.py
@@ -1,0 +1,149 @@
+import typing
+from json import dumps as json_dumps
+from urllib.parse import urlencode
+
+from .multipart import multipart_encode
+
+RequestData = typing.Union[dict, str, bytes, typing.AsyncIterator[bytes]]
+
+RequestFiles = typing.Dict[
+    str,
+    typing.Union[
+        # file (or str)
+        typing.Union[typing.IO[typing.AnyStr], typing.AnyStr],
+        # (filename, file (or str))
+        typing.Tuple[
+            typing.Optional[str], typing.Union[typing.IO[typing.AnyStr], typing.AnyStr],
+        ],
+        # (filename, file (or str), content_type)
+        typing.Tuple[
+            typing.Optional[str],
+            typing.Union[typing.IO[typing.AnyStr], typing.AnyStr],
+            typing.Optional[str],
+        ],
+    ],
+]
+
+
+class RequestContent:
+    def headers(self) -> typing.Dict[str, str]:
+        return {}
+
+    def can_rewind(self) -> bool:
+        return True
+
+    async def __aiter__(self) -> typing.AsyncIterator[bytes]:
+        yield b""  # pragma: nocover
+
+    async def aread(self) -> bytes:
+        return b"".join([part async for part in self])
+
+
+class BytesRequestContent(RequestContent):
+    """
+    Request content encoded as plain bytes.
+    """
+
+    def __init__(self, body: typing.Union[str, bytes]) -> None:
+        self.body = body.encode("utf-8") if isinstance(body, str) else body
+
+    def headers(self) -> typing.Dict[str, str]:
+        content_length = str(len(self.body))
+        return {"Content-Length": content_length}
+
+    async def __aiter__(self) -> typing.AsyncIterator[bytes]:
+        yield self.body
+
+
+class StreamingRequestContent(RequestContent):
+    """
+    Request content encoded as plain bytes, using an async byte iterator.
+    """
+
+    def __init__(self, aiterator: typing.AsyncIterator[bytes]) -> None:
+        self.aiterator = aiterator
+
+    def can_rewind(self) -> bool:
+        return False
+
+    def headers(self) -> typing.Dict[str, str]:
+        return {"Transfer-Encoding": "chunked"}
+
+    async def __aiter__(self) -> typing.AsyncIterator[bytes]:
+        async for part in self.aiterator:
+            yield part
+
+
+class JSONRequestContent(RequestContent):
+    """
+    Request content encoded as JSON.
+    """
+
+    def __init__(self, json: typing.Any) -> None:
+        self.body = json_dumps(json).encode("utf-8")
+
+    def headers(self) -> typing.Dict[str, str]:
+        content_length = str(len(self.body))
+        content_type = "application/json"
+        return {"Content-Length": content_length, "Content-Type": content_type}
+
+    async def __aiter__(self) -> typing.AsyncIterator[bytes]:
+        yield self.body
+
+
+class URLEncodedRequestContent(RequestContent):
+    """
+    Request content as URL encoded form data.
+    """
+
+    def __init__(self, data: dict) -> None:
+        self.body = urlencode(data, doseq=True).encode("utf-8")
+
+    def headers(self) -> typing.Dict[str, str]:
+        content_length = str(len(self.body))
+        content_type = "application/x-www-form-urlencoded"
+        return {"Content-Length": content_length, "Content-Type": content_type}
+
+    async def __aiter__(self) -> typing.AsyncIterator[bytes]:
+        yield self.body
+
+
+class MultipartRequestContent(RequestContent):
+    """
+    Request content as multipart encoded form data.
+    """
+
+    def __init__(self, data: dict, files: dict, boundary: bytes = None) -> None:
+        self.body, self.content_type = multipart_encode(data, files, boundary)
+
+    def headers(self) -> typing.Dict[str, str]:
+        content_length = str(len(self.body))
+        content_type = self.content_type
+        return {"Content-Length": content_length, "Content-Type": content_type}
+
+    async def __aiter__(self) -> typing.AsyncIterator[bytes]:
+        yield self.body
+
+
+def encode(
+    data: RequestData = None,
+    files: RequestFiles = None,
+    json: typing.Any = None,
+    boundary: bytes = None,
+) -> RequestContent:
+    if data is None:
+        if json is not None:
+            return JSONRequestContent(json)
+        elif files:
+            return MultipartRequestContent({}, files, boundary=boundary)
+        else:
+            return RequestContent()
+    elif isinstance(data, dict):
+        if files:
+            return MultipartRequestContent(data, files, boundary=boundary)
+        else:
+            return URLEncodedRequestContent(data)
+    elif isinstance(data, (str, bytes)):
+        return BytesRequestContent(data)
+    else:
+        return StreamingRequestContent(data)

--- a/httpx/content.py
+++ b/httpx/content.py
@@ -26,14 +26,14 @@ RequestFiles = typing.Dict[
 
 
 class RequestContent:
-    def headers(self) -> typing.Dict[str, str]:
+    def get_headers(self) -> typing.Dict[str, str]:
         return {}
 
     def can_rewind(self) -> bool:
         return True
 
     async def __aiter__(self) -> typing.AsyncIterator[bytes]:
-        yield b""  # pragma: nocover
+        yield b""
 
     async def aread(self) -> bytes:
         return b"".join([part async for part in self])
@@ -47,7 +47,7 @@ class BytesRequestContent(RequestContent):
     def __init__(self, body: typing.Union[str, bytes]) -> None:
         self.body = body.encode("utf-8") if isinstance(body, str) else body
 
-    def headers(self) -> typing.Dict[str, str]:
+    def get_headers(self) -> typing.Dict[str, str]:
         content_length = str(len(self.body))
         return {"Content-Length": content_length}
 
@@ -66,7 +66,7 @@ class StreamingRequestContent(RequestContent):
     def can_rewind(self) -> bool:
         return False
 
-    def headers(self) -> typing.Dict[str, str]:
+    def get_headers(self) -> typing.Dict[str, str]:
         return {"Transfer-Encoding": "chunked"}
 
     async def __aiter__(self) -> typing.AsyncIterator[bytes]:
@@ -82,7 +82,7 @@ class JSONRequestContent(RequestContent):
     def __init__(self, json: typing.Any) -> None:
         self.body = json_dumps(json).encode("utf-8")
 
-    def headers(self) -> typing.Dict[str, str]:
+    def get_headers(self) -> typing.Dict[str, str]:
         content_length = str(len(self.body))
         content_type = "application/json"
         return {"Content-Length": content_length, "Content-Type": content_type}
@@ -99,7 +99,7 @@ class URLEncodedRequestContent(RequestContent):
     def __init__(self, data: dict) -> None:
         self.body = urlencode(data, doseq=True).encode("utf-8")
 
-    def headers(self) -> typing.Dict[str, str]:
+    def get_headers(self) -> typing.Dict[str, str]:
         content_length = str(len(self.body))
         content_type = "application/x-www-form-urlencoded"
         return {"Content-Length": content_length, "Content-Type": content_type}
@@ -116,7 +116,7 @@ class MultipartRequestContent(RequestContent):
     def __init__(self, data: dict, files: dict, boundary: bytes = None) -> None:
         self.body, self.content_type = multipart_encode(data, files, boundary)
 
-    def headers(self) -> typing.Dict[str, str]:
+    def get_headers(self) -> typing.Dict[str, str]:
         content_length = str(len(self.body))
         content_type = self.content_type
         return {"Content-Length": content_length, "Content-Type": content_type}

--- a/httpx/content.py
+++ b/httpx/content.py
@@ -32,9 +32,18 @@ class RequestContent:
     """
 
     def get_headers(self) -> typing.Dict[str, str]:
+        """
+        Return a dictionary of request headers that are implied by the encoding.
+        """
         return {}
 
-    def can_rewind(self) -> bool:
+    def can_replay(self) -> bool:
+        """
+        Return `True` if `__aiter__` can be called multiple times.
+
+        We need this in order to determine if we can re-issue a request body
+        when we receive a redirect response.
+        """
         return True
 
     async def __aiter__(self) -> typing.AsyncIterator[bytes]:
@@ -68,7 +77,7 @@ class StreamingRequestContent(RequestContent):
     def __init__(self, aiterator: typing.AsyncIterator[bytes]) -> None:
         self.aiterator = aiterator
 
-    def can_rewind(self) -> bool:
+    def can_replay(self) -> bool:
         return False
 
     def get_headers(self) -> typing.Dict[str, str]:

--- a/httpx/content.py
+++ b/httpx/content.py
@@ -152,7 +152,7 @@ def encode(
         else:
             return RequestContent()
     elif isinstance(data, dict):
-        if files:
+        if files is not None:
             return MultipartRequestContent(data, files, boundary=boundary)
         else:
             return URLEncodedRequestContent(data)

--- a/httpx/content.py
+++ b/httpx/content.py
@@ -26,6 +26,11 @@ RequestFiles = typing.Dict[
 
 
 class RequestContent:
+    """
+    Base class for request content.
+    Defaults to a "no request body" implementation.
+    """
+
     def get_headers(self) -> typing.Dict[str, str]:
         return {}
 
@@ -131,6 +136,14 @@ def encode(
     json: typing.Any = None,
     boundary: bytes = None,
 ) -> RequestContent:
+    """
+    Handles encoding the given `data`, `files`, and `json`, returning
+    a `RequestContent` implementation which provides a byte iterator onto
+    the content, as well as `.is_rewindable()` and `.get_headers()` interfaces.
+
+    The `boundary` argument is also included for reproducible test cases
+    when working with multipart data.
+    """
     if data is None:
         if json is not None:
             return JSONRequestContent(json)

--- a/httpx/models.py
+++ b/httpx/models.py
@@ -13,6 +13,7 @@ import chardet
 import rfc3986
 
 from .config import USER_AGENT
+from .content import RequestData, RequestFiles
 from .decoders import (
     ACCEPT_ENCODING,
     SUPPORTED_DECODERS,
@@ -75,26 +76,6 @@ AuthTypes = typing.Union[
 
 ProxiesTypes = typing.Union[
     URLTypes, "Dispatcher", typing.Dict[URLTypes, typing.Union[URLTypes, "Dispatcher"]]
-]
-
-RequestData = typing.Union[dict, str, bytes, typing.AsyncIterator[bytes]]
-
-RequestFiles = typing.Dict[
-    str,
-    typing.Union[
-        # file (or str)
-        typing.Union[typing.IO[typing.AnyStr], typing.AnyStr],
-        # (filename, file (or str))
-        typing.Tuple[
-            typing.Optional[str], typing.Union[typing.IO[typing.AnyStr], typing.AnyStr],
-        ],
-        # (filename, file (or str), content_type)
-        typing.Tuple[
-            typing.Optional[str],
-            typing.Union[typing.IO[typing.AnyStr], typing.AnyStr],
-            typing.Optional[str],
-        ],
-    ],
 ]
 
 ResponseContent = typing.Union[bytes, typing.AsyncIterator[bytes]]

--- a/httpx/models.py
+++ b/httpx/models.py
@@ -13,7 +13,7 @@ import chardet
 import rfc3986
 
 from .config import USER_AGENT
-from .content import RequestData, RequestFiles
+from .content import RequestData, RequestFiles, encode
 from .decoders import (
     ACCEPT_ENCODING,
     SUPPORTED_DECODERS,
@@ -32,7 +32,6 @@ from .exceptions import (
     ResponseNotRead,
     StreamConsumed,
 )
-from .multipart import multipart_encode
 from .status_codes import StatusCode
 from .utils import (
     flatten_queryparams,
@@ -600,50 +599,18 @@ class Request:
         if cookies:
             self._cookies = Cookies(cookies)
             self._cookies.set_cookie_header(self)
-        if data is None or isinstance(data, dict):
-            content, content_type = self.encode_data(data, files, json)
-            self.is_streaming = False
-            self.content = content
-            if content_type:
-                self.headers.setdefault("Content-Type", content_type)
-        elif isinstance(data, (str, bytes)):
-            data = data.encode("utf-8") if isinstance(data, str) else data
-            self.is_streaming = False
-            self.content = data
-        else:
-            assert hasattr(data, "__aiter__")
-            self.is_streaming = True
-            self.content_aiter = data
+        self.content = encode(data, files, json)
         self.prepare()
 
-    def encode_data(
-        self, data: dict = None, files: RequestFiles = None, json: typing.Any = None
-    ) -> typing.Tuple[bytes, str]:
-        if json is not None:
-            content = jsonlib.dumps(json).encode("utf-8")
-            content_type = "application/json"
-        elif files is not None:
-            content, content_type = multipart_encode(data or {}, files)
-        elif data is not None:
-            content = urlencode(data, doseq=True).encode("utf-8")
-            content_type = "application/x-www-form-urlencoded"
-        else:
-            content = b""
-            content_type = ""
-        return content, content_type
-
     def prepare(self) -> None:
-        content: typing.Optional[bytes] = getattr(self, "content", None)
-        is_streaming = getattr(self, "is_streaming", False)
+        for key, value in self.content.get_headers().items():
+            self.headers.setdefault(key, value)
 
         auto_headers: typing.List[typing.Tuple[bytes, bytes]] = []
 
         has_host = "host" in self.headers
         has_user_agent = "user-agent" in self.headers
         has_accept = "accept" in self.headers
-        has_content_length = (
-            "content-length" in self.headers or "transfer-encoding" in self.headers
-        )
         has_accept_encoding = "accept-encoding" in self.headers
         has_connection = "connection" in self.headers
 
@@ -656,12 +623,6 @@ class Request:
             auto_headers.append((b"user-agent", USER_AGENT.encode("ascii")))
         if not has_accept:
             auto_headers.append((b"accept", b"*/*"))
-        if not has_content_length:
-            if is_streaming:
-                auto_headers.append((b"transfer-encoding", b"chunked"))
-            elif content:
-                content_length = str(len(content)).encode()
-                auto_headers.append((b"content-length", content_length))
         if not has_accept_encoding:
             auto_headers.append((b"accept-encoding", ACCEPT_ENCODING.encode()))
         if not has_connection:
@@ -685,16 +646,11 @@ class Request:
         """
         Read and return the request content.
         """
-        if not hasattr(self, "content"):
-            self.content = b"".join([part async for part in self.stream()])
-        return self.content
+        return await self.content.aread()
 
     async def stream(self) -> typing.AsyncIterator[bytes]:
-        if self.is_streaming:
-            async for part in self.content_aiter:
-                yield part
-        elif self.content:
-            yield self.content
+        async for part in self.content:
+            yield part
 
 
 class Response:

--- a/httpx/multipart.py
+++ b/httpx/multipart.py
@@ -95,9 +95,12 @@ def iter_fields(data: dict, files: dict) -> typing.Iterator[Field]:
         yield FileField(name=name, value=value)
 
 
-def multipart_encode(data: dict, files: dict) -> typing.Tuple[bytes, str]:
+def multipart_encode(
+    data: dict, files: dict, boundary: bytes = None
+) -> typing.Tuple[bytes, str]:
     body = BytesIO()
-    boundary = binascii.hexlify(os.urandom(16))
+    if boundary is None:
+        boundary = binascii.hexlify(os.urandom(16))
 
     for field in iter_fields(data, files):
         body.write(b"--%s\r\n" % boundary)

--- a/tests/client/test_redirects.py
+++ b/tests/client/test_redirects.py
@@ -77,7 +77,6 @@ class MockDispatch(Dispatcher):
             return Response(codes.OK, content=content, request=request)
 
         elif request.url.path == "/redirect_body":
-            await request.read()
             headers = {"location": "/redirect_body_target"}
             return Response(codes.PERMANENT_REDIRECT, headers=headers, request=request)
 

--- a/tests/dispatch/test_http2.py
+++ b/tests/dispatch/test_http2.py
@@ -11,13 +11,12 @@ from httpx import Client, Response, TimeoutException
 from .utils import MockHTTP2Backend
 
 
-def app(request):
+async def app(request):
+    method = request.method
+    path = request.url.path
+    body = await request.read()
     content = json.dumps(
-        {
-            "method": request.method,
-            "path": request.url.path,
-            "body": request.content.decode(),
-        }
+        {"method": method, "path": path, "body": body.decode()}
     ).encode()
     headers = {"Content-Length": str(len(content))}
     return Response(200, headers=headers, content=content)

--- a/tests/models/test_requests.py
+++ b/tests/models/test_requests.py
@@ -18,16 +18,18 @@ def test_content_length_header():
     assert request.headers["Content-Length"] == "8"
 
 
-def test_url_encoded_data():
+@pytest.mark.asyncio
+async def test_url_encoded_data():
     request = httpx.Request("POST", "http://example.org", data={"test": "123"})
     assert request.headers["Content-Type"] == "application/x-www-form-urlencoded"
-    assert request.content == b"test=123"
+    assert await request.content.aread() == b"test=123"
 
 
-def test_json_encoded_data():
+@pytest.mark.asyncio
+async def test_json_encoded_data():
     request = httpx.Request("POST", "http://example.org", json={"test": 123})
     assert request.headers["Content-Type"] == "application/json"
-    assert request.content == b'{"test": 123}'
+    assert await request.content.aread() == b'{"test": 123}'
 
 
 def test_transfer_encoding_header():

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -9,7 +9,7 @@ from httpx.content import encode
 async def test_empty_content():
     content = encode()
 
-    assert content.can_rewind()
+    assert content.can_replay()
     assert content.get_headers() == {}
     assert await content.aread() == b""
 
@@ -18,7 +18,7 @@ async def test_empty_content():
 async def test_bytes_content():
     content = encode(data=b"Hello, world!")
 
-    assert content.can_rewind()
+    assert content.can_replay()
     assert content.get_headers() == {"Content-Length": "13"}
     assert await content.aread() == b"Hello, world!"
 
@@ -31,7 +31,7 @@ async def test_aiterator_content():
 
     content = encode(data=hello_world())
 
-    assert not content.can_rewind()
+    assert not content.can_replay()
     assert content.get_headers() == {"Transfer-Encoding": "chunked"}
     assert await content.aread() == b"Hello, world!"
 
@@ -40,7 +40,7 @@ async def test_aiterator_content():
 async def test_json_content():
     content = encode(json={"Hello": "world!"})
 
-    assert content.can_rewind()
+    assert content.can_replay()
     assert content.get_headers() == {
         "Content-Length": "19",
         "Content-Type": "application/json",
@@ -52,7 +52,7 @@ async def test_json_content():
 async def test_urlencoded_content():
     content = encode(data={"Hello": "world!"})
 
-    assert content.can_rewind()
+    assert content.can_replay()
     assert content.get_headers() == {
         "Content-Length": "14",
         "Content-Type": "application/x-www-form-urlencoded",
@@ -65,7 +65,7 @@ async def test_multipart_files_content():
     files = {"file": io.BytesIO(b"<file content>")}
     content = encode(files=files, boundary=b"+++")
 
-    assert content.can_rewind()
+    assert content.can_replay()
     assert content.get_headers() == {
         "Content-Length": "138",
         "Content-Type": "multipart/form-data; boundary=+++",
@@ -88,7 +88,7 @@ async def test_multipart_data_and_files_content():
     files = {"file": io.BytesIO(b"<file content>")}
     content = encode(data=data, files=files, boundary=b"+++")
 
-    assert content.can_rewind()
+    assert content.can_replay()
     assert content.get_headers() == {
         "Content-Length": "210",
         "Content-Type": "multipart/form-data; boundary=+++",

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -10,7 +10,7 @@ async def test_empty_content():
     content = encode()
 
     assert content.can_rewind()
-    assert content.headers() == {}
+    assert content.get_headers() == {}
     assert await content.aread() == b""
 
 
@@ -19,7 +19,7 @@ async def test_bytes_content():
     content = encode(data=b"Hello, world!")
 
     assert content.can_rewind()
-    assert content.headers() == {"Content-Length": "13"}
+    assert content.get_headers() == {"Content-Length": "13"}
     assert await content.aread() == b"Hello, world!"
 
 
@@ -32,7 +32,7 @@ async def test_aiterator_content():
     content = encode(data=hello_world())
 
     assert not content.can_rewind()
-    assert content.headers() == {"Transfer-Encoding": "chunked"}
+    assert content.get_headers() == {"Transfer-Encoding": "chunked"}
     assert await content.aread() == b"Hello, world!"
 
 
@@ -41,7 +41,7 @@ async def test_json_content():
     content = encode(json={"Hello": "world!"})
 
     assert content.can_rewind()
-    assert content.headers() == {
+    assert content.get_headers() == {
         "Content-Length": "19",
         "Content-Type": "application/json",
     }
@@ -53,7 +53,7 @@ async def test_urlencoded_content():
     content = encode(data={"Hello": "world!"})
 
     assert content.can_rewind()
-    assert content.headers() == {
+    assert content.get_headers() == {
         "Content-Length": "14",
         "Content-Type": "application/x-www-form-urlencoded",
     }
@@ -66,7 +66,7 @@ async def test_multipart_files_content():
     content = encode(files=files, boundary=b"+++")
 
     assert content.can_rewind()
-    assert content.headers() == {
+    assert content.get_headers() == {
         "Content-Length": "138",
         "Content-Type": "multipart/form-data; boundary=+++",
     }
@@ -89,7 +89,7 @@ async def test_multipart_data_and_files_content():
     content = encode(data=data, files=files, boundary=b"+++")
 
     assert content.can_rewind()
-    assert content.headers() == {
+    assert content.get_headers() == {
         "Content-Length": "210",
         "Content-Type": "multipart/form-data; boundary=+++",
     }

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -1,0 +1,109 @@
+import io
+
+import pytest
+
+from httpx.content import encode
+
+
+@pytest.mark.asyncio
+async def test_empty_content():
+    content = encode()
+
+    assert content.can_rewind()
+    assert content.headers() == {}
+    assert await content.aread() == b""
+
+
+@pytest.mark.asyncio
+async def test_bytes_content():
+    content = encode(data=b"Hello, world!")
+
+    assert content.can_rewind()
+    assert content.headers() == {"Content-Length": "13"}
+    assert await content.aread() == b"Hello, world!"
+
+
+@pytest.mark.asyncio
+async def test_aiterator_content():
+    async def hello_world():
+        yield b"Hello, "
+        yield b"world!"
+
+    content = encode(data=hello_world())
+
+    assert not content.can_rewind()
+    assert content.headers() == {"Transfer-Encoding": "chunked"}
+    assert await content.aread() == b"Hello, world!"
+
+
+@pytest.mark.asyncio
+async def test_json_content():
+    content = encode(json={"Hello": "world!"})
+
+    assert content.can_rewind()
+    assert content.headers() == {
+        "Content-Length": "19",
+        "Content-Type": "application/json",
+    }
+    assert await content.aread() == b'{"Hello": "world!"}'
+
+
+@pytest.mark.asyncio
+async def test_urlencoded_content():
+    content = encode(data={"Hello": "world!"})
+
+    assert content.can_rewind()
+    assert content.headers() == {
+        "Content-Length": "14",
+        "Content-Type": "application/x-www-form-urlencoded",
+    }
+    assert await content.aread() == b"Hello=world%21"
+
+
+@pytest.mark.asyncio
+async def test_multipart_files_content():
+    files = {"file": io.BytesIO(b"<file content>")}
+    content = encode(files=files, boundary=b"+++")
+
+    assert content.can_rewind()
+    assert content.headers() == {
+        "Content-Length": "138",
+        "Content-Type": "multipart/form-data; boundary=+++",
+    }
+    assert await content.aread() == b"".join(
+        [
+            b"--+++\r\n",
+            b'Content-Disposition: form-data; name="file"; filename="upload"\r\n',
+            b"Content-Type: application/octet-stream\r\n",
+            b"\r\n",
+            b"<file content>\r\n",
+            b"--+++--\r\n",
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_multipart_data_and_files_content():
+    data = {"message": "Hello, world!"}
+    files = {"file": io.BytesIO(b"<file content>")}
+    content = encode(data=data, files=files, boundary=b"+++")
+
+    assert content.can_rewind()
+    assert content.headers() == {
+        "Content-Length": "210",
+        "Content-Type": "multipart/form-data; boundary=+++",
+    }
+    assert await content.aread() == b"".join(
+        [
+            b"--+++\r\n",
+            b'Content-Disposition: form-data; name="message"\r\n',
+            b"\r\n",
+            b"Hello, world!\r\n",
+            b"--+++\r\n",
+            b'Content-Disposition: form-data; name="file"; filename="upload"\r\n',
+            b"Content-Type: application/octet-stream\r\n",
+            b"\r\n",
+            b"<file content>\r\n",
+            b"--+++--\r\n",
+        ]
+    )


### PR DESCRIPTION
## The RequestContent interface

This pull requests adds `RequestContent` as the internal interface for all request body construction. The RequestContent interface provides:

* `.get_headers()` - Return the headers for the encoding.
* `.is_rewindable()` - True if the content can be replayed, False otherwise.
* `async def __aiter__() -> bytes` - Returns the byte stream for the encoded data.

There are a few concrete implementations.

* `RequestContent` - An empty request content.
* `BytesRequestContent` - Handles plain bytes and str content.
* `StreamingRequestContent` - Handles byte async iterables. Not rewindable.
* `JSONRequestContent` - Handles JSON data.
* `URLEncodedRequestContent` - Handles URL encoded form data.
* `MultipartEncodedRequestContent` - Handles Multipart encoded form data.

There is also a top level function for handling returning a `RequestContent` instance, given `data, files, json` arguments.

* `encode(data, files, json) -> RequestContent`

## Motivation

Short: Generally a much nicer seperation of logic & will allow us to support both sync+async cases on a single `Request` class.

* All the request encoding logic is nicely seperated for the `Request` class itself, and testable in isolation.
* We'll be able to have both async and sync variants by implementing `__iter__` on the the interface alongside the existing `__aiter__` - most encodings will support both. The StreamingRequestContent will end up as two distinct cases sync+async, which will only support one or the other case, and will error if used incorrectly. (Eg. passing an async iterable as a `data=` argument will raise an error when used with a sync client.)
* This gets us much closer to being able to implement a streaming, rewindable multipart implementation.