### PR TITLE
Rename Client to AsyncClient (with compat synonym)

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -10,7 +10,7 @@ all outgoing requests.
     A Client instance is equivalent to a Session instance in `requests`.
 
 !!! note
-    Starting from `httpx==0.10.0`, the default and recommended Client class is `AsyncClient`.
+    Starting from `httpx==0.10.0`, the default and recommended Client class is `AsyncClient`. This should help prevent breaking changes once sync support is reintroduced.
 
     A `Client` synonym remains for compatibility with `httpx==0.9.*` releases, but you are encouraged to migrate to `AsyncClient` as soon as possible.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -32,9 +32,9 @@
 ::: httpx.delete
     :docstring:
 
-## `Client`
+## `AsyncClient`
 
-::: httpx.Client
+::: httpx.AsyncClient
     :docstring:
     :members: headers cookies params request get head options post put patch delete build_request send close
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -52,7 +52,7 @@ We don't support `response.is_ok` since the naming is ambiguous there, and might
 
 ## Client instances
 
-The HTTPX equivalent of `requests.Session` is `httpx.Client`.
+The HTTPX equivalent of `requests.Session` is `httpx.AsyncClient`.
 
 ```python
 session = requests.Session(**kwargs)
@@ -61,7 +61,7 @@ session = requests.Session(**kwargs)
 is generally equivalent to
 
 ```python
-client = httpx.Client(**kwargs)
+client = httpx.AsyncClient(**kwargs)
 ```
 
 ## Mocking

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -4,7 +4,7 @@ Environment Variables
 The HTTPX library can be configured via environment variables.
 Environment variables are used by default. To ignore environment variables, `trust_env` has to be set `False`. There are two ways to set `trust_env` to disable environment variables:
 
-* On the client via `httpx.Client(trust_env=False)`.
+* On the client via `httpx.AsyncClient(trust_env=False)`.
 * Using the top-level API, such as `httpx.get("<url>", trust_env=False)`.
 
 Here is a list of environment variables that HTTPX recognizes and what function they serve:
@@ -24,7 +24,7 @@ Example:
 # test_script.py
 import httpx
 
-with httpx.Client() as client:
+with httpx.AsyncClient() as client:
     r = client.get("https://google.com")
 ```
 
@@ -89,7 +89,7 @@ Example:
 # test_script.py
 import httpx
 
-with httpx.Client() as client:
+with httpx.AsyncClient() as client:
     r = client.get("https://google.com")
 ```
 

--- a/docs/http2.md
+++ b/docs/http2.md
@@ -30,7 +30,7 @@ trying out our HTTP/2 support. You can do so by instantiating a client with
 HTTP/2 support enabled:
 
 ```python
-client = httpx.Client(http2=True)
+client = httpx.AsyncClient(http2=True)
 ...
 ```
 
@@ -39,7 +39,7 @@ HTTP connections are nicely scoped, and will be closed once the context block
 is exited.
 
 ```python
-async with httpx.Client(http2=True) as client:
+async with httpx.AsyncClient(http2=True) as client:
     ...
 ```
 
@@ -54,7 +54,7 @@ You can determine which version of the HTTP protocol was used by examining
 the `.http_version` property on the response.
 
 ```python
-client = httpx.Client(http2=True)
+client = httpx.AsyncClient(http2=True)
 response = await client.get(...)
 print(response.http_version)  # "HTTP/1.0", "HTTP/1.1", or "HTTP/2".
 ```

--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -1,7 +1,7 @@
 from .__version__ import __description__, __title__, __version__
 from .api import delete, get, head, options, patch, post, put, request, stream
 from .auth import BasicAuth, DigestAuth
-from .client import Client
+from .client import AsyncClient, Client
 from .config import TimeoutConfig  # For 0.8 backwards compat.
 from .config import PoolLimits, Timeout
 from .dispatch.proxy_http import HTTPProxy, HTTPProxyMode
@@ -44,6 +44,7 @@ __all__ = [
     "request",
     "stream",
     "codes",
+    "AsyncClient",
     "BasicAuth",
     "Client",
     "DigestAuth",

--- a/httpx/api.py
+++ b/httpx/api.py
@@ -1,7 +1,7 @@
 import typing
 
 from .auth import AuthTypes
-from .client import Client, StreamContextManager
+from .client import AsyncClient, StreamContextManager
 from .config import DEFAULT_TIMEOUT_CONFIG, CertTypes, TimeoutTypes, VerifyTypes
 from .models import (
     CookieTypes,
@@ -81,7 +81,7 @@ async def request(
     <Response [200 OK]>
     ```
     """
-    async with Client(
+    async with AsyncClient(
         cert=cert, verify=verify, timeout=timeout, trust_env=trust_env,
     ) as client:
         return await client.request(
@@ -116,7 +116,7 @@ def stream(
     cert: CertTypes = None,
     trust_env: bool = True,
 ) -> StreamContextManager:
-    client = Client(cert=cert, verify=verify, trust_env=trust_env)
+    client = AsyncClient(cert=cert, verify=verify, trust_env=trust_env)
     request = Request(
         method=method,
         url=url,

--- a/httpx/client.py
+++ b/httpx/client.py
@@ -52,14 +52,15 @@ from .utils import ElapsedTimer, NetRCInfo, get_environment_proxies, get_logger
 logger = get_logger(__name__)
 
 
-class Client:
+class AsyncClient:
     """
-    An HTTP client, with connection pooling, HTTP/2, redirects, cookie persistence, etc.
+    An asynchronous HTTP client, with connection pooling, HTTP/2, redirects,
+    cookie persistence, etc.
 
     Usage:
 
