### PR TITLE
Set `open_connection` before adding the connection to `active_connections` (see https://github.com/encode/httpx/issues/689)

### DIFF
--- a/httpx/dispatch/connection.py
+++ b/httpx/dispatch/connection.py
@@ -51,7 +51,9 @@ class HTTPConnection(Dispatcher):
 
         return response
 
-    async def connect(self, timeout: Timeout) -> None:
+    async def connect(self, timeout: Timeout = None) -> None:
+        timeout = Timeout() if timeout is None else timeout
+
         host = self.origin.host
         port = self.origin.port
         ssl_context = await self.get_ssl_context(self.ssl)

--- a/httpx/dispatch/connection_pool.py
+++ b/httpx/dispatch/connection_pool.py
@@ -174,6 +174,7 @@ class ConnectionPool(Dispatcher):
                 trust_env=self.trust_env,
                 uds=self.uds,
             )
+            await connection.connect(timeout=timeout)
             logger.trace(f"new_connection connection={connection!r}")
         else:
             logger.trace(f"reuse_connection connection={connection!r}")

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import timedelta
 
 import pytest
@@ -180,3 +181,18 @@ async def test_elapsed_delay(server):
     async with httpx.AsyncClient() as client:
         response = await client.get(url)
     assert response.elapsed.total_seconds() > 0.0
+
+
+@pytest.mark.asyncio
+async def test_open_connection_invariance(server):
+    """
+    Check that `assert self.open_connection is not None` statement is not violated.
+    See https://github.com/encode/httpx/issues/689 .
+    """
+
+    async def run_many(client, n):
+        for _ in range(n):
+            await client.get(server.url)
+
+    async with httpx.AsyncClient() as client:
+        await asyncio.gather(*[run_many(client, 10) for _ in range(11)])


### PR DESCRIPTION
Fixes #689