### PR TITLE
Make timeout parameter None-able & cleanup __all__.

### DIFF
--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -71,8 +71,6 @@ __all__ = [
     "ProxyError",
     "TooManyRedirects",
     "WriteTimeout",
-    "BaseSocketStream",
-    "ConcurrencyBackend",
     "URL",
     "StatusCode",
     "Cookies",

--- a/httpx/config.py
+++ b/httpx/config.py
@@ -10,7 +10,9 @@ from .utils import get_ca_bundle_from_env, get_logger
 
 CertTypes = typing.Union[str, typing.Tuple[str, str], typing.Tuple[str, str, str]]
 VerifyTypes = typing.Union[str, bool, ssl.SSLContext]
-TimeoutTypes = typing.Union[float, typing.Tuple[float, float, float, float], "Timeout"]
+TimeoutTypes = typing.Union[
+    None, float, typing.Tuple[float, float, float, float], "Timeout"
+]
 
 
 USER_AGENT = f"python-httpx/{__version__}"

--- a/httpx/models.py
+++ b/httpx/models.py
@@ -46,7 +46,6 @@ from .utils import (
 )
 
 if typing.TYPE_CHECKING:  # pragma: no cover
-    from .middleware.base import BaseMiddleware  # noqa: F401
     from .dispatch.base import Dispatcher  # noqa: F401
 
 PrimitiveData = typing.Optional[typing.Union[str, int, float, bool]]


### PR DESCRIPTION
[The doc](https://www.encode.io/httpx/advanced/#setting-and-disabling-timeouts) says we can disable timeout by setting it to None, but currently `TimeoutTypes`  doesn't allow a None, so I added it.
Plus, cleans up two removed entries from `__all__`.