-    ```
-    >>> client = httpx.Client()
+    ```python
+    >>> client = httpx.AsyncClient()
     >>> response = client.get('https://example.org')
     ```
 
@@ -894,7 +895,7 @@ class Client:
     async def close(self) -> None:
         await self.dispatch.close()
 
-    async def __aenter__(self) -> "Client":
+    async def __aenter__(self) -> "AsyncClient":
         return self
 
     async def __aexit__(
@@ -949,7 +950,7 @@ def _proxies_to_dispatchers(
 class StreamContextManager:
     def __init__(
         self,
-        client: Client,
+        client: AsyncClient,
         request: Request,
         *,
         auth: AuthTypes = None,
@@ -983,3 +984,7 @@ class StreamContextManager:
         await self.response.close()
         if self.close_client:
             await self.client.close()
+
+
+# For compatibility with 0.9.x.
+Client = AsyncClient

--- a/httpx/dispatch/asgi.py
+++ b/httpx/dispatch/asgi.py
@@ -15,7 +15,7 @@ class ASGIDispatch(Dispatcher):
     and will setup an appropriate dispatch class:
 
     ```
-    client = httpx.Client(app=app)
+    client = httpx.AsyncClient(app=app)
     ```
 
     Alternatively, you can setup the dispatch instance explicitly.
@@ -28,7 +28,7 @@ class ASGIDispatch(Dispatcher):
         root_path="/submount",
         client=("1.2.3.4", 123)
     )
-    client = httpx.Client(dispatch=dispatch)
+    client = httpx.AsyncClient(dispatch=dispatch)
     ```
 
     Arguments:

--- a/httpx/dispatch/base.py
+++ b/httpx/dispatch/base.py
@@ -18,7 +18,7 @@ class Dispatcher:
 
     Stubs out the interface, as well as providing a `.request()` convenience
     implementation, to make it easy to use or test stand-alone dispatchers,
