### PR TITLE
`DigestAuth` will raise an exception if non replayable request is passed #670

### DIFF
--- a/httpx/auth.py
+++ b/httpx/auth.py
@@ -6,7 +6,7 @@ import typing
 from base64 import b64encode
 from urllib.request import parse_http_list
 
-from .exceptions import ProtocolError
+from .exceptions import ProtocolError, RedirectBodyUnavailable
 from .models import Request, Response
 from .utils import to_bytes, to_str, unquote
 
@@ -104,6 +104,8 @@ class DigestAuth(Auth):
         self.password = to_bytes(password)
 
     def __call__(self, request: Request) -> AuthFlow:
+        if not request.stream.can_replay():
+            raise RedirectBodyUnavailable("Non-replayable request is passed")
         response = yield request
 
         if response.status_code != 401 or "www-authenticate" not in response.headers:


### PR DESCRIPTION
Fixes #670

1. `DigestAuth` will now raise an `RedirectBodyUnavailable` exception if a non-replayable request is passed to its `__call__` method.

Feedback will be appreciated. :)