### PR TITLE
Brush up response deprecations

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -62,12 +62,12 @@
   the total elapsed seconds.
 * `def .raise_for_status()` - **None**
 * `def .json()` - **Any**
-* `def .read()` - **bytes**
+* `def .aread()` - **bytes**
 * `def .stream_raw()` - **async bytes iterator**
 * `def .stream_bytes()` - **async bytes iterator**
 * `def .stream_text()` - **async text iterator**
 * `def .stream_lines()` - **async text iterator**
-* `def .close()` - **None**
+* `def .aclose()` - **None**
 * `def .next()` - **Response**
 
 ## `Request`

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -32,7 +32,7 @@ Within a `stream()` block request data is made available with:
 * `.aiter_text()` - Instead of `response.iter_content(decode_unicode=True)`
 * `.aiter_lines()` - Instead of `response.iter_lines()`
 * `.aiter_raw()` - Use this instead of `response.raw`
-* `.read()` - Read the entire response body, making `request.text` and `response.content` available.
+* `.aread()` - Read the entire response body, making `request.text` and `response.content` available.
 
 ## SSL configuration
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -339,7 +339,7 @@ If you're using streaming responses in any of these ways then the `response.cont
 ```
 >>> async with httpx.stream("GET", "https://www.example.com") as r:
 ...     if r.headers['Content-Length'] < TOO_LONG:
-...         await r.read()
+...         await r.aread()
 ...         print(r.text)
 ```
 

--- a/httpx/client.py
+++ b/httpx/client.py
@@ -411,9 +411,9 @@ class Client:
 
         if not stream:
             try:
-                await response.read()
+                await response.aread()
             finally:
-                await response.close()
+                await response.aclose()
 
         return response
 
@@ -470,7 +470,7 @@ class Client:
             if not response.is_redirect:
                 return response
 
-            await response.read()
+            await response.aread()
             request = self.build_redirect_request(request, response)
             history = history + [response]
 
@@ -596,11 +596,11 @@ class Client:
             except StopIteration:
                 return response
             except BaseException as exc:
-                await response.close()
+                await response.aclose()
                 raise exc from None
             else:
                 request = next_request
-                await response.close()
+                await response.aclose()
 
     async def send_single_request(
         self,
@@ -980,6 +980,6 @@ class StreamContextManager:
         exc_value: BaseException = None,
         traceback: TracebackType = None,
     ) -> None:
-        await self.response.close()
+        await self.response.aclose()
         if self.close_client:
             await self.client.close()

--- a/httpx/dispatch/proxy_http.py
+++ b/httpx/dispatch/proxy_http.py
@@ -159,7 +159,7 @@ class HTTPProxy(ConnectionPool):
             f"response={proxy_response!r}"
         )
         if not (200 <= proxy_response.status_code <= 299):