-    without requiring a complete `Client` instance.
+    without requiring a complete `AsyncClient` instance.
     """
 
     async def request(

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -8,7 +8,7 @@ import httpx
 @pytest.mark.usefixtures("async_environment")
 async def test_get(server):
     url = server.url
-    async with httpx.Client() as client:
+    async with httpx.AsyncClient() as client:
         response = await client.get(url)
     assert response.status_code == 200
     assert response.text == "Hello, world!"
@@ -22,7 +22,7 @@ async def test_get(server):
 async def test_build_request(server):
     url = server.url.copy_with(path="/echo_headers")
     headers = {"Custom-header": "value"}
-    async with httpx.Client() as client:
+    async with httpx.AsyncClient() as client:
         request = client.build_request("GET", url)
         request.headers.update(headers)
         response = await client.send(request)
@@ -36,7 +36,7 @@ async def test_build_request(server):
 @pytest.mark.usefixtures("async_environment")
 async def test_post(server):
     url = server.url
-    async with httpx.Client() as client:
+    async with httpx.AsyncClient() as client:
         response = await client.post(url, data=b"Hello, world!")
     assert response.status_code == 200
 
@@ -44,14 +44,14 @@ async def test_post(server):
 @pytest.mark.usefixtures("async_environment")
 async def test_post_json(server):
     url = server.url
-    async with httpx.Client() as client:
+    async with httpx.AsyncClient() as client:
         response = await client.post(url, json={"text": "Hello, world!"})
     assert response.status_code == 200
 
 
 @pytest.mark.usefixtures("async_environment")
 async def test_stream_response(server):
-    async with httpx.Client() as client:
+    async with httpx.AsyncClient() as client:
         async with client.stream("GET", server.url) as response:
             body = await response.read()
 
@@ -62,7 +62,7 @@ async def test_stream_response(server):
 
 @pytest.mark.usefixtures("async_environment")
 async def test_access_content_stream_response(server):
-    async with httpx.Client() as client:
+    async with httpx.AsyncClient() as client:
         async with client.stream("GET", server.url) as response:
             pass
 
@@ -77,14 +77,14 @@ async def test_stream_request(server):
         yield b"Hello, "
         yield b"world!"
 
-    async with httpx.Client() as client:
+    async with httpx.AsyncClient() as client:
         response = await client.request("POST", server.url, data=hello_world())
     assert response.status_code == 200
 
 
 @pytest.mark.usefixtures("async_environment")
 async def test_raise_for_status(server):
-    async with httpx.Client() as client:
+    async with httpx.AsyncClient() as client:
         for status_code in (200, 400, 404, 500, 505):
             response = await client.request(
                 "GET", server.url.copy_with(path=f"/status/{status_code}")
@@ -100,7 +100,7 @@ async def test_raise_for_status(server):
 
 @pytest.mark.usefixtures("async_environment")
 async def test_options(server):
-    async with httpx.Client() as client:
+    async with httpx.AsyncClient() as client:
         response = await client.options(server.url)
     assert response.status_code == 200
     assert response.text == "Hello, world!"
@@ -108,7 +108,7 @@ async def test_options(server):
 
 @pytest.mark.usefixtures("async_environment")
 async def test_head(server):
-    async with httpx.Client() as client:
+    async with httpx.AsyncClient() as client:
         response = await client.head(server.url)
     assert response.status_code == 200
     assert response.text == ""
@@ -116,21 +116,21 @@ async def test_head(server):
 
 @pytest.mark.usefixtures("async_environment")
 async def test_put(server):
-    async with httpx.Client() as client:
+    async with httpx.AsyncClient() as client:
         response = await client.put(server.url, data=b"Hello, world!")
     assert response.status_code == 200
 
 
 @pytest.mark.usefixtures("async_environment")
 async def test_patch(server):
-    async with httpx.Client() as client:
+    async with httpx.AsyncClient() as client:
         response = await client.patch(server.url, data=b"Hello, world!")
     assert response.status_code == 200
 
 
 @pytest.mark.usefixtures("async_environment")
 async def test_delete(server):
-    async with httpx.Client() as client:
+    async with httpx.AsyncClient() as client:
         response = await client.delete(server.url)
     assert response.status_code == 200
     assert response.text == "Hello, world!"
@@ -141,7 +141,7 @@ async def test_100_continue(server):
     headers = {"Expect": "100-continue"}
     data = b"Echo request body"
 
-    async with httpx.Client() as client:
+    async with httpx.AsyncClient() as client:
         response = await client.post(
             server.url.copy_with(path="/echo_body"), headers=headers, data=data
         )
@@ -155,7 +155,7 @@ async def test_uds(uds_server):
     url = uds_server.url
     uds = uds_server.config.uds
     assert uds is not None
-    async with httpx.Client(uds=uds) as client:
+    async with httpx.AsyncClient(uds=uds) as client:
         response = await client.get(url)
     assert response.status_code == 200
     assert response.text == "Hello, world!"
@@ -163,7 +163,7 @@ async def test_uds(uds_server):
 
 
 async def test_explicit_backend(server, async_environment):
-    async with httpx.Client(backend=async_environment) as client:
+    async with httpx.AsyncClient(backend=async_environment) as client:
         response = await client.get(server.url)
     assert response.status_code == 200
     assert response.text == "Hello, world!"

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -8,7 +8,7 @@ import httpx
 @pytest.mark.asyncio
 async def test_get(server):
     url = server.url
-    async with httpx.Client() as http:
+    async with httpx.AsyncClient() as http:
         response = await http.get(url)
     assert response.status_code == 200
     assert response.url == url
@@ -28,7 +28,7 @@ async def test_build_request(server):
     url = server.url.copy_with(path="/echo_headers")
     headers = {"Custom-header": "value"}
 
-    async with httpx.Client() as client:
+    async with httpx.AsyncClient() as client:
         request = client.build_request("GET", url)
         request.headers.update(headers)
         response = await client.send(request)
@@ -41,7 +41,7 @@ async def test_build_request(server):
 
 @pytest.mark.asyncio
 async def test_post(server):
-    async with httpx.Client() as client:
+    async with httpx.AsyncClient() as client:
         response = await client.post(server.url, data=b"Hello, world!")
     assert response.status_code == 200
     assert response.reason_phrase == "OK"
@@ -49,7 +49,7 @@ async def test_post(server):
 
 @pytest.mark.asyncio
 async def test_post_json(server):
-    async with httpx.Client() as client:
+    async with httpx.AsyncClient() as client:
         response = await client.post(server.url, json={"text": "Hello, world!"})
     assert response.status_code == 200
     assert response.reason_phrase == "OK"
@@ -57,7 +57,7 @@ async def test_post_json(server):
 
 @pytest.mark.asyncio
 async def test_stream_response(server):
-    async with httpx.Client() as client:
+    async with httpx.AsyncClient() as client:
         async with client.stream("GET", server.url) as response:
             content = await response.read()
     assert response.status_code == 200
@@ -68,7 +68,7 @@ async def test_stream_response(server):
 async def test_stream_iterator(server):
     body = b""
 
-    async with httpx.Client() as client:
+    async with httpx.AsyncClient() as client:
         async with client.stream("GET", server.url) as response:
             async for chunk in response.aiter_bytes():
                 body += chunk
@@ -81,7 +81,7 @@ async def test_stream_iterator(server):
 async def test_raw_iterator(server):
     body = b""
 
-    async with httpx.Client() as client:
+    async with httpx.AsyncClient() as client:
         async with client.stream("GET", server.url) as response:
             async for chunk in response.aiter_raw():
                 body += chunk
@@ -92,7 +92,7 @@ async def test_raw_iterator(server):
 
 @pytest.mark.asyncio
 async def test_raise_for_status(server):
-    async with httpx.Client() as client:
+    async with httpx.AsyncClient() as client:
         for status_code in (200, 400, 404, 500, 505):
             response = await client.request(
                 "GET", server.url.copy_with(path="/status/{}".format(status_code))
@@ -107,7 +107,7 @@ async def test_raise_for_status(server):
 
 @pytest.mark.asyncio
 async def test_options(server):
-    async with httpx.Client() as client:
+    async with httpx.AsyncClient() as client:
         response = await client.options(server.url)
     assert response.status_code == 200
     assert response.reason_phrase == "OK"
@@ -115,7 +115,7 @@ async def test_options(server):
 
 @pytest.mark.asyncio
 async def test_head(server):
-    async with httpx.Client() as client:
+    async with httpx.AsyncClient() as client:
         response = await client.head(server.url)
     assert response.status_code == 200
     assert response.reason_phrase == "OK"
@@ -123,7 +123,7 @@ async def test_head(server):
 
 @pytest.mark.asyncio
 async def test_put(server):
-    async with httpx.Client() as client:
+    async with httpx.AsyncClient() as client:
         response = await client.put(server.url, data=b"Hello, world!")
     assert response.status_code == 200
     assert response.reason_phrase == "OK"
@@ -131,7 +131,7 @@ async def test_put(server):
 
 @pytest.mark.asyncio
 async def test_patch(server):
-    async with httpx.Client() as client:
+    async with httpx.AsyncClient() as client:
         response = await client.patch(server.url, data=b"Hello, world!")
     assert response.status_code == 200
     assert response.reason_phrase == "OK"
@@ -139,7 +139,7 @@ async def test_patch(server):
 
 @pytest.mark.asyncio
 async def test_delete(server):
-    async with httpx.Client() as client:
+    async with httpx.AsyncClient() as client:
         response = await client.delete(server.url)
     assert response.status_code == 200
     assert response.reason_phrase == "OK"
@@ -148,7 +148,7 @@ async def test_delete(server):
 @pytest.mark.asyncio
 async def test_base_url(server):
     base_url = server.url
-    async with httpx.Client(base_url=base_url) as client:
+    async with httpx.AsyncClient(base_url=base_url) as client:
         response = await client.get("/")
     assert response.status_code == 200
     assert response.url == base_url
@@ -159,7 +159,7 @@ async def test_uds(uds_server):
     url = uds_server.url
     uds = uds_server.config.uds
     assert uds is not None
-    async with httpx.Client(uds=uds) as client:
+    async with httpx.AsyncClient(uds=uds) as client:
         response = await client.get(url)
     assert response.status_code == 200
     assert response.text == "Hello, world!"
@@ -167,7 +167,7 @@ async def test_uds(uds_server):
 
 
 def test_merge_url():
-    client = httpx.Client(base_url="https://www.paypal.com/")
+    client = httpx.AsyncClient(base_url="https://www.paypal.com/")
     url = client.merge_url("http://www.paypal.com")
 
     assert url.scheme == "https"
@@ -177,6 +177,6 @@ def test_merge_url():
 @pytest.mark.asyncio
 async def test_elapsed_delay(server):
     url = server.url.copy_with(path="/slow_response/100")
-    async with httpx.Client() as client:
+    async with httpx.AsyncClient() as client:
         response = await client.get(url)
     assert response.elapsed.total_seconds() > 0.0

--- a/tests/client/test_cookies.py
+++ b/tests/client/test_cookies.py
@@ -3,7 +3,7 @@ from http.cookiejar import Cookie, CookieJar
 
 import pytest
 
-from httpx import Client, Cookies, Request, Response
+from httpx import AsyncClient, Cookies, Request, Response
 from httpx.config import CertTypes, TimeoutTypes, VerifyTypes
 from httpx.dispatch.base import Dispatcher
 
@@ -34,7 +34,7 @@ async def test_set_cookie() -> None:
     url = "http://example.org/echo_cookies"
     cookies = {"example-name": "example-value"}
 
-    client = Client(dispatch=MockDispatch())
+    client = AsyncClient(dispatch=MockDispatch())
     response = await client.get(url, cookies=cookies)
 
     assert response.status_code == 200
@@ -70,7 +70,7 @@ async def test_set_cookie_with_cookiejar() -> None:
     )
     cookies.set_cookie(cookie)
 
-    client = Client(dispatch=MockDispatch())
+    client = AsyncClient(dispatch=MockDispatch())
     response = await client.get(url, cookies=cookies)
 
     assert response.status_code == 200
@@ -106,7 +106,7 @@ async def test_setting_client_cookies_to_cookiejar() -> None:
     )
     cookies.set_cookie(cookie)
 
-    client = Client(dispatch=MockDispatch())
+    client = AsyncClient(dispatch=MockDispatch())
     client.cookies = cookies  # type: ignore
     response = await client.get(url)
 
@@ -124,7 +124,7 @@ async def test_set_cookie_with_cookies_model() -> None:
     cookies = Cookies()
     cookies["example-name"] = "example-value"
 
-    client = Client(dispatch=MockDispatch())
+    client = AsyncClient(dispatch=MockDispatch())
     response = await client.get(url, cookies=cookies)
 
     assert response.status_code == 200
@@ -135,7 +135,7 @@ async def test_set_cookie_with_cookies_model() -> None:
 async def test_get_cookie() -> None:
     url = "http://example.org/set_cookie"
 
-    client = Client(dispatch=MockDispatch())
+    client = AsyncClient(dispatch=MockDispatch())
     response = await client.get(url)
 
     assert response.status_code == 200
@@ -148,7 +148,7 @@ async def test_cookie_persistence() -> None:
     """
     Ensure that Client instances persist cookies between requests.
     """
-    client = Client(dispatch=MockDispatch())
+    client = AsyncClient(dispatch=MockDispatch())
 
     response = await client.get("http://example.org/echo_cookies")
     assert response.status_code == 200

--- a/tests/client/test_headers.py
+++ b/tests/client/test_headers.py
@@ -4,7 +4,7 @@ import json
 
 import pytest
 
-from httpx import Client, Headers, Request, Response, __version__
+from httpx import AsyncClient, Headers, Request, Response, __version__
 from httpx.config import CertTypes, TimeoutTypes, VerifyTypes
 from httpx.dispatch.base import Dispatcher
 
@@ -31,7 +31,7 @@ async def test_client_header():
     url = "http://example.org/echo_headers"
     headers = {"Example-Header": "example-value"}
 
-    client = Client(dispatch=MockDispatch(), headers=headers)
+    client = AsyncClient(dispatch=MockDispatch(), headers=headers)
     response = await client.get(url)
 
     assert response.status_code == 200
@@ -52,7 +52,7 @@ async def test_header_merge():
     url = "http://example.org/echo_headers"
     client_headers = {"User-Agent": "python-myclient/0.2.1"}
     request_headers = {"X-Auth-Token": "FooBarBazToken"}
-    client = Client(dispatch=MockDispatch(), headers=client_headers)
+    client = AsyncClient(dispatch=MockDispatch(), headers=client_headers)
     response = await client.get(url, headers=request_headers)
 
     assert response.status_code == 200
@@ -73,7 +73,7 @@ async def test_header_merge_conflicting_headers():
     url = "http://example.org/echo_headers"
     client_headers = {"X-Auth-Token": "FooBar"}
     request_headers = {"X-Auth-Token": "BazToken"}
-    client = Client(dispatch=MockDispatch(), headers=client_headers)
+    client = AsyncClient(dispatch=MockDispatch(), headers=client_headers)
     response = await client.get(url, headers=request_headers)
 
     assert response.status_code == 200
@@ -92,7 +92,7 @@ async def test_header_merge_conflicting_headers():
 @pytest.mark.asyncio
 async def test_header_update():
     url = "http://example.org/echo_headers"
-    client = Client(dispatch=MockDispatch())
+    client = AsyncClient(dispatch=MockDispatch())
     first_response = await client.get(url)
     client.headers.update(
         {"User-Agent": "python-myclient/0.2.1", "Another-Header": "AThing"}
@@ -138,7 +138,7 @@ async def test_host_with_auth_and_port_in_url():
     """
     url = "http://username:password@example.org:80/echo_headers"
 
