### PR TITLE
Drop `OpenConnection`

### DIFF
--- a/httpx/dispatch/base.py
+++ b/httpx/dispatch/base.py
@@ -50,26 +50,3 @@ class Dispatcher:
         traceback: TracebackType = None,
     ) -> None:
         await self.close()
-
-
-class OpenConnection:
-    """
-    Base class for connection classes that interact with a host via HTTP.
-    """
-
-    @property
-    def is_http2(self) -> bool:
-        raise NotImplementedError()  # pragma: no cover
-
-    async def send(self, request: Request, timeout: Timeout = None,) -> Response:
-        raise NotImplementedError()  # pragma: no cover
-
-    @property
-    def is_closed(self) -> bool:
-        raise NotImplementedError()  # pragma: no cover
-
-    def is_connection_dropped(self) -> bool:
-        raise NotImplementedError()  # pragma: no cover
-
-    async def close(self) -> None:
-        raise NotImplementedError()  # pragma: no cover

--- a/httpx/dispatch/http11.py
+++ b/httpx/dispatch/http11.py
@@ -8,7 +8,6 @@ from ..content_streams import AsyncIteratorStream
 from ..exceptions import ConnectionClosed, ProtocolError
 from ..models import Request, Response
 from ..utils import get_logger
-from .base import OpenConnection
 
 H11Event = typing.Union[
     h11.Request,
@@ -29,7 +28,7 @@ OnReleaseCallback = typing.Callable[[], typing.Awaitable[None]]
 logger = get_logger(__name__)
 
 
-class HTTP11Connection(OpenConnection):
+class HTTP11Connection:
     READ_NUM_BYTES = 4096
 
     def __init__(

--- a/httpx/dispatch/http2.py
+++ b/httpx/dispatch/http2.py
@@ -16,12 +16,11 @@ from ..content_streams import AsyncIteratorStream
 from ..exceptions import ProtocolError
 from ..models import Request, Response
 from ..utils import get_logger
-from .base import OpenConnection
 
 logger = get_logger(__name__)
 
 
-class HTTP2Connection(OpenConnection):
+class HTTP2Connection:
     READ_NUM_BYTES = 4096
     CONFIG = H2Configuration(validate_inbound_headers=False)
 


### PR DESCRIPTION
Since we're not 100% on if we want #496 or not, I think we should drop the `OpenConection` abstraction for now - really we should only introduce that if we need it.

I've also made some other refactoring tweaks:

* `.open_connection` -> `.connection`.
* Drop `.set_open_connection` in favor of just instantiating the connection where used.
* More robust behavior for `.is_http2`, `.is_closed`, `.is_connection_dropped` properties.

Also closes #689