### PR TITLE
Load SSL Context on init

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,20 +13,19 @@ from httpx.config import SSLConfig
 
 def test_load_ssl_config():
     ssl_config = SSLConfig()
-    context = ssl_config.load_ssl_context()
+    context = ssl_config.ssl_context
     assert context.verify_mode == ssl.VerifyMode.CERT_REQUIRED
     assert context.check_hostname is True
 
 
 def test_load_ssl_config_verify_non_existing_path():
-    ssl_config = SSLConfig(verify="/path/to/nowhere")
     with pytest.raises(IOError):
-        ssl_config.load_ssl_context()
+        SSLConfig(verify="/path/to/nowhere")
 
 
 def test_load_ssl_config_verify_existing_file():
     ssl_config = SSLConfig(verify=certifi.where())
-    context = ssl_config.load_ssl_context()
+    context = ssl_config.ssl_context
     assert context.verify_mode == ssl.VerifyMode.CERT_REQUIRED
     assert context.check_hostname is True
 
@@ -39,7 +38,7 @@ def test_load_ssl_config_verify_env_file(https_server, ca_cert_pem_file, config)
         else str(Path(ca_cert_pem_file).parent)
     )
     ssl_config = SSLConfig(trust_env=True)
-    context = ssl_config.load_ssl_context()
+    context = ssl_config.ssl_context
     assert context.verify_mode == ssl.VerifyMode.CERT_REQUIRED
     assert context.check_hostname is True
     assert ssl_config.verify == os.environ[config]
@@ -58,14 +57,14 @@ def test_load_ssl_config_verify_env_file(https_server, ca_cert_pem_file, config)
 def test_load_ssl_config_verify_directory():
     path = Path(certifi.where()).parent
     ssl_config = SSLConfig(verify=path)
-    context = ssl_config.load_ssl_context()
+    context = ssl_config.ssl_context
     assert context.verify_mode == ssl.VerifyMode.CERT_REQUIRED
     assert context.check_hostname is True
 
 
 def test_load_ssl_config_cert_and_key(cert_pem_file, cert_private_key_file):
     ssl_config = SSLConfig(cert=(cert_pem_file, cert_private_key_file))
-    context = ssl_config.load_ssl_context()
+    context = ssl_config.ssl_context
     assert context.verify_mode == ssl.VerifyMode.CERT_REQUIRED
     assert context.check_hostname is True
 
@@ -77,7 +76,7 @@ def test_load_ssl_config_cert_and_encrypted_key(
     ssl_config = SSLConfig(
         cert=(cert_pem_file, cert_encrypted_private_key_file, password)
     )
-    context = ssl_config.load_ssl_context()
+    context = ssl_config.ssl_context
     assert context.verify_mode == ssl.VerifyMode.CERT_REQUIRED
     assert context.check_hostname is True
 
@@ -85,23 +84,18 @@ def test_load_ssl_config_cert_and_encrypted_key(
 def test_load_ssl_config_cert_and_key_invalid_password(
     cert_pem_file, cert_encrypted_private_key_file
 ):
-    ssl_config = SSLConfig(
-        cert=(cert_pem_file, cert_encrypted_private_key_file, "password1")
-    )
-
     with pytest.raises(ssl.SSLError):
-        ssl_config.load_ssl_context()
+        SSLConfig(cert=(cert_pem_file, cert_encrypted_private_key_file, "password1"))
 
 
 def test_load_ssl_config_cert_without_key_raises(cert_pem_file):
-    ssl_config = SSLConfig(cert=cert_pem_file)
     with pytest.raises(ssl.SSLError):
-        ssl_config.load_ssl_context()
+        SSLConfig(cert=cert_pem_file)
 
 
 def test_load_ssl_config_no_verify():
     ssl_config = SSLConfig(verify=False)
-    context = ssl_config.load_ssl_context()
+    context = ssl_config.ssl_context
     assert context.verify_mode == ssl.VerifyMode.CERT_NONE
     assert context.check_hostname is False
 
@@ -110,9 +104,7 @@ def test_load_ssl_context():
     ssl_context = ssl.create_default_context()
     ssl_config = SSLConfig(verify=ssl_context)
 
-    assert ssl_config.verify is True
     assert ssl_config.ssl_context is ssl_context
-    assert repr(ssl_config) == "SSLConfig(cert=None, verify=True)"
 
 
 def test_ssl_repr():
@@ -199,7 +191,6 @@ def test_ssl_config_support_for_keylog_file(tmpdir, monkeypatch):  # pragma: noc
         m.delenv("SSLKEYLOGFILE", raising=False)
 
         ssl_config = SSLConfig(trust_env=True)
-        ssl_config.load_ssl_context()
 
         assert ssl_config.ssl_context.keylog_filename is None
 
@@ -209,11 +200,9 @@ def test_ssl_config_support_for_keylog_file(tmpdir, monkeypatch):  # pragma: noc
         m.setenv("SSLKEYLOGFILE", filename)
 
         ssl_config = SSLConfig(trust_env=True)
-        ssl_config.load_ssl_context()
 
         assert ssl_config.ssl_context.keylog_filename == filename
 
         ssl_config = SSLConfig(trust_env=False)
-        ssl_config.load_ssl_context()
 
         assert ssl_config.ssl_context.keylog_filename is None


### PR DESCRIPTION
Follow up to #706

Load the SSLContext at the point that SSLConfig is initialized, rather than per-request.

One benefit of this is that we'll now raise any configuration errors that the point of client-init, rather than on the initial request.