-    client = Client(dispatch=MockDispatch())
+    client = AsyncClient(dispatch=MockDispatch())
     response = await client.get(url)
 
     assert response.status_code == 200
@@ -162,7 +162,7 @@ async def test_host_with_non_default_port_in_url():
     """
     url = "http://username:password@example.org:123/echo_headers"
 
-    client = Client(dispatch=MockDispatch())
+    client = AsyncClient(dispatch=MockDispatch())
     response = await client.get(url)
 
     assert response.status_code == 200

--- a/tests/client/test_properties.py
+++ b/tests/client/test_properties.py
@@ -1,15 +1,15 @@
-from httpx import Client, Cookies, Headers
+from httpx import AsyncClient, Cookies, Headers
 
 
 def test_client_headers():
-    client = Client()
+    client = AsyncClient()
     client.headers = {"a": "b"}
     assert isinstance(client.headers, Headers)
     assert client.headers["A"] == "b"
 
 
 def test_client_cookies():
-    client = Client()
+    client = AsyncClient()
     client.cookies = {"a": "b"}
     assert isinstance(client.cookies, Cookies)
     mycookies = list(client.cookies.jar)

--- a/tests/client/test_proxies.py
+++ b/tests/client/test_proxies.py
@@ -20,7 +20,7 @@ import httpx
     ],
 )
 def test_proxies_parameter(proxies, expected_proxies):
-    client = httpx.Client(proxies=proxies)
+    client = httpx.AsyncClient(proxies=proxies)
 
     for proxy_key, url in expected_proxies:
         assert proxy_key in client.proxies
@@ -30,7 +30,7 @@ def test_proxies_parameter(proxies, expected_proxies):
 
 
 def test_proxies_has_same_properties_as_dispatch():
-    client = httpx.Client(
+    client = httpx.AsyncClient(
         proxies="http://127.0.0.1",
         verify="/path/to/verify",
         cert="/path/to/cert",
@@ -96,7 +96,7 @@ PROXY_URL = "http://[::1]"
     ],
 )
 def test_dispatcher_for_request(url, proxies, expected):
-    client = httpx.Client(proxies=proxies)
+    client = httpx.AsyncClient(proxies=proxies)
     dispatcher = client.dispatcher_for_url(httpx.URL(url))
 
     if expected is None:
@@ -108,4 +108,4 @@ def test_dispatcher_for_request(url, proxies, expected):
 
 def test_unsupported_proxy_scheme():
     with pytest.raises(ValueError):
-        httpx.Client(proxies="ftp://127.0.0.1")
+        httpx.AsyncClient(proxies="ftp://127.0.0.1")

--- a/tests/client/test_queryparams.py
+++ b/tests/client/test_queryparams.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from httpx import URL, Client, QueryParams, Request, Response
+from httpx import URL, AsyncClient, QueryParams, Request, Response
 from httpx.config import CertTypes, TimeoutTypes, VerifyTypes
 from httpx.dispatch.base import Dispatcher
 
@@ -21,17 +21,17 @@ class MockDispatch(Dispatcher):
 
 
 def test_client_queryparams():
-    client = Client(params={"a": "b"})
+    client = AsyncClient(params={"a": "b"})
     assert isinstance(client.params, QueryParams)
     assert client.params["a"] == "b"
 
 
 def test_client_queryparams_string():
-    client = Client(params="a=b")
+    client = AsyncClient(params="a=b")
     assert isinstance(client.params, QueryParams)
     assert client.params["a"] == "b"
 
-    client = Client()
+    client = AsyncClient()
     client.params = "a=b"
     assert isinstance(client.params, QueryParams)
     assert client.params["a"] == "b"
@@ -42,7 +42,7 @@ async def test_client_queryparams_echo():
     url = "http://example.org/echo_queryparams"
     client_queryparams = "first=str"
     request_queryparams = {"second": "dict"}
-    client = Client(dispatch=MockDispatch(), params=client_queryparams)
+    client = AsyncClient(dispatch=MockDispatch(), params=client_queryparams)
     response = await client.get(url, params=request_queryparams)
 
     assert response.status_code == 200

--- a/tests/client/test_redirects.py
+++ b/tests/client/test_redirects.py
@@ -5,7 +5,7 @@ import pytest
 
 from httpx import (
     URL,
-    Client,
+    AsyncClient,
     NotRedirectResponse,
     RedirectBodyUnavailable,
     RedirectLoop,
@@ -105,7 +105,7 @@ class MockDispatch(Dispatcher):
 
 @pytest.mark.usefixtures("async_environment")
 async def test_no_redirect():
-    client = Client(dispatch=MockDispatch())
+    client = AsyncClient(dispatch=MockDispatch())
     url = "https://example.com/no_redirect"
     response = await client.get(url)
     assert response.status_code == 200
@@ -115,7 +115,7 @@ async def test_no_redirect():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_redirect_301():
-    client = Client(dispatch=MockDispatch())
+    client = AsyncClient(dispatch=MockDispatch())
     response = await client.post("https://example.org/redirect_301")
     assert response.status_code == codes.OK
     assert response.url == URL("https://example.org/")
@@ -124,7 +124,7 @@ async def test_redirect_301():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_redirect_302():
-    client = Client(dispatch=MockDispatch())
+    client = AsyncClient(dispatch=MockDispatch())
     response = await client.post("https://example.org/redirect_302")
     assert response.status_code == codes.OK
     assert response.url == URL("https://example.org/")
@@ -133,7 +133,7 @@ async def test_redirect_302():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_redirect_303():
-    client = Client(dispatch=MockDispatch())
+    client = AsyncClient(dispatch=MockDispatch())
     response = await client.get("https://example.org/redirect_303")
     assert response.status_code == codes.OK
     assert response.url == URL("https://example.org/")
@@ -142,7 +142,7 @@ async def test_redirect_303():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_disallow_redirects():
-    client = Client(dispatch=MockDispatch())
+    client = AsyncClient(dispatch=MockDispatch())
     response = await client.post(
         "https://example.org/redirect_303", allow_redirects=False
     )
@@ -160,7 +160,7 @@ async def test_disallow_redirects():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_relative_redirect():
-    client = Client(dispatch=MockDispatch())
+    client = AsyncClient(dispatch=MockDispatch())
     response = await client.get("https://example.org/relative_redirect")
     assert response.status_code == codes.OK
     assert response.url == URL("https://example.org/")
@@ -169,7 +169,7 @@ async def test_relative_redirect():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_no_scheme_redirect():
-    client = Client(dispatch=MockDispatch())
+    client = AsyncClient(dispatch=MockDispatch())
     response = await client.get("https://example.org/no_scheme_redirect")
     assert response.status_code == codes.OK
     assert response.url == URL("https://example.org/")
@@ -178,7 +178,7 @@ async def test_no_scheme_redirect():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_fragment_redirect():
-    client = Client(dispatch=MockDispatch())
+    client = AsyncClient(dispatch=MockDispatch())
     response = await client.get("https://example.org/relative_redirect#fragment")
     assert response.status_code == codes.OK
     assert response.url == URL("https://example.org/#fragment")
@@ -187,7 +187,7 @@ async def test_fragment_redirect():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_multiple_redirects():
-    client = Client(dispatch=MockDispatch())
+    client = AsyncClient(dispatch=MockDispatch())
     response = await client.get("https://example.org/multiple_redirects?count=20")
     assert response.status_code == codes.OK
     assert response.url == URL("https://example.org/multiple_redirects")
@@ -204,14 +204,14 @@ async def test_multiple_redirects():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_too_many_redirects():
-    client = Client(dispatch=MockDispatch())
+    client = AsyncClient(dispatch=MockDispatch())
     with pytest.raises(TooManyRedirects):
         await client.get("https://example.org/multiple_redirects?count=21")
 
 
 @pytest.mark.usefixtures("async_environment")
 async def test_too_many_redirects_calling_next():
-    client = Client(dispatch=MockDispatch())
+    client = AsyncClient(dispatch=MockDispatch())
     url = "https://example.org/multiple_redirects?count=21"
     response = await client.get(url, allow_redirects=False)
     with pytest.raises(TooManyRedirects):
@@ -221,14 +221,14 @@ async def test_too_many_redirects_calling_next():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_redirect_loop():
-    client = Client(dispatch=MockDispatch())
+    client = AsyncClient(dispatch=MockDispatch())
     with pytest.raises(RedirectLoop):
         await client.get("https://example.org/redirect_loop")
 
 
 @pytest.mark.usefixtures("async_environment")
 async def test_redirect_loop_calling_next():
-    client = Client(dispatch=MockDispatch())
+    client = AsyncClient(dispatch=MockDispatch())
     url = "https://example.org/redirect_loop"
     response = await client.get(url, allow_redirects=False)
     with pytest.raises(RedirectLoop):
@@ -238,7 +238,7 @@ async def test_redirect_loop_calling_next():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_cross_domain_redirect():
-    client = Client(dispatch=MockDispatch())
+    client = AsyncClient(dispatch=MockDispatch())
     url = "https://example.com/cross_domain"
     headers = {"Authorization": "abc"}
     response = await client.get(url, headers=headers)
@@ -248,7 +248,7 @@ async def test_cross_domain_redirect():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_same_domain_redirect():
-    client = Client(dispatch=MockDispatch())
+    client = AsyncClient(dispatch=MockDispatch())
     url = "https://example.org/cross_domain"
     headers = {"Authorization": "abc"}
     response = await client.get(url, headers=headers)
@@ -261,7 +261,7 @@ async def test_body_redirect():
     """
     A 308 redirect should preserve the request body.
     """
-    client = Client(dispatch=MockDispatch())
+    client = AsyncClient(dispatch=MockDispatch())
     url = "https://example.org/redirect_body"
     data = b"Example request body"
     response = await client.post(url, data=data)
@@ -275,7 +275,7 @@ async def test_no_body_redirect():
     """
     A 303 redirect should remove the request body.
     """
-    client = Client(dispatch=MockDispatch())
+    client = AsyncClient(dispatch=MockDispatch())
     url = "https://example.org/redirect_no_body"
     data = b"Example request body"
     response = await client.post(url, data=data)
@@ -286,7 +286,7 @@ async def test_no_body_redirect():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_cannot_redirect_streaming_body():
-    client = Client(dispatch=MockDispatch())
+    client = AsyncClient(dispatch=MockDispatch())
     url = "https://example.org/redirect_body"
 
     async def streaming_body():
@@ -298,7 +298,7 @@ async def test_cannot_redirect_streaming_body():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_cross_subdomain_redirect():
-    client = Client(dispatch=MockDispatch())
+    client = AsyncClient(dispatch=MockDispatch())
     url = "https://example.com/cross_subdomain"
     response = await client.get(url)
     assert response.url == URL("https://www.example.org/cross_subdomain")
@@ -345,7 +345,7 @@ class MockCookieDispatch(Dispatcher):
 
 @pytest.mark.usefixtures("async_environment")
 async def test_redirect_cookie_behavior():
-    client = Client(dispatch=MockCookieDispatch())
+    client = AsyncClient(dispatch=MockCookieDispatch())
 
     # The client is not logged in.
     response = await client.get("https://example.com/")

--- a/tests/dispatch/test_http2.py
+++ b/tests/dispatch/test_http2.py
@@ -6,7 +6,7 @@ import h2.events
 import pytest
 from h2.settings import SettingCodes
 
-from httpx import Client, Response, TimeoutException
+from httpx import AsyncClient, Response, TimeoutException
 
 from .utils import MockHTTP2Backend
 
@@ -26,7 +26,7 @@ async def app(request):
 async def test_http2_get_request():
     backend = MockHTTP2Backend(app=app)
 
-    async with Client(backend=backend, http2=True) as client:
+    async with AsyncClient(backend=backend, http2=True) as client:
         response = await client.get("http://example.org")
 
     assert response.status_code == 200
@@ -37,7 +37,7 @@ async def test_http2_get_request():
 async def test_http2_post_request():
     backend = MockHTTP2Backend(app=app)
 
-    async with Client(backend=backend, http2=True) as client:
+    async with AsyncClient(backend=backend, http2=True) as client:
         response = await client.post("http://example.org", data=b"<data>")
 
     assert response.status_code == 200
@@ -53,7 +53,7 @@ async def test_http2_large_post_request():
     backend = MockHTTP2Backend(app=app)
 
     data = b"a" * 100000
-    async with Client(backend=backend, http2=True) as client:
+    async with AsyncClient(backend=backend, http2=True) as client:
         response = await client.post("http://example.org", data=data)
     assert response.status_code == 200
     assert json.loads(response.content) == {
@@ -67,7 +67,7 @@ async def test_http2_large_post_request():
 async def test_http2_multiple_requests():
     backend = MockHTTP2Backend(app=app)
 
-    async with Client(backend=backend, http2=True) as client:
+    async with AsyncClient(backend=backend, http2=True) as client:
         response_1 = await client.get("http://example.org/1")
         response_2 = await client.get("http://example.org/2")
         response_3 = await client.get("http://example.org/3")
@@ -90,7 +90,7 @@ async def test_http2_reconnect():
     """
     backend = MockHTTP2Backend(app=app)
 
