### PR TITLE
Fix out-of-date streaming methods on Response API docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -63,10 +63,10 @@
 * `def .raise_for_status()` - **None**
 * `def .json()` - **Any**
 * `def .read()` - **bytes**
-* `def .stream_raw()` - **async bytes iterator**
-* `def .stream_bytes()` - **async bytes iterator**
-* `def .stream_text()` - **async text iterator**
-* `def .stream_lines()` - **async text iterator**
+* `def .aiter_raw()` - **async bytes iterator**
+* `def .aiter_bytes()` - **async bytes iterator**
+* `def .aiter_text()` - **async text iterator**
+* `def .aiter_lines()` - **async text iterator**
 * `def .close()` - **None**
 * `def .next()` - **Response**
 


### PR DESCRIPTION
The `Response` API reference still showcased the `stream_*` methods instead of `aiter_*` - refs #610.