### PR TITLE
Bump coverage

### DIFF
--- a/httpx/client.py
+++ b/httpx/client.py
@@ -223,28 +223,28 @@ class AsyncClient:
         timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
         trust_env: bool = None,
     ) -> Response:
-        if cert is not None:
+        if cert is not None:  # pragma: nocover
             raise RuntimeError(
                 "Passing a 'cert' argument when making a request on a client "
                 "is not supported anymore. Instantiate a new client instead, "
                 "passing any 'cert' arguments to the client itself."
             )
 
-        if verify is not None:
+        if verify is not None:  # pragma: nocover
             raise RuntimeError(
                 "Passing a 'verify' argument when making a request on a client "
                 "is not supported anymore. Instantiate a new client instead, "
                 "passing any 'verify' arguments to the client itself."
             )
 
-        if trust_env is not None:
+        if trust_env is not None:  # pragma: nocover
             raise RuntimeError(
                 "Passing a 'trust_env' argument when making a request on a client "
                 "is not supported anymore. Instantiate a new client instead, "
                 "passing any 'trust_env' argument to the client itself."
             )
 
-        if stream:
+        if stream:  # pragma: nocover
             warnings.warn(
                 "The 'stream=True' argument is due to be deprecated. "
                 "Use 'async with client.stream(method, url, ...) as response' instead."

--- a/httpx/config.py
+++ b/httpx/config.py
@@ -177,7 +177,7 @@ class SSLConfig:
             alpn_idents = ["http/1.1", "h2"] if http2 else ["http/1.1"]
             context.set_alpn_protocols(alpn_idents)
 
-        if hasattr(context, "keylog_filename"):
+        if hasattr(context, "keylog_filename"):  # pragma: nocover (Available in 3.8+)
             keylogfile = os.environ.get("SSLKEYLOGFILE")
             if keylogfile and self.trust_env:
                 context.keylog_filename = keylogfile  # type: ignore

--- a/httpx/dispatch/proxy_http.py
+++ b/httpx/dispatch/proxy_http.py
@@ -46,7 +46,7 @@ class HTTPProxy(ConnectionPool):
         backend: typing.Union[str, ConcurrencyBackend] = "auto",
     ):
 
-        if isinstance(proxy_mode, HTTPProxyMode):
+        if isinstance(proxy_mode, HTTPProxyMode):  # pragma: nocover
             warnings.warn(
                 "The 'HTTPProxyMode' enum is pending deprecation. "
                 "Use a plain string instead. proxy_mode='FORWARD_ONLY', or "

--- a/httpx/models.py
+++ b/httpx/models.py
@@ -861,19 +861,19 @@ class Response:
 
     @property
     def stream(self):  # type: ignore
-        warnings.warn(
+        warnings.warn(  # pragma: nocover
             "Response.stream() is due to be deprecated. "
             "Use Response.aiter_bytes() instead."
         )
-        return self.aiter_bytes
+        return self.aiter_bytes  # pragma: nocover
 
     @property
     def raw(self):  # type: ignore
-        warnings.warn(
+        warnings.warn(  # pragma: nocover
             "Response.raw() is due to be deprecated. "
             "Use Response.aiter_raw() instead."
         )
-        return self.aiter_raw
+        return self.aiter_raw  # pragma: nocover
 
     async def aiter_bytes(self) -> typing.AsyncIterator[bytes]:
         """

--- a/tests/client/test_redirects.py
+++ b/tests/client/test_redirects.py
@@ -77,6 +77,7 @@ class MockDispatch(Dispatcher):
             return Response(codes.OK, content=content, request=request)
 
         elif request.url.path == "/redirect_body":
+            body = b"".join([part async for part in request.stream])
             headers = {"location": "/redirect_body_target"}
             return Response(codes.PERMANENT_REDIRECT, headers=headers, request=request)
 

--- a/tests/dispatch/test_http2.py
+++ b/tests/dispatch/test_http2.py
@@ -143,9 +143,9 @@ async def test_http2_live_request():
     async with AsyncClient(http2=True) as client:
         try:
             resp = await client.get("https://nghttp2.org/httpbin/anything")
-        except TimeoutException:
+        except TimeoutException:  # pragma: nocover
             pytest.xfail(reason="nghttp2.org appears to be unresponsive")
-        except socket.gaierror:
+        except socket.gaierror:  # pragma: nocover
             pytest.xfail(reason="You appear to be offline")
         assert resp.status_code == 200
         assert resp.http_version == "HTTP/2"

--- a/tests/dispatch/utils.py
+++ b/tests/dispatch/utils.py
@@ -141,9 +141,7 @@ class MockHTTP2Server(BaseSocketStream):
                 flow_control,
                 self.conn.max_outbound_frame_size,
             )
-            if chunk_size == 0:
-                return
-            else:
+            if chunk_size > 0:
                 chunk, self.return_data[stream_id] = (
                     self.return_data[stream_id][:chunk_size],
                     self.return_data[stream_id][chunk_size:],

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -235,6 +235,15 @@ async def test_cannot_read_after_response_closed():
         await response.aread()
 
 
+@pytest.mark.asyncio
+async def test_elapsed_not_available_until_closed():
+    stream = AsyncIteratorStream(aiterator=async_streaming_body())
+    response = httpx.Response(200, stream=stream, request=REQUEST)
+
+    with pytest.raises(RuntimeError):
+        response.elapsed
+
+
 def test_unknown_status_code():
     response = httpx.Response(600, request=REQUEST)
     assert response.status_code == 600

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -155,10 +155,17 @@ async def test_text_decoder(data, encoding):
         for chunk in data:
             yield chunk
 
+    # Accessing `.text` on a read response.
     stream = AsyncIteratorStream(aiterator=iterator())
     response = httpx.Response(200, stream=stream, request=REQUEST)
     await response.aread()
     assert response.text == (b"".join(data)).decode(encoding)
+
+    # Streaming `.aiter_text` iteratively.
+    stream = AsyncIteratorStream(aiterator=iterator())
+    response = httpx.Response(200, stream=stream, request=REQUEST)
+    text = "".join([part async for part in response.aiter_text()])
+    assert text == (b"".join(data)).decode(encoding)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
* `nocover` on deprecated API.
* `nocover` on areas that are not available on all Python versions.
* `nocover` on xfail exception cases in tests.
* Test for uncovered behavior accessing `response.elapsed` before response is closed.
* Test for uncovered behavior of `aiter_text()` decoding.
* Refactor to remove uncovered line from test utils.
* Ingest request body in RedirectBodyUnavailable test case.