-    async with Client(backend=backend, http2=True) as client:
+    async with AsyncClient(backend=backend, http2=True) as client:
         response_1 = await client.get("http://example.org/1")
         backend.server.close_connection = True
         response_2 = await client.get("http://example.org/2")
@@ -106,7 +106,7 @@ async def test_http2_reconnect():
 async def test_http2_settings_in_handshake():
     backend = MockHTTP2Backend(app=app)
 
-    async with Client(backend=backend, http2=True) as client:
+    async with AsyncClient(backend=backend, http2=True) as client:
         await client.get("http://example.org")
 
     h2_conn = backend.server.conn
@@ -140,7 +140,7 @@ async def test_http2_settings_in_handshake():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_http2_live_request():
-    async with Client(http2=True) as client:
+    async with AsyncClient(http2=True) as client:
         try:
             resp = await client.get("https://nghttp2.org/httpbin/anything")
         except TimeoutException:

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -41,7 +41,7 @@ async def raise_exc_after_response(scope, receive, send):
 
 @pytest.mark.asyncio
 async def test_asgi():
-    client = httpx.Client(app=hello_world)
+    client = httpx.AsyncClient(app=hello_world)
     response = await client.get("http://www.example.org/")
     assert response.status_code == 200
     assert response.text == "Hello, World!"
