### PR TITLE
Improve docstring for PoolLimits

### DIFF
--- a/httpx/config.py
+++ b/httpx/config.py
@@ -293,6 +293,11 @@ class Timeout:
 class PoolLimits:
     """
     Limits on the number of connections in a connection pool.
+
+    **Parameters:**
+
+    * **soft_limit** - Allow the connection pool to maintain keep-alive connections below this point.
+    * **hard_limit** - The maximum number of concurrenct connections that may be established.
     """
 
     def __init__(

--- a/httpx/config.py
+++ b/httpx/config.py
@@ -296,8 +296,10 @@ class PoolLimits:
 
     **Parameters:**
 
-    * **soft_limit** - Allow the connection pool to maintain keep-alive connections below this point.
-    * **hard_limit** - The maximum number of concurrenct connections that may be established.
+    * **soft_limit** - Allow the connection pool to maintain keep-alive connections
+                       below this point.
+    * **hard_limit** - The maximum number of concurrenct connections that may be
+                       established.
     """
 
     def __init__(


### PR DESCRIPTION
Include description of `soft_limit` and `hard_limit` on PoolLimits.

Refs #708, but probably not sufficient to close it.

We'll probably want an explicit section in the advanced docs on connection pool limits, pool timeouts, max streams per connection etc. Also complicated by the sync implementation currently having a different style of behavior to the async version.