### PR TITLE
Wrap network errors as HTTPX-specific exceptions

### DIFF
--- a/httpx/exceptions.py
+++ b/httpx/exceptions.py
@@ -71,6 +71,21 @@ class DecodingError(HTTPError):
     """
 
 
+# Network exceptions...
+
+
+class NetworkError(HTTPError):
+    """
+    A failure occurred while trying to access the network.
+    """
+
+
+class ConnectionClosed(NetworkError):
+    """
+    Expected more data from peer, but connection was closed.
+    """
+
+
 # Redirect exceptions...
 
 
@@ -144,12 +159,6 @@ class ResponseClosed(StreamError):
 class InvalidURL(HTTPError):
     """
     URL was missing a hostname, or was not one of HTTP/HTTPS.
-    """
-
-
-class ConnectionClosed(HTTPError):
-    """
-    Expected more data from peer, but connection was closed.
     """
 
 

--- a/httpx/utils.py
+++ b/httpx/utils.py
@@ -1,5 +1,6 @@
 import codecs
 import collections
+import contextlib
 import logging
 import netrc
 import os
@@ -11,6 +12,8 @@ from pathlib import Path
 from time import perf_counter
 from types import TracebackType
 from urllib.request import getproxies
+
+from .exceptions import NetworkError
 
 if typing.TYPE_CHECKING:  # pragma: no cover
     from .models import PrimitiveData
@@ -362,3 +365,14 @@ class ElapsedTimer:
         if self.end is None:
             return timedelta(seconds=perf_counter() - self.start)
         return timedelta(seconds=self.end - self.start)
+
+
+@contextlib.contextmanager
+def as_network_error(*exception_classes: type) -> typing.Iterator[None]:
+    try:
+        yield
+    except BaseException as exc:
+        for cls in exception_classes:
+            if isinstance(exc, cls):
+                raise NetworkError(exc) from exc
+        raise


### PR DESCRIPTION
Fixes #349 

- Wrap `OSError` exceptions raised in backends `.read()`, `.write()`, `.close()`, as well as `.open_xxx_stream()` methods.
- For trio, handle `BrokenResourceError` exceptions as well when we can expect trio to raise them instead of `OSError`-derived exceptions.
- Specialize `ConnectionClosed` to be a subclass of `NetworkError`.

Note that we're not doing special handling for `ConnectionError` because it's a subclass of `OSError`.

Not married to the naming/API specifics of the `as_network_error()` construct — could also be e.g. `raise_as(NetworkError, OSError)`. But I think it's a good idea to have a dedicated utility for actually performing the wrapping, instead of bare `try/except`. Eg. this centralizes which behavior we'd like to expose w.r.t. exposing or hiding the `__cause__` of the `NetworkError`.