@@ -49,7 +49,7 @@ async def test_asgi():
 
 @pytest.mark.asyncio
 async def test_asgi_upload():
-    client = httpx.Client(app=echo_body)
+    client = httpx.AsyncClient(app=echo_body)
     response = await client.post("http://www.example.org/", data=b"example")
     assert response.status_code == 200
     assert response.text == "example"
@@ -57,13 +57,13 @@ async def test_asgi_upload():
 
 @pytest.mark.asyncio
 async def test_asgi_exc():
-    client = httpx.Client(app=raise_exc)
+    client = httpx.AsyncClient(app=raise_exc)
     with pytest.raises(ValueError):
         await client.get("http://www.example.org/")
 
 
 @pytest.mark.asyncio
 async def test_asgi_exc_after_response():
-    client = httpx.Client(app=raise_exc_after_response)
+    client = httpx.AsyncClient(app=raise_exc_after_response)
     with pytest.raises(ValueError):
         await client.get("http://www.example.org/")

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -28,7 +28,7 @@ class MockDispatch(Dispatcher):
 @pytest.mark.parametrize(("value,output"), (("abc", b"abc"), (b"abc", b"abc")))
 @pytest.mark.asyncio
 async def test_multipart(value, output):
-    client = httpx.Client(dispatch=MockDispatch())
+    client = httpx.AsyncClient(dispatch=MockDispatch())
 
     # Test with a single-value 'data' argument, and a plain file 'files' argument.
     data = {"text": value}
