### PR TITLE
Save history if authentication flow makes more than one request

### DIFF
--- a/httpx/client.py
+++ b/httpx/client.py
@@ -451,7 +451,7 @@ class AsyncClient:
                 raise RedirectLoop()
 
             response = await self.send_handling_auth(
-                request, history, auth=auth, timeout=timeout, verify=verify, cert=cert
+                request, history, auth=auth, timeout=timeout,
             )
             response.history = list(history)
 
@@ -571,8 +571,6 @@ class AsyncClient:
         history: typing.List[Response],
         auth: Auth,
         timeout: Timeout,
-        verify: VerifyTypes = None,
-        cert: CertTypes = None,
     ) -> Response:
         auth_flow = auth(request)
         request = next(auth_flow)

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -381,3 +381,18 @@ async def test_digest_auth_raises_protocol_error_on_malformed_header(
 
     with pytest.raises(ProtocolError):
         await client.get(url, auth=auth)
+
+
+@pytest.mark.asyncio
+async def test_auth_responses_get_saved_in_history():
+    """
+    Test if auth makes more than one request, the responses get saved
+    in history
+    """
+    auth = DigestAuth(username="tomchristie", password="password123")
+
+    client = AsyncClient(dispatch=MockDigestAuthDispatch(send_response_after_attempt=2))
+    response = await client.get("https://example.org", auth=auth)
+
+    assert response.status_code == 401
+    assert len(response.history) == 1  # the response from send_handling_auth


### PR DESCRIPTION
Fixes #669 
Saves the response to `history` if authentication flow makes more than one request. This history is assigned to `response.history`