### PR TITLE
Rationalize backend Semaphore interface slightly

### DIFF
--- a/httpx/concurrency/auto.py
+++ b/httpx/concurrency/auto.py
@@ -6,7 +6,7 @@ import sniffio
 from ..config import Timeout
 from .base import (
     BaseEvent,
-    BasePoolSemaphore,
+    BaseSemaphore,
     BaseSocketStream,
     ConcurrencyBackend,
     lookup_backend,
@@ -44,13 +44,13 @@ class AutoBackend(ConcurrencyBackend):
     def time(self) -> float:
         return self.backend.time()
 
-    def get_semaphore(self, max_value: int) -> BasePoolSemaphore:
-        return self.backend.get_semaphore(max_value)
-
     async def run_in_threadpool(
         self, func: typing.Callable, *args: typing.Any, **kwargs: typing.Any
     ) -> typing.Any:
         return await self.backend.run_in_threadpool(func, *args, **kwargs)
+
+    def create_semaphore(self, max_value: int, exc_class: type) -> BaseSemaphore:
+        return self.backend.create_semaphore(max_value, exc_class)
 
     def create_event(self) -> BaseEvent:
         return self.backend.create_event()

--- a/httpx/concurrency/base.py
+++ b/httpx/concurrency/base.py
@@ -56,7 +56,8 @@ class BaseSocketStream:
 
 class BaseEvent:
     """
-    An event object. Abstracts away any asyncio-specific interfaces.
+    An abstract interface for Event classes.
+    Abstracts away any asyncio-specific interfaces.
     """
 
     def set(self) -> None:
@@ -66,10 +67,9 @@ class BaseEvent:
         raise NotImplementedError()  # pragma: no cover
 
 
-class BasePoolSemaphore:
+class BaseSemaphore:
     """
-    A semaphore for use with connection pooling.
-
+    An abstract interface for Semaphore classes.
     Abstracts away any asyncio-specific interfaces.
     """
 
@@ -102,9 +102,6 @@ class ConcurrencyBackend:
     def time(self) -> float:
         raise NotImplementedError()  # pragma: no cover
 
-    def get_semaphore(self, max_value: int) -> BasePoolSemaphore:
-        raise NotImplementedError()  # pragma: no cover
-
     async def run_in_threadpool(
         self, func: typing.Callable, *args: typing.Any, **kwargs: typing.Any
     ) -> typing.Any:
@@ -113,6 +110,9 @@ class ConcurrencyBackend:
     def run(
         self, coroutine: typing.Callable, *args: typing.Any, **kwargs: typing.Any
     ) -> typing.Any:
+        raise NotImplementedError()  # pragma: no cover
+
+    def create_semaphore(self, max_value: int, exc_class: type) -> BaseSemaphore:
         raise NotImplementedError()  # pragma: no cover
 
     def create_event(self) -> BaseEvent:


### PR DESCRIPTION
Some internal refactoring, to make the usage of backend 'semaphore' and 'event' classes more consistent.

* Switch to `create_semaphore()` for consistency with `create_event()`.
* Stop using `BasePoolSemaphore`, and instead just use a generic `BaseSemaphore`. Pass the `exc_class=PoolTimeout`, so that backend semaphores are *not* specific to any particular use-case. (We don't strictly need to do this, but I think it feels neater?)
* Move implementations into more consistent locations, so that event and semaphore implementations are kept close.