@@ -52,7 +52,7 @@ async def test_multipart(value, output):
 @pytest.mark.parametrize(("key"), (b"abc", 1, 2.3, None))
 @pytest.mark.asyncio
 async def test_multipart_invalid_key(key):
-    client = httpx.Client(dispatch=MockDispatch())
+    client = httpx.AsyncClient(dispatch=MockDispatch())
     data = {key: "abc"}
     files = {"file": io.BytesIO(b"<file content>")}
     with pytest.raises(TypeError) as e:
@@ -63,7 +63,7 @@ async def test_multipart_invalid_key(key):
 @pytest.mark.parametrize(("value"), (1, 2.3, None, [None, "abc"], {None: "abc"}))
 @pytest.mark.asyncio
 async def test_multipart_invalid_value(value):
-    client = httpx.Client(dispatch=MockDispatch())
+    client = httpx.AsyncClient(dispatch=MockDispatch())
     data = {"text": value}
     files = {"file": io.BytesIO(b"<file content>")}
     with pytest.raises(TypeError) as e:
@@ -73,7 +73,7 @@ async def test_multipart_invalid_value(value):
 
 @pytest.mark.asyncio
 async def test_multipart_file_tuple():
-    client = httpx.Client(dispatch=MockDispatch())
+    client = httpx.AsyncClient(dispatch=MockDispatch())
 
     # Test with a list of values 'data' argument, and a tuple style 'files' argument.
     data = {"text": ["abc"]}

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -7,7 +7,7 @@ import httpx
 async def test_read_timeout(server):
     timeout = httpx.Timeout(read_timeout=1e-6)
 
