### PR TITLE
Drop non-functional `Request.cookies` property.

### DIFF
--- a/httpx/models.py
+++ b/httpx/models.py
@@ -600,8 +600,7 @@ class Request:
         self.url = URL(url, params=params)
         self.headers = Headers(headers)
         if cookies:
-            self._cookies = Cookies(cookies)
-            self._cookies.set_cookie_header(self)
+            Cookies(cookies).set_cookie_header(self)
 
         if stream is not None:
             self.stream = stream
@@ -639,12 +638,6 @@ class Request:
 
         for item in reversed(auto_headers):
             self.headers.raw.insert(0, item)
-
-    @property
-    def cookies(self) -> "Cookies":
-        if not hasattr(self, "_cookies"):
-            self._cookies = Cookies()
-        return self._cookies
 
     def __repr__(self) -> str:
         class_name = self.__class__.__name__


### PR DESCRIPTION
Although this might look like an API breaking change on first sight, I think we could actually treat it as a borderline bugfix...

We're currently exposing a `.cookies` property on `Request`, but we don't *do anything with it*.
If a user builds a request instance explicitly, and sets items on `request.cookies` it won't have any effect.

I'd potentially be okay with us *having* a `request.cookies` property at some point, tho it's not neccessarily a given that we ought to. Given that it doesn't currently have the behavior users would expect from it, I think it's reasonable just to drop it outright for now.