### PR TITLE
Upgrade h11 to support both 0.8 and 0.9.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         "certifi",
         "hstspreload",
         "chardet==3.*",
-        "h11==0.8.*",
+        "h11>=0.8,<0.10",
         "h2==3.*",
         "idna==2.*",
         "rfc3986>=1.3,<2",


### PR DESCRIPTION
We ought to prefer using the latest `h11`, but we *are* still 0.8 compatible, so restrict allowed versions to `0.8.*`, `0.9.*`.