-    async with httpx.Client(timeout=timeout) as client:
+    async with httpx.AsyncClient(timeout=timeout) as client:
         with pytest.raises(httpx.ReadTimeout):
             await client.get(server.url.copy_with(path="/slow_response"))
 
@@ -16,7 +16,7 @@ async def test_read_timeout(server):
 async def test_write_timeout(server):
     timeout = httpx.Timeout(write_timeout=1e-6)
 
-    async with httpx.Client(timeout=timeout) as client:
+    async with httpx.AsyncClient(timeout=timeout) as client:
         with pytest.raises(httpx.WriteTimeout):
             data = b"*" * 1024 * 1024 * 100
             await client.put(server.url.copy_with(path="/slow_response"), data=data)
@@ -26,7 +26,7 @@ async def test_write_timeout(server):
 async def test_connect_timeout(server):
     timeout = httpx.Timeout(connect_timeout=1e-6)
 
-    async with httpx.Client(timeout=timeout) as client:
+    async with httpx.AsyncClient(timeout=timeout) as client:
         with pytest.raises(httpx.ConnectTimeout):
             # See https://stackoverflow.com/questions/100841/
             await client.get("http://10.255.255.1/")
@@ -37,7 +37,7 @@ async def test_pool_timeout(server):
     pool_limits = httpx.PoolLimits(hard_limit=1)
     timeout = httpx.Timeout(pool_timeout=1e-4)
 
-    async with httpx.Client(pool_limits=pool_limits, timeout=timeout) as client:
+    async with httpx.AsyncClient(pool_limits=pool_limits, timeout=timeout) as client:
         async with client.stream("GET", server.url):
             with pytest.raises(httpx.PoolTimeout):
                 await client.get("http://localhost:8000/")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -93,7 +93,7 @@ def test_parse_header_links(value, expected):
 @pytest.mark.asyncio
 async def test_logs_debug(server, capsys):
     with override_log_level("debug"):
-        async with httpx.Client() as client:
+        async with httpx.AsyncClient() as client:
             response = await client.get(server.url)
             assert response.status_code == 200
     stderr = capsys.readouterr().err
@@ -104,7 +104,7 @@ async def test_logs_debug(server, capsys):
 @pytest.mark.asyncio
 async def test_logs_trace(server, capsys):
     with override_log_level("trace"):
-        async with httpx.Client() as client:
+        async with httpx.AsyncClient() as client:
             response = await client.get(server.url)
             assert response.status_code == 200
     stderr = capsys.readouterr().err
@@ -115,7 +115,7 @@ async def test_logs_trace(server, capsys):
 @pytest.mark.asyncio
 async def test_logs_redirect_chain(server, capsys):
     with override_log_level("debug"):
-        async with httpx.Client() as client:
+        async with httpx.AsyncClient() as client:
             response = await client.get(server.url.copy_with(path="/redirect_301"))
             assert response.status_code == 200
 


### PR DESCRIPTION
Refs #667 

- Rename `Client` to `AsyncClient`
- Update references to `Client` in core and tests.
- Change docs to encourage using `AsyncClient` from 0.10.0 and on.
- Add `Client` synonym for backwards compat with `0.9.*`.

Regex search & replace was a good mate on this one. 💯 