### PR TITLE
Sync streaming interface on responses

### DIFF
--- a/httpx/content_streams.py
+++ b/httpx/content_streams.py
@@ -108,10 +108,8 @@ class IteratorStream(ContentStream):
         for part in self.iterator:
             yield part
 
-    async def __aiter__(self) -> typing.AsyncIterator[bytes]:
+    def __aiter__(self) -> typing.AsyncIterator[bytes]:
         raise RuntimeError("Attempted to call a async iterator on an sync stream.")
-        async for part in ():  # pragma: nocover
-            yield b""
 
     def close(self) -> None:
         if self.close_func is not None:

--- a/httpx/content_streams.py
+++ b/httpx/content_streams.py
@@ -46,6 +46,12 @@ class ContentStream:
         """
         return True
 
+    def __iter__(self) -> typing.Iterator[bytes]:
+        yield b""
+
+    def close(self) -> None:
+        pass
+
     async def __aiter__(self) -> typing.AsyncIterator[bytes]:
         yield b""
 
@@ -67,6 +73,9 @@ class ByteStream(ContentStream):
         content_length = str(len(self.body))
         return {"Content-Length": content_length}
 
+    def __iter__(self) -> typing.Iterator[bytes]:
+        yield self.body
+
     async def __aiter__(self) -> typing.AsyncIterator[bytes]:
         yield self.body
 
@@ -87,6 +96,9 @@ class AsyncIteratorStream(ContentStream):
 
     def get_headers(self) -> typing.Dict[str, str]:
         return {"Transfer-Encoding": "chunked"}
+
+    def __iter__(self) -> typing.Iterator[bytes]:
+        raise RuntimeError("Attempted to call a sync iterator on an async stream.")
 
     async def __aiter__(self) -> typing.AsyncIterator[bytes]:
         async for part in self.aiterator:
@@ -110,6 +122,9 @@ class JSONStream(ContentStream):
         content_type = "application/json"
         return {"Content-Length": content_length, "Content-Type": content_type}
 
+    def __iter__(self) -> typing.Iterator[bytes]:
+        yield self.body
+
     async def __aiter__(self) -> typing.AsyncIterator[bytes]:
         yield self.body
 
@@ -126,6 +141,9 @@ class URLEncodedStream(ContentStream):
         content_length = str(len(self.body))
         content_type = "application/x-www-form-urlencoded"
         return {"Content-Length": content_length, "Content-Type": content_type}
+
+    def __iter__(self) -> typing.Iterator[bytes]:
+        yield self.body
 
     async def __aiter__(self) -> typing.AsyncIterator[bytes]:
         yield self.body
@@ -246,6 +264,9 @@ class MultipartStream(ContentStream):
         content_length = str(len(self.body))
         content_type = self.content_type
         return {"Content-Length": content_length, "Content-Type": content_type}
+
+    def __iter__(self) -> typing.Iterator[bytes]:
+        yield self.body
 
     async def __aiter__(self) -> typing.AsyncIterator[bytes]:
         yield self.body

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -132,7 +132,7 @@ def test_read_response():
     assert response.encoding == "ascii"
     assert response.is_closed
 
-    content = await response.read()
+    content = response.read()
 
     assert content == b"Hello, world!"
     assert response.content == b"Hello, world!"

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -124,8 +124,23 @@ def test_response_force_encoding():
     assert response.encoding == "iso-8859-1"
 
 
+def test_read_response():
+    response = httpx.Response(200, content=b"Hello, world!", request=REQUEST)
+
+    assert response.status_code == 200
+    assert response.text == "Hello, world!"
+    assert response.encoding == "ascii"
+    assert response.is_closed
+
+    content = await response.read()
+
+    assert content == b"Hello, world!"
+    assert response.content == b"Hello, world!"
+    assert response.is_closed
+
+
 @pytest.mark.asyncio
-async def test_read_response():
+async def test_aread_response():
     response = httpx.Response(200, content=b"Hello, world!", request=REQUEST)
 
     assert response.status_code == 200
@@ -142,7 +157,8 @@ async def test_read_response():
 
 @pytest.mark.asyncio
 async def test_raw_interface():
-    response = httpx.Response(200, content=b"Hello, world!", request=REQUEST)
+    stream = AsyncIteratorStream(aiterator=async_streaming_body())
+    response = httpx.Response(200, stream=stream, request=REQUEST)
 
     raw = b""
     async for part in response.aiter_raw():

--- a/tests/test_content_streams.py
+++ b/tests/test_content_streams.py
@@ -189,7 +189,6 @@ async def test_multipart_data_and_files_content():
     )
 
 
-@pytest.mark.asyncio
-async def test_invalid_argument():
+def test_invalid_argument():
     with pytest.raises(TypeError):
         encode(123)

--- a/tests/test_content_streams.py
+++ b/tests/test_content_streams.py
@@ -2,27 +2,60 @@ import io
 
 import pytest
 
-from httpx.content_streams import encode
+from httpx.content_streams import ContentStream, encode
+
+
+@pytest.mark.asyncio
+async def test_base_content():
+    stream = ContentStream()
+    sync_content = b"".join([part for part in stream])
+    async_content = b"".join([part async for part in stream])
+
+    assert stream.can_replay()
+    assert stream.get_headers() == {}
+    assert sync_content == b""
+    assert async_content == b""
 
 
 @pytest.mark.asyncio
 async def test_empty_content():
     stream = encode()
-    content = b"".join([part async for part in stream])
+    sync_content = b"".join([part for part in stream])
+    async_content = b"".join([part async for part in stream])
 
     assert stream.can_replay()
     assert stream.get_headers() == {}
-    assert content == b""
+    assert sync_content == b""
+    assert async_content == b""
 
 
 @pytest.mark.asyncio
 async def test_bytes_content():
     stream = encode(data=b"Hello, world!")
-    content = b"".join([part async for part in stream])
+    sync_content = b"".join([part for part in stream])
+    async_content = b"".join([part async for part in stream])
 
     assert stream.can_replay()
     assert stream.get_headers() == {"Content-Length": "13"}
+    assert sync_content == b"Hello, world!"
+    assert async_content == b"Hello, world!"
+
+
+@pytest.mark.asyncio
+async def test_iterator_content():
+    def hello_world():
+        yield b"Hello, "
+        yield b"world!"
+
+    stream = encode(data=hello_world())
+    content = b"".join([part for part in stream])
+
+    assert not stream.can_replay()
+    assert stream.get_headers() == {"Transfer-Encoding": "chunked"}
     assert content == b"Hello, world!"
+
+    with pytest.raises(RuntimeError):
+        [part async for part in stream]
 
 
 @pytest.mark.asyncio
@@ -38,45 +71,63 @@ async def test_aiterator_content():
     assert stream.get_headers() == {"Transfer-Encoding": "chunked"}
     assert content == b"Hello, world!"
 
+    with pytest.raises(RuntimeError):
+        [part for part in stream]
+
 
 @pytest.mark.asyncio
 async def test_json_content():
     stream = encode(json={"Hello": "world!"})
-    content = b"".join([part async for part in stream])
+    sync_content = b"".join([part for part in stream])
+    async_content = b"".join([part async for part in stream])
 
     assert stream.can_replay()
     assert stream.get_headers() == {
         "Content-Length": "19",
         "Content-Type": "application/json",
     }
-    assert content == b'{"Hello": "world!"}'
+    assert sync_content == b'{"Hello": "world!"}'
+    assert async_content == b'{"Hello": "world!"}'
 
 
 @pytest.mark.asyncio
 async def test_urlencoded_content():
     stream = encode(data={"Hello": "world!"})
-    content = b"".join([part async for part in stream])
+    sync_content = b"".join([part for part in stream])
+    async_content = b"".join([part async for part in stream])
 
     assert stream.can_replay()
     assert stream.get_headers() == {
         "Content-Length": "14",
         "Content-Type": "application/x-www-form-urlencoded",
     }
-    assert content == b"Hello=world%21"
+    assert sync_content == b"Hello=world%21"
+    assert async_content == b"Hello=world%21"
 
 
 @pytest.mark.asyncio
 async def test_multipart_files_content():
     files = {"file": io.BytesIO(b"<file content>")}
     stream = encode(files=files, boundary=b"+++")
-    content = b"".join([part async for part in stream])
+    sync_content = b"".join([part for part in stream])
+    async_content = b"".join([part async for part in stream])
 
     assert stream.can_replay()
     assert stream.get_headers() == {
         "Content-Length": "138",
         "Content-Type": "multipart/form-data; boundary=+++",
     }
-    assert content == b"".join(
+    assert sync_content == b"".join(
+        [
+            b"--+++\r\n",
+            b'Content-Disposition: form-data; name="file"; filename="upload"\r\n',
+            b"Content-Type: application/octet-stream\r\n",
+            b"\r\n",
+            b"<file content>\r\n",
+            b"--+++--\r\n",
+        ]
+    )
+    assert async_content == b"".join(
         [
             b"--+++\r\n",
             b'Content-Disposition: form-data; name="file"; filename="upload"\r\n',
@@ -93,14 +144,15 @@ async def test_multipart_data_and_files_content():
     data = {"message": "Hello, world!"}
     files = {"file": io.BytesIO(b"<file content>")}
     stream = encode(data=data, files=files, boundary=b"+++")
-    content = b"".join([part async for part in stream])
+    sync_content = b"".join([part for part in stream])
+    async_content = b"".join([part async for part in stream])
 
     assert stream.can_replay()
     assert stream.get_headers() == {
         "Content-Length": "210",
         "Content-Type": "multipart/form-data; boundary=+++",
     }
-    assert content == b"".join(
+    assert sync_content == b"".join(
         [
             b"--+++\r\n",
             b'Content-Disposition: form-data; name="message"\r\n',
@@ -114,3 +166,23 @@ async def test_multipart_data_and_files_content():
             b"--+++--\r\n",
         ]
     )
+    assert async_content == b"".join(
+        [
+            b"--+++\r\n",
+            b'Content-Disposition: form-data; name="message"\r\n',
+            b"\r\n",
+            b"Hello, world!\r\n",
+            b"--+++\r\n",
+            b'Content-Disposition: form-data; name="file"; filename="upload"\r\n',
+            b"Content-Type: application/octet-stream\r\n",
+            b"\r\n",
+            b"<file content>\r\n",
+            b"--+++--\r\n",
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_invalid_argument():
+    with pytest.raises(TypeError):
+        encode(123)


### PR DESCRIPTION
Refs #572 

Add sync interfaces for streaming on responses.

Draft PR at the moment just to demonstrate how it'll look... The tests will need filling out to.

Related to this will be:

* Ability to support both sync and async request bodies... We need an `IteratorStream` in `content_streams.py`.
* `.next()`