### PR TITLE
Drop `Origin` from public API

### DIFF
--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -26,7 +26,7 @@ from .exceptions import (
     TooManyRedirects,
     WriteTimeout,
 )
-from .models import URL, Cookies, Headers, Origin, QueryParams, Request, Response
+from .models import URL, Cookies, Headers, QueryParams, Request, Response
 from .status_codes import StatusCode, codes
 
 __all__ = [
@@ -75,7 +75,6 @@ __all__ = [
     "StatusCode",
     "Cookies",
     "Headers",
-    "Origin",
     "QueryParams",
     "Request",
     "TimeoutException",

--- a/httpx/client.py
+++ b/httpx/client.py
@@ -37,6 +37,7 @@ from .models import (
     CookieTypes,
     Headers,
     HeaderTypes,
+    Origin,
     ProxiesTypes,
     QueryParams,
     QueryParamTypes,
@@ -535,7 +536,7 @@ class AsyncClient:
         """
         headers = Headers(request.headers)
 
-        if url.origin != request.url.origin:
+        if Origin(url) != Origin(request.url):
             # Strip Authorization headers when responses are redirected away from
             # the origin.
             headers.pop("Authorization", None)

--- a/httpx/dispatch/connection_pool.py
+++ b/httpx/dispatch/connection_pool.py
@@ -143,7 +143,7 @@ class ConnectionPool(Dispatcher):
     async def send(self, request: Request, timeout: Timeout = None) -> Response:
         await self.check_keepalive_expiry()
         connection = await self.acquire_connection(
-            origin=request.url.origin, timeout=timeout
+            origin=Origin(request.url), timeout=timeout
         )
         try:
             response = await connection.send(request, timeout=timeout)

--- a/httpx/dispatch/proxy_http.py
+++ b/httpx/dispatch/proxy_http.py
@@ -91,7 +91,7 @@ class HTTPProxy(ConnectionPool):
             logger.trace(
                 f"forward_connection proxy_url={self.proxy_url!r} origin={origin!r}"
             )
-            return await super().acquire_connection(self.proxy_url.origin, timeout)
+            return await super().acquire_connection(Origin(self.proxy_url), timeout)
         else:
             logger.trace(
                 f"tunnel_connection proxy_url={self.proxy_url!r} origin={origin!r}"
@@ -136,7 +136,7 @@ class HTTPProxy(ConnectionPool):
         await self.max_connections.acquire()
 
         connection = HTTPConnection(
-            self.proxy_url.origin,
+            Origin(self.proxy_url),
             verify=self.verify,
             cert=self.cert,
             backend=self.backend,
@@ -180,7 +180,7 @@ class HTTPProxy(ConnectionPool):
         ) or self.proxy_mode == FORWARD_ONLY
 
     async def send(self, request: Request, timeout: Timeout = None) -> Response:
-        if self.should_forward_origin(request.url.origin):
+        if self.should_forward_origin(Origin(request.url)):
             # Change the request to have the target URL
             # as its full_path and switch the proxy URL
             # for where the request will be sent.

--- a/httpx/models.py
+++ b/httpx/models.py
@@ -191,10 +191,6 @@ class URL:
     def is_relative_url(self) -> bool:
         return not self.is_absolute_url
 
-    @property
-    def origin(self) -> "Origin":
-        return Origin(self)
-
     def copy_with(self, **kwargs: typing.Any) -> "URL":
         if (
             "username" in kwargs

--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -1,6 +1,7 @@
 import pytest
 
-from httpx import URL, InvalidURL, Origin
+from httpx import URL, InvalidURL
+from httpx.models import Origin
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- [x] Drop the `url.origin` property.
- [x] Drop `Origin` from the top-level export.
- [ ] ~Move `Origin` into `utils.py`.~
- [x] Use `origin = Origin(url)` in our internal usage, rather than `url.origin`.

Closes #656 