### PR TITLE
Force compiling 'regex' from source to resolve failing CI builds

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@
 brotlipy==0.7.*
 
 autoflake
-black
+# See: https://github.com/encode/httpx/pull/639#issuecomment-566235998
+black --no-binary=regex
 cryptography
 flake8
 flake8-bugbear


### PR DESCRIPTION
Prompted by https://github.com/encode/httpx/pull/639#issuecomment-566235998. This issue is affecting all new builds (e.g. https://github.com/encode/httpx/pull/641). I notified the `regex` maintainers about it [here](https://bitbucket.org/mrabarnett/mrab-regex/issues/343/wheel-for-linux) and the issue is tracked [here](https://bitbucket.org/mrabarnett/mrab-regex/issues/349/no-module-named-regex_regex-regex-is-not-a), but for now we should get our CI back on track.