### PR TITLE
Brush up client deprecations

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -21,14 +21,14 @@ The recommended way to use a `Client` is as a context manager. This will ensure 
 <Response [200 OK]>
 ```
 
-Alternatively, you can explicitly close the connection pool without block-usage using `.close()`:
+Alternatively, you can explicitly close the connection pool without block-usage using `.aclose()`:
 
 ```python
 >>> client = httpx.Client()
 >>> try:
 ...     r = await client.get('https://example.com')
 ... finally:
-...     await client.close()
+...     await client.aclose()
 ...
 >>> r
 <Response [200 OK]>

--- a/httpx/client.py
+++ b/httpx/client.py
@@ -226,24 +226,28 @@ class Client:
             warnings.warn(
                 "Passing a 'cert' argument when making a request on a client "
                 "is due to be deprecated. Instantiate a new client instead, "
-                "passing any 'cert' arguments to the client itself."
+                "passing any 'cert' arguments to the client itself.",
+                category=DeprecationWarning,
             )
         if verify is not None:
             warnings.warn(
                 "Passing a 'verify' argument when making a request on a client "
                 "is due to be deprecated. Instantiate a new client instead, "
-                "passing any 'verify' arguments to the client itself."
+                "passing any 'verify' arguments to the client itself.",
+                category=DeprecationWarning,
             )
         if trust_env is not None:
             warnings.warn(
                 "Passing a 'trust_env' argument when making a request on a client "
                 "is due to be deprecated. Instantiate a new client instead, "
-                "passing any 'trust_env' argument to the client itself."
+                "passing any 'trust_env' argument to the client itself.",
+                category=DeprecationWarning,
             )
         if stream:
             warnings.warn(
                 "The 'stream=True' argument is due to be deprecated. "
-                "Use 'async with client.stream(method, url, ...) as response' instead."
+                "Use 'async with client.stream(method, url, ...) as response' instead.",
+                category=DeprecationWarning,
             )
 
         request = self.build_request(
@@ -891,7 +895,15 @@ class Client:
             trust_env=trust_env,
         )
 
-    async def close(self) -> None:
+    @property
+    def close(self) -> typing.Callable:
+        warnings.warn(
+            "Client.close() is due to be deprecated. Use Client.aclose() instead.",
+            category=DeprecationWarning,
+        )
+        return self.aclose
+
+    async def aclose(self) -> None:
         await self.dispatch.close()
 
     async def __aenter__(self) -> "Client":
@@ -903,7 +915,7 @@ class Client:
         exc_value: BaseException = None,
         traceback: TracebackType = None,
     ) -> None:
-        await self.close()
+        await self.aclose()
 
 
 def _proxies_to_dispatchers(
@@ -982,4 +994,4 @@ class StreamContextManager:
     ) -> None:
         await self.response.close()
         if self.close_client:
-            await self.client.close()
+            await self.client.aclose()

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -1,3 +1,4 @@
+import typing
 from datetime import timedelta
 
 import pytest
@@ -167,3 +168,25 @@ async def test_explicit_backend(server, async_environment):
         response = await client.get(server.url)
     assert response.status_code == 200
     assert response.text == "Hello, world!"
+
+
+@pytest.mark.asyncio
+async def test_client_deprecations(server: typing.Any) -> None:
+    url = server.url
+    client = httpx.Client()
+
+    with pytest.deprecated_call():
+        await client.get(url, cert="example.pem")
+
+    with pytest.deprecated_call():
+        await client.get(url, verify=False)
+
+    with pytest.deprecated_call():
+        await client.get(url, trust_env=False)
+
+    with pytest.deprecated_call(match="client.stream"):
+        response = await client.get(url, stream=True)
+        await response.close()
+
+    with pytest.deprecated_call(match="aclose"):
+        await client.close()


### PR DESCRIPTION
Refs #667 

- Deprecate `.close()` in favor of `.aclose()`.
- Use the `DeprecationWarning` category for all deprecation-related warnings on `Response`.
- Add a test for deprecated `Client` methods and parameters.