### PR TITLE
Version 0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.9.5 (December 20th, 2019)
+
+### Fixed
+
+- Fix Host header and HSTS rewrites when an explicit `:80` port is included in URL. (Pull #649)
+- Query Params on the URL string are merged with any `params=...` argument. (Pull #653)
+- More robust behavior when closing connections. (Pull #640)
+- More robust behavior when handling HTTP/2 headers with trailing whitespace. (Pull #637)
+- Allow any explicit `Content-Type` header to take precedence over the encoding default. (Pull #633)
+
 ## 0.9.4 (December 12th, 2019)
 
 ### Fixed

--- a/httpx/__version__.py
+++ b/httpx/__version__.py
@@ -1,3 +1,3 @@
 __title__ = "httpx"
 __description__ = "A next generation HTTP client, for Python 3."
-__version__ = "0.9.4"
+__version__ = "0.9.5"


### PR DESCRIPTION
## 0.9.5 (December 20th, 2019)

### Fixed

- Fix Host header and HSTS rewrites when an explicit `:80` port is included in URL. (Pull #649)
- Query Params on the URL string are merged with any `params=...` argument. (Pull #653)
- More robust behavior when closing connections. (Pull #640)
- More robust behavior when handling HTTP/2 headers with trailing whitespace. (Pull #637)
- Allow any explicit `Content-Type` header to take precedence over the encoding default. (Pull #633)
