### PR TITLE
Make client.cookies setter expect a Cookies instance

### DIFF
--- a/httpx/client.py
+++ b/httpx/client.py
@@ -189,8 +189,8 @@ class Client:
         return self._cookies
 
     @cookies.setter
-    def cookies(self, cookies: CookieTypes) -> None:
-        self._cookies = Cookies(cookies)
+    def cookies(self, cookies: Cookies) -> None:
+        self._cookies = cookies
 
     @property
     def params(self) -> QueryParams:

--- a/tests/client/test_cookies.py
+++ b/tests/client/test_cookies.py
@@ -105,7 +105,7 @@ async def test_setting_client_cookies_to_cookiejar():
     cookies.set_cookie(cookie)
 
     client = Client(dispatch=MockDispatch())
-    client.cookies = cookies
+    client.cookies = Cookies(cookies)
     response = await client.get(url)
 
     assert response.status_code == 200

--- a/tests/client/test_properties.py
+++ b/tests/client/test_properties.py
@@ -10,7 +10,7 @@ def test_client_headers():
 
 def test_client_cookies():
     client = Client()
-    client.cookies = {"a": "b"}
+    client.cookies = Cookies({"a": "b"})
     assert isinstance(client.cookies, Cookies)
     mycookies = list(client.cookies.jar)
     assert len(mycookies) == 1


### PR DESCRIPTION
Prompted by https://github.com/encode/httpx/pull/677#discussion_r360668301

@tomchristie IMO the only thing that *does* look odd (at least from a typing perspective) is the setter magic, so this PR focuses on that. In particular, not sure we really want to get rid of `CookieTypes` and change the `cookies` parameters to prevent using the convenience `dict`/`CookieJar` types.