### PR TITLE
Version 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.10.0 (December 29th, 2019)
+
+The 0.10.0 makes some changes that will allow us to support both sync and async interfaces.
+
+In particular with streaming responses the `response.read()` method becomes `response.aread()`, and the `response.close()` method becomes `response.aclose()`.
+
+If following redirects explicitly the `response.next()` method becomes `response.anext()`.
+
+### Fixed
+
+- End HTTP/2 streams immediately on no-body requests, rather than sending an empty body message. (Pull #682)
+
+### Changed
+
+- Added `AsyncClient` as a synonym for `Client`. (Pull #680)
+- Switch to `response.aread()` for conditionally reading streaming responses. (Pull #674)
+- Switch to `response.aclose()` and `client.aclose()` for explicit closing. (Pull #674, #675)
+- Switch to `response.anext()` for resolving the next redirect response. (Pull #676)
+
+### Removed
+
+- When using a client instance, the per-request usage of `verify`, `cert`, and `trust_env` have now escalated from raising a warning to raising an error. You should set these arguments on the client instead. (Pull #617)
+- Removed the undocumented `request.read()`, since end users should not require it.
+
 ## 0.9.5 (December 20th, 2019)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.10.0 (December 29th, 2019)
 
-The 0.10.0 makes some changes that will allow us to support both sync and async interfaces.
+The 0.10.0 release makes some changes that will allow us to support both sync and async interfaces.
 
 In particular with streaming responses the `response.read()` method becomes `response.aread()`, and the `response.close()` method becomes `response.aclose()`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ If following redirects explicitly the `response.next()` method becomes `response
 ### Fixed
 
 - End HTTP/2 streams immediately on no-body requests, rather than sending an empty body message. (Pull #682)
+- Improve typing for `Response.request`: switch from `Optional[Request]` to `Request`. (Pull #666)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ If following redirects explicitly the `response.next()` method becomes `response
 
 - End HTTP/2 streams immediately on no-body requests, rather than sending an empty body message. (Pull #682)
 - Improve typing for `Response.request`: switch from `Optional[Request]` to `Request`. (Pull #666)
-- `Response.elapsed` now reflects the entire download time. (Pull #692)
+- `Response.elapsed` now reflects the entire download time. (Pull #687, #692)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ If following redirects explicitly the `response.next()` method becomes `response
 
 - End HTTP/2 streams immediately on no-body requests, rather than sending an empty body message. (Pull #682)
 - Improve typing for `Response.request`: switch from `Optional[Request]` to `Request`. (Pull #666)
+- `Response.elapsed` now reflects the entire download time. (Pull #692)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ or trio, and is able to support making large numbers of requests concurrently.
 **Note**: *HTTPX should still be considered in alpha. We'd love early users and feedback,
 but would strongly recommend pinning your dependencies to the latest median
 release, so that you're able to properly review API changes between package
-updates. Currently you should be using `httpx==0.9.*`.*
+updates. Currently you should be using `httpx==0.10.*`.*
 
 *In particular, the 0.8 release switched HTTPX into focusing exclusively on
 providing an async client, in order to move the project forward, and help

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ or trio, and is able to support making large numbers of concurrent requests.
     HTTPX should currently be considered in alpha. We'd love early users and feedback,
     but would strongly recommend pinning your dependencies to the latest median
     release, so that you're able to properly review API changes between package
-    updates. Currently you should be using `httpx==0.9.*`.
+    updates. Currently you should be using `httpx==0.10.*`.
 
     In particular, the 0.8 release switched HTTPX into focusing exclusively on
     providing an async client, in order to move the project forward, and help

--- a/httpx/__version__.py
+++ b/httpx/__version__.py
@@ -1,3 +1,3 @@
 __title__ = "httpx"
 __description__ = "A next generation HTTP client, for Python 3."
-__version__ = "0.9.5"
+__version__ = "0.10.0"


### PR DESCRIPTION
Closes #667

## 0.10.0 (December 29th, 2019)

The 0.10.0 makes some changes that will allow us to support both sync and async interfaces.

In particular with streaming responses the `response.read()` method becomes `response.aread()`, and the `response.close()` method becomes `response.aclose()`.

If following redirects explicitly the `response.next()` method becomes `response.anext()`.

### Fixed

- End HTTP/2 streams immediately on no-body requests, rather than sending an empty body message. (Pull #682)
- Improve typing for `Response.request`: switch from `Optional[Request]` to `Request`. (Pull #666)
- `Response.elapsed` now reflects the entire download time. (Pull #692)

### Changed

- Added `AsyncClient` as a synonym for `Client`. (Pull #680)
- Switch to `response.aread()` for conditionally reading streaming responses. (Pull #674)
- Switch to `response.aclose()` and `client.aclose()` for explicit closing. (Pull #674, #675)
- Switch to `response.anext()` for resolving the next redirect response. (Pull #676)

### Removed

- When using a client instance, the per-request usage of `verify`, `cert`, and `trust_env` have now escalated from raising a warning to raising an error. You should set these arguments on the client instead. (Pull #617)
- Removed the undocumented `request.read()`, since end users should not require it.
