### PR TITLE
Make 'request' non-optional on responses

### DIFF
--- a/httpx/models.py
+++ b/httpx/models.py
@@ -661,11 +661,11 @@ class Response:
         self,
         status_code: int,
         *,
+        request: Request,
         http_version: str = None,
         headers: HeaderTypes = None,
         stream: ContentStream = None,
         content: bytes = None,
-        request: Request = None,
         history: typing.List["Response"] = None,
         elapsed: datetime.timedelta = None,
     ):
@@ -699,7 +699,7 @@ class Response:
 
         Requires that `request` was provided when instantiating the response.
         """
-        return None if self.request is None else self.request.url
+        return self.request.url
 
     @property
     def content(self) -> bytes:
@@ -831,7 +831,6 @@ class Response:
     @property
     def cookies(self) -> "Cookies":
         if not hasattr(self, "_cookies"):
-            assert self.request is not None
             self._cookies = Cookies()
             self._cookies.extract_cookies(self)
         return self._cookies
@@ -967,7 +966,6 @@ class Cookies(MutableMapping):
         """
         Loads any cookies based on the response `Set-Cookie` headers.
         """
-        assert response.request is not None
         urlib_response = self._CookieCompatResponse(response)
         urllib_request = self._CookieCompatRequest(response.request)
 

--- a/httpx/models.py
+++ b/httpx/models.py
@@ -696,8 +696,6 @@ class Response:
     def url(self) -> typing.Optional[URL]:
         """
         Returns the URL for which the request was made.
-
-        Requires that `request` was provided when instantiating the response.
         """
         return self.request.url
 

--- a/tests/dispatch/test_http2.py
+++ b/tests/dispatch/test_http2.py
@@ -19,7 +19,7 @@ async def app(request):
         {"method": method, "path": path, "body": body.decode()}
     ).encode()
     headers = {"Content-Length": str(len(content))}
-    return Response(200, headers=headers, content=content)
+    return Response(200, headers=headers, content=content, request=request)
 
 
 @pytest.mark.asyncio

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -41,9 +41,7 @@ def test_response_content_type_encoding():
     """
     headers = {"Content-Type": "text-plain; charset=latin-1"}
     content = "Latin 1: ÿ".encode("latin-1")
-    response = httpx.Response(
-        200, content=content, headers=headers, request=REQUEST
-    )
+    response = httpx.Response(200, content=content, headers=headers, request=REQUEST)
     assert response.text == "Latin 1: ÿ"
     assert response.encoding == "latin-1"
 
@@ -64,9 +62,7 @@ def test_response_fallback_to_autodetect():
     """
     headers = {"Content-Type": "text-plain; charset=invalid-codec-name"}
     content = "おはようございます。".encode("EUC-JP")
-    response = httpx.Response(
-        200, content=content, headers=headers, request=REQUEST
-    )
+    response = httpx.Response(200, content=content, headers=headers, request=REQUEST)
     assert response.text == "おはようございます。"
     assert response.encoding == "EUC-JP"
 
@@ -78,9 +74,7 @@ def test_response_default_text_encoding():
     """
     content = b"Hello, world!"
     headers = {"Content-Type": "text/plain"}
-    response = httpx.Response(
-        200, content=content, headers=headers, request=REQUEST
-    )
+    response = httpx.Response(200, content=content, headers=headers, request=REQUEST)
     assert response.status_code == 200
     assert response.encoding == "iso-8859-1"
     assert response.text == "Hello, world!"