-            await proxy_response.read()
+            await proxy_response.aread()
             raise ProxyError(
                 f"Non-2XX response received from HTTP proxy "
                 f"({proxy_response.status_code})",

--- a/httpx/models.py
+++ b/httpx/models.py
@@ -850,7 +850,15 @@ class Response:
     def __repr__(self) -> str:
         return f"<Response [{self.status_code} {self.reason_phrase}]>"
 
-    async def read(self) -> bytes:
+    @property
+    def read(self) -> typing.Callable:
+        warnings.warn(
+            "Response.read() is due to be deprecated. Use Response.aread() instead.",
+            category=DeprecationWarning,
+        )
+        return self.aread
+
+    async def aread(self) -> bytes:
         """
         Read and return the response content.
         """
@@ -862,7 +870,8 @@ class Response:
     def stream(self):  # type: ignore
         warnings.warn(
             "Response.stream() is due to be deprecated. "
-            "Use Response.aiter_bytes() instead."
+            "Use Response.aiter_bytes() instead.",
+            category=DeprecationWarning,
         )
         return self.aiter_bytes
 
@@ -870,7 +879,8 @@ class Response:
     def raw(self):  # type: ignore
         warnings.warn(
             "Response.raw() is due to be deprecated. "
-            "Use Response.aiter_raw() instead."
+            "Use Response.aiter_raw() instead.",
+            category=DeprecationWarning,
         )
         return self.aiter_raw
 
@@ -920,7 +930,7 @@ class Response:
             self.is_stream_consumed = True
             async for part in self._raw_stream:
                 yield part
-            await self.close()
+            await self.aclose()
 
     async def next(self) -> "Response":
         """
@@ -931,7 +941,16 @@ class Response:
         assert self.call_next is not None
         return await self.call_next()
 
-    async def close(self) -> None:
+    @property
+    def close(self) -> typing.Callable:
+        warnings.warn(
+            "Response.close() is due to be deprecated. "
+            "Use Response.aclose() instead.",
+            category=DeprecationWarning,
+        )
+        return self.aclose
+
+    async def aclose(self) -> None:
         """
         Close the response and release the connection.
         Automatically called if the response body is read to completion.

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -53,7 +53,7 @@ async def test_post_json(server):
 async def test_stream_response(server):
     async with httpx.Client() as client:
         async with client.stream("GET", server.url) as response:
-            body = await response.read()
+            body = await response.aread()
 
     assert response.status_code == 200
     assert body == b"Hello, world!"

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -59,7 +59,7 @@ async def test_post_json(server):
 async def test_stream_response(server):
     async with httpx.Client() as client:
         async with client.stream("GET", server.url) as response:
-            content = await response.read()
+            content = await response.aread()
     assert response.status_code == 200
     assert content == b"Hello, world!"
 

--- a/tests/dispatch/test_connection_pools.py
+++ b/tests/dispatch/test_connection_pools.py
@@ -11,12 +11,12 @@ async def test_keepalive_connections(server):
     """
     async with ConnectionPool() as http:
         response = await http.request("GET", server.url)
-        await response.read()
+        await response.aread()
         assert len(http.active_connections) == 0
         assert len(http.keepalive_connections) == 1
 
         response = await http.request("GET", server.url)
-        await response.read()
+        await response.aread()
         assert len(http.active_connections) == 0
         assert len(http.keepalive_connections) == 1
 
@@ -28,7 +28,7 @@ async def test_keepalive_timeout(server):
     """
     async with ConnectionPool() as http:
         response = await http.request("GET", server.url)
-        await response.read()
+        await response.aread()
         assert len(http.active_connections) == 0
         assert len(http.keepalive_connections) == 1
 
@@ -42,7 +42,7 @@ async def test_keepalive_timeout(server):
         http.KEEP_ALIVE_EXPIRY = 0.0
 
         response = await http.request("GET", server.url)
-        await response.read()
+        await response.aread()
         assert len(http.active_connections) == 0
         assert len(http.keepalive_connections) == 1
 
@@ -60,12 +60,12 @@ async def test_differing_connection_keys(server):
     """
     async with ConnectionPool() as http:
         response = await http.request("GET", server.url)
-        await response.read()
+        await response.aread()
         assert len(http.active_connections) == 0
         assert len(http.keepalive_connections) == 1
 
         response = await http.request("GET", "http://localhost:8000/")
-        await response.read()
+        await response.aread()
         assert len(http.active_connections) == 0
         assert len(http.keepalive_connections) == 2
 
@@ -79,12 +79,12 @@ async def test_soft_limit(server):
 
     async with ConnectionPool(pool_limits=pool_limits) as http:
         response = await http.request("GET", server.url)
-        await response.read()
+        await response.aread()
         assert len(http.active_connections) == 0
         assert len(http.keepalive_connections) == 1
 
         response = await http.request("GET", "http://localhost:8000/")
-        await response.read()
+        await response.aread()
         assert len(http.active_connections) == 0
         assert len(http.keepalive_connections) == 1
 
@@ -99,7 +99,7 @@ async def test_streaming_response_holds_connection(server):
         assert len(http.active_connections) == 1
         assert len(http.keepalive_connections) == 0
 
-        await response.read()
+        await response.aread()
 
         assert len(http.active_connections) == 0
         assert len(http.keepalive_connections) == 1
@@ -119,11 +119,11 @@ async def test_multiple_concurrent_connections(server):
         assert len(http.active_connections) == 2
         assert len(http.keepalive_connections) == 0
 
-        await response_b.read()
+        await response_b.aread()
         assert len(http.active_connections) == 1
         assert len(http.keepalive_connections) == 1
 
-        await response_a.read()
+        await response_a.aread()
         assert len(http.active_connections) == 0
         assert len(http.keepalive_connections) == 2
 
@@ -136,7 +136,7 @@ async def test_close_connections(server):
     headers = [(b"connection", b"close")]
     async with ConnectionPool() as http:
         response = await http.request("GET", server.url, headers=headers)
-        await response.read()
+        await response.aread()
         assert len(http.active_connections) == 0
         assert len(http.keepalive_connections) == 0
 
@@ -148,8 +148,8 @@ async def test_standard_response_close(server):
     """
     async with ConnectionPool() as http:
         response = await http.request("GET", server.url)
-        await response.read()
-        await response.close()
+        await response.aread()
+        await response.aclose()
         assert len(http.active_connections) == 0
         assert len(http.keepalive_connections) == 1
 
@@ -161,7 +161,7 @@ async def test_premature_response_close(server):
     """
     async with ConnectionPool() as http:
         response = await http.request("GET", server.url)
-        await response.close()
+        await response.aclose()
         assert len(http.active_connections) == 0
         assert len(http.keepalive_connections) == 0
 
@@ -174,13 +174,13 @@ async def test_keepalive_connection_closed_by_server_is_reestablished(server, re
     """
     async with ConnectionPool() as http:
         response = await http.request("GET", server.url)
-        await response.read()
+        await response.aread()
 
         # Shutdown the server to close the keep-alive connection
         await restart(server)
 
         response = await http.request("GET", server.url)
-        await response.read()
+        await response.aread()
         assert len(http.active_connections) == 0
         assert len(http.keepalive_connections) == 1
 
@@ -195,13 +195,13 @@ async def test_keepalive_http2_connection_closed_by_server_is_reestablished(
     """
     async with ConnectionPool() as http:
         response = await http.request("GET", server.url)
-        await response.read()
+        await response.aread()
 
         # Shutdown the server to close the keep-alive connection
         await restart(server)
 
         response = await http.request("GET", server.url)
-        await response.read()
+        await response.aread()
         assert len(http.active_connections) == 0
         assert len(http.keepalive_connections) == 1
 
@@ -214,7 +214,7 @@ async def test_connection_closed_free_semaphore_on_acquire(server, restart):
     """
     async with ConnectionPool(pool_limits=httpx.PoolLimits(hard_limit=1)) as http:
         response = await http.request("GET", server.url)
-        await response.read()
+        await response.aread()
 
         # Close the connection so we're forced to recycle it
         await restart(server)

--- a/tests/dispatch/test_connections.py
+++ b/tests/dispatch/test_connections.py
@@ -8,7 +8,7 @@ from httpx.dispatch.connection import HTTPConnection
 async def test_get(server):
     async with HTTPConnection(origin=server.url) as conn:
         response = await conn.request("GET", server.url)
-        await response.read()
+        await response.aread()
         assert response.status_code == 200
         assert response.content == b"Hello, world!"
 
@@ -27,7 +27,7 @@ async def test_premature_close(server):
             response = await conn.request(
                 "GET", server.url.copy_with(path="/premature_close")
             )
-            await response.read()
+            await response.aread()
 
 
 @pytest.mark.usefixtures("async_environment")
@@ -37,7 +37,7 @@ async def test_https_get_with_ssl_defaults(https_server, ca_cert_pem_file):
     """
     async with HTTPConnection(origin=https_server.url, verify=ca_cert_pem_file) as conn:
         response = await conn.request("GET", https_server.url)
-        await response.read()
+        await response.aread()
         assert response.status_code == 200
         assert response.content == b"Hello, world!"
 
@@ -49,6 +49,6 @@ async def test_https_get_with_sll_overrides(https_server, ca_cert_pem_file):
     """
     async with HTTPConnection(origin=https_server.url) as conn:
         response = await conn.request("GET", https_server.url, verify=ca_cert_pem_file)
-        await response.read()
+        await response.aread()
         assert response.status_code == 200
         assert response.content == b"Hello, world!"

--- a/tests/dispatch/test_proxy_http.py
+++ b/tests/dispatch/test_proxy_http.py
@@ -119,7 +119,7 @@ async def test_proxy_tunnel_start_tls():
         assert resp.request.url == "https://example.com"
         assert resp.request.headers["Host"] == "example.com"
 
-        await resp.read()
+        await resp.aread()
 
         # Make another request to see that the tunnel is re-used.
         resp = await proxy.request("GET", "https://example.com/target")
@@ -131,7 +131,7 @@ async def test_proxy_tunnel_start_tls():
         assert resp.request.url == "https://example.com/target"
         assert resp.request.headers["Host"] == "example.com"
 
-        await resp.read()
+        await resp.aread()
 
     recv = raw_io.received_data
     assert len(recv) == 5

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -131,7 +131,7 @@ async def test_read_response():
     assert response.encoding == "ascii"
     assert response.is_closed
 
-    content = await response.read()
+    content = await response.aread()
 
     assert content == b"Hello, world!"
     assert response.content == b"Hello, world!"
@@ -162,7 +162,7 @@ async def test_bytes_interface():
 async def test_text_interface():
     response = httpx.Response(200, content=b"Hello, world!", request=REQUEST)
 
-    await response.read()
+    await response.aread()
 
     content = ""
     async for part in response.aiter_text():
@@ -174,7 +174,7 @@ async def test_text_interface():
 async def test_lines_interface():
     response = httpx.Response(200, content=b"Hello,\nworld!", request=REQUEST)
 
-    await response.read()
+    await response.aread()
 
     content = []
     async for line in response.aiter_lines():
@@ -186,7 +186,7 @@ async def test_lines_interface():
 async def test_stream_interface_after_read():
     response = httpx.Response(200, content=b"Hello, world!", request=REQUEST)
 
-    await response.read()
+    await response.aread()
 
     content = b""
     async for part in response.aiter_bytes():
@@ -202,7 +202,7 @@ async def test_streaming_response():
     assert response.status_code == 200
     assert not response.is_closed
 
-    content = await response.read()
+    content = await response.aread()
 
     assert content == b"Hello, world!"
     assert response.content == b"Hello, world!"
@@ -219,7 +219,7 @@ async def test_cannot_read_after_stream_consumed():
         content += part
 
     with pytest.raises(httpx.StreamConsumed):
-        await response.read()
+        await response.aread()
 
 
 @pytest.mark.asyncio
@@ -227,10 +227,10 @@ async def test_cannot_read_after_response_closed():
     stream = AsyncIteratorStream(aiterator=async_streaming_body())
     response = httpx.Response(200, stream=stream, request=REQUEST)
 
-    await response.close()
+    await response.aclose()
 
     with pytest.raises(httpx.ResponseClosed):
-        await response.read()
+        await response.aread()
 
 
 def test_unknown_status_code():
@@ -296,3 +296,22 @@ def test_json_without_specified_encoding_decode_error():
 def test_link_headers(headers, expected):
     response = httpx.Response(200, content=None, headers=headers, request=REQUEST)
     assert response.links == expected
+
+
+@pytest.mark.asyncio
+async def test_response_deprecations() -> None:
+    response = httpx.Response(200, request=REQUEST)
+
+    with pytest.deprecated_call(match="aread"):
+        await response.read()
+
+    with pytest.deprecated_call(match="aiter_raw"):
+        async for _ in response.raw():
+            pass
+
+    with pytest.deprecated_call(match="aiter_bytes"):
+        async for _ in response.stream():
+            pass
+
+    with pytest.deprecated_call(match="aclose"):
+        await response.close()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -69,7 +69,7 @@ async def test_delete(server):
 @pytest.mark.asyncio
 async def test_stream(server):
     async with httpx.stream("GET", server.url) as response:
-        await response.read()
+        await response.aread()
 
     assert response.status_code == 200
     assert response.reason_phrase == "OK"

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -100,7 +100,7 @@ async def test_streaming():
     stream = AsyncIteratorStream(aiterator=compress(body))
     response = httpx.Response(200, headers=headers, stream=stream, request=REQUEST)
     assert not hasattr(response, "body")
-    assert await response.read() == body
+    assert await response.aread() == body
 
 
 @pytest.mark.parametrize("header_value", (b"deflate", b"gzip", b"br", b"identity"))
@@ -157,7 +157,7 @@ async def test_text_decoder(data, encoding):
 
     stream = AsyncIteratorStream(aiterator=iterator())
     response = httpx.Response(200, stream=stream, request=REQUEST)
-    await response.read()
+    await response.aread()
     assert response.text == (b"".join(data)).decode(encoding)
 
 
@@ -176,7 +176,7 @@ async def test_text_decoder_known_encoding():
         request=REQUEST,
     )
 
-    await response.read()
+    await response.aread()
     assert "".join(response.text) == "トラベル"
 
 


### PR DESCRIPTION
Refs #667 

- Deprecate `.read()` in favor of `.aread()`.
- Deprecate `.close()` in favor of `.aclose()`.
- Use the `DeprecationWarning` category for all deprecation-related warnings on `Response`.
- Add a test for deprecated `Response` methods.