### PR TITLE
Changed behaviour of elapsed on response

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -56,8 +56,7 @@
 * `.cookies` - **Cookies**
 * `.history` - **List[Response]**
 * `.elapsed` - **[timedelta](https://docs.python.org/3/library/datetime.html)**
-  * The amount of time elapsed between sending the first byte and parsing the headers (not including time spent reading
-  the response).  Use
+  * The amount of time elapsed between sending the request and calling `close()` on the corresponding response received for that request.
   [total_seconds()](https://docs.python.org/3/library/datetime.html#datetime.timedelta.total_seconds) to correctly get
   the total elapsed seconds.
 * `def .raise_for_status()` - **None**

--- a/httpx/client.py
+++ b/httpx/client.py
@@ -47,7 +47,7 @@ from .models import (
     URLTypes,
 )
 from .status_codes import codes
-from .utils import ElapsedTimer, NetRCInfo, get_environment_proxies, get_logger
+from .utils import NetRCInfo, get_environment_proxies, get_logger
 
 logger = get_logger(__name__)
 
@@ -616,11 +616,9 @@ class Client:
         dispatcher = self.dispatcher_for_url(request.url)
 
         try:
-            with ElapsedTimer() as timer:
-                response = await dispatcher.send(
-                    request, verify=verify, cert=cert, timeout=timeout
-                )
-            response.elapsed = timer.elapsed
+            response = await dispatcher.send(
+                request, verify=verify, cert=cert, timeout=timeout
+            )
             response.request = request
         except HTTPError as exc:
             # Add the original request to any HTTPError unless

--- a/httpx/models.py
+++ b/httpx/models.py
@@ -34,6 +34,7 @@ from .exceptions import (
 )
 from .status_codes import StatusCode
 from .utils import (
+    ElapsedTimer,
     flatten_queryparams,
     guess_json_utf,
     is_known_encoding,
@@ -607,6 +608,7 @@ class Request:
         else:
             self.stream = encode(data, files, json)
 
+        self.timer = ElapsedTimer()
         self.prepare()
 
     def prepare(self) -> None:
@@ -667,14 +669,12 @@ class Response:
         stream: ContentStream = None,
         content: bytes = None,
         history: typing.List["Response"] = None,
-        elapsed: datetime.timedelta = None,
     ):
         self.status_code = status_code
         self.http_version = http_version
         self.headers = Headers(headers)
 
         self.request = request
-        self.elapsed = datetime.timedelta(0) if elapsed is None else elapsed
         self.call_next: typing.Optional[typing.Callable] = None
 
         self.history = [] if history is None else list(history)
@@ -687,6 +687,19 @@ class Response:
             self.is_closed = False
             self.is_stream_consumed = False
             self._raw_stream = stream
+
+    @property
+    def elapsed(self) -> datetime.timedelta:
+        """
+        Returns the time taken for the complete request/response
+        cycle to complete.
+        """
+        if not hasattr(self, "_elapsed"):
+            raise RuntimeError(
+                "'.elapsed' may only be accessed after the response "
+                "has been read or closed."
+            )
+        return self._elapsed
 
     @property
     def reason_phrase(self) -> str:
@@ -940,6 +953,7 @@ class Response:
             self.is_closed = True
             if hasattr(self, "_raw_stream"):
                 await self._raw_stream.aclose()
+        self._elapsed = self.request.timer.elapsed
 
 
 class Cookies(MutableMapping):

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -20,13 +20,16 @@ async def async_streaming_body():
     yield b"world!"
 
 
-def test_response():
+@pytest.mark.asyncio
+async def test_response():
     response = httpx.Response(200, content=b"Hello, world!", request=REQUEST)
+    await response.close()
+
     assert response.status_code == 200
     assert response.reason_phrase == "OK"
     assert response.text == "Hello, world!"
     assert response.request is REQUEST
-    assert response.elapsed == datetime.timedelta(0)
+    assert response.elapsed > datetime.timedelta(0)
     assert not response.is_error
 
 


### PR DESCRIPTION
Fixes #655 
Makes elapsed time only available after response is closed

Took the django-rest-framework approach here (as making .data available only when `is_valid` is called)
Used `ElapsedTimer` on the request to start the timer and assigned the `elapsed` from request timer to response.