@@ -100,9 +94,7 @@ def test_response_non_text_encoding():
     Default to apparent encoding for non-text content-type headers.
     """
     headers = {"Content-Type": "image/png"}
-    response = httpx.Response(
-        200, content=b"xyz", headers=headers, request=REQUEST
-    )
+    response = httpx.Response(200, content=b"xyz", headers=headers, request=REQUEST)
     assert response.text == "xyz"
     assert response.encoding == "ascii"
 
@@ -112,10 +104,7 @@ def test_response_set_explicit_encoding():
         "Content-Type": "text-plain; charset=utf-8"
     }  # Deliberately incorrect charset
     response = httpx.Response(
-        200,
-        content="Latin 1: ÿ".encode("latin-1"),
-        headers=headers,
-        request=REQUEST,
+        200, content="Latin 1: ÿ".encode("latin-1"), headers=headers, request=REQUEST,
     )
     response.encoding = "latin-1"
     assert response.text == "Latin 1: ÿ"
@@ -255,9 +244,7 @@ def test_json_with_specified_encoding():
     data = {"greeting": "hello", "recipient": "world"}
     content = json.dumps(data).encode("utf-16")
     headers = {"Content-Type": "application/json, charset=utf-16"}
-    response = httpx.Response(
-        200, content=content, headers=headers, request=REQUEST
-    )
+    response = httpx.Response(200, content=content, headers=headers, request=REQUEST)
     assert response.json() == data
 
 
@@ -265,9 +252,7 @@ def test_json_with_options():
     data = {"greeting": "hello", "recipient": "world", "amount": 1}
     content = json.dumps(data).encode("utf-16")
     headers = {"Content-Type": "application/json, charset=utf-16"}
-    response = httpx.Response(
-        200, content=content, headers=headers, request=REQUEST
-    )
+    response = httpx.Response(200, content=content, headers=headers, request=REQUEST)
     assert response.json(parse_int=str)["amount"] == "1"
 
 
@@ -275,9 +260,7 @@ def test_json_without_specified_encoding():
     data = {"greeting": "hello", "recipient": "world"}
     content = json.dumps(data).encode("utf-32-be")
     headers = {"Content-Type": "application/json"}
-    response = httpx.Response(
-        200, content=content, headers=headers, request=REQUEST
-    )
+    response = httpx.Response(200, content=content, headers=headers, request=REQUEST)
     assert response.json() == data
 
 

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -98,9 +98,7 @@ async def test_streaming():
 
     headers = [(b"Content-Encoding", b"gzip")]
     stream = AsyncIteratorStream(aiterator=compress(body))
-    response = httpx.Response(
-        200, headers=headers, stream=stream, request=REQUEST
-    )
+    response = httpx.Response(200, headers=headers, stream=stream, request=REQUEST)
     assert not hasattr(response, "body")
     assert await response.read() == body
 

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -14,6 +14,8 @@ from httpx.decoders import (
     TextDecoder,
 )
 
+REQUEST = httpx.Request("GET", "https://example.org")
+
 
 def test_deflate():
     body = b"test 123"
@@ -21,7 +23,9 @@ def test_deflate():
     compressed_body = compressor.compress(body) + compressor.flush()
 
     headers = [(b"Content-Encoding", b"deflate")]
-    response = httpx.Response(200, headers=headers, content=compressed_body)
+    response = httpx.Response(
+        200, headers=headers, content=compressed_body, request=REQUEST
+    )
     assert response.content == body
 
 
@@ -31,7 +35,9 @@ def test_gzip():
     compressed_body = compressor.compress(body) + compressor.flush()
 
     headers = [(b"Content-Encoding", b"gzip")]
-    response = httpx.Response(200, headers=headers, content=compressed_body)
+    response = httpx.Response(
+        200, headers=headers, content=compressed_body, request=REQUEST
+    )
     assert response.content == body
 
 
@@ -40,7 +46,9 @@ def test_brotli():
     compressed_body = brotli.compress(body)
 
     headers = [(b"Content-Encoding", b"br")]
-    response = httpx.Response(200, headers=headers, content=compressed_body)
+    response = httpx.Response(
+        200, headers=headers, content=compressed_body, request=REQUEST
+    )
     assert response.content == body
 
 
@@ -56,7 +64,9 @@ def test_multi():
     )
 
     headers = [(b"Content-Encoding", b"deflate, gzip")]
-    response = httpx.Response(200, headers=headers, content=compressed_body)
+    response = httpx.Response(
+        200, headers=headers, content=compressed_body, request=REQUEST
+    )
     assert response.content == body
 
 
@@ -65,11 +75,15 @@ def test_multi_with_identity():
     compressed_body = brotli.compress(body)
 
     headers = [(b"Content-Encoding", b"br, identity")]
-    response = httpx.Response(200, headers=headers, content=compressed_body)
+    response = httpx.Response(
+        200, headers=headers, content=compressed_body, request=REQUEST
+    )
     assert response.content == body
 
     headers = [(b"Content-Encoding", b"identity, br")]
-    response = httpx.Response(200, headers=headers, content=compressed_body)
+    response = httpx.Response(
+        200, headers=headers, content=compressed_body, request=REQUEST
+    )
     assert response.content == body
 
 
@@ -84,7 +98,9 @@ async def test_streaming():
 
     headers = [(b"Content-Encoding", b"gzip")]
     stream = AsyncIteratorStream(aiterator=compress(body))
-    response = httpx.Response(200, headers=headers, stream=stream)
+    response = httpx.Response(
+        200, headers=headers, stream=stream, request=REQUEST
+    )
     assert not hasattr(response, "body")
     assert await response.read() == body
 
@@ -92,7 +108,7 @@ async def test_streaming():
 @pytest.mark.parametrize("header_value", (b"deflate", b"gzip", b"br", b"identity"))
 def test_empty_content(header_value):
     headers = [(b"Content-Encoding", header_value)]
-    response = httpx.Response(200, headers=headers, content=b"")
+    response = httpx.Response(200, headers=headers, content=b"", request=REQUEST)
     assert response.content == b""
 
 
@@ -111,7 +127,9 @@ def test_decoding_errors(header_value):
     body = b"test 123"
     compressed_body = brotli.compress(body)[3:]
     with pytest.raises(httpx.DecodingError):
-        response = httpx.Response(200, headers=headers, content=compressed_body)
+        response = httpx.Response(
+            200, headers=headers, content=compressed_body, request=REQUEST
+        )
         response.content
 
 
@@ -140,7 +158,7 @@ async def test_text_decoder(data, encoding):
             yield chunk
 
     stream = AsyncIteratorStream(aiterator=iterator())
-    response = httpx.Response(200, stream=stream)
+    response = httpx.Response(200, stream=stream, request=REQUEST)
     await response.read()
     assert response.text == (b"".join(data)).decode(encoding)
 
@@ -157,6 +175,7 @@ async def test_text_decoder_known_encoding():
         200,
         headers=[(b"Content-Type", b"text/html; charset=shift-jis")],
         stream=stream,
+        request=REQUEST,
     )
 
     await response.read()
@@ -218,5 +237,5 @@ def test_invalid_content_encoding_header():
     headers = [(b"Content-Encoding", b"invalid-header")]
     body = b"test 123"
 
-    response = httpx.Response(200, headers=headers, content=body)
+    response = httpx.Response(200, headers=headers, content=body, request=REQUEST)
     assert response.content == body

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -22,7 +22,7 @@ class MockDispatch(Dispatcher):
         timeout: TimeoutTypes = None,
     ) -> httpx.Response:
         content = b"".join([part async for part in request.stream])
-        return httpx.Response(200, content=content)
+        return httpx.Response(200, content=content, request=request)
 
 
 @pytest.mark.parametrize(("value,output"), (("abc", b"abc"), (b"abc", b"abc")))


### PR DESCRIPTION
Prompted by https://github.com/encode/httpx/pull/665/files#r360601429: `response.request` is only ever `None` in our tests, so let's make it non-optional to provide better type-checking UX on the user side.