### PR TITLE
Refactor ConnectionPool/HTTPConnection for extensibility

### DIFF
--- a/httpx/dispatch/connection.py
+++ b/httpx/dispatch/connection.py
@@ -34,6 +34,8 @@ class HTTPConnection(Dispatcher):
         self.connection: typing.Union[None, HTTP11Connection, HTTP2Connection] = None
         self.expires_at: typing.Optional[float] = None
 
+        self.logger = logger
+
     async def send(self, request: Request, timeout: Timeout = None) -> Response:
         timeout = Timeout() if timeout is None else timeout
 


### PR DESCRIPTION
Builds on #726, refs #723.

Demonstration of changes required to make [httpx-unixsocket-poc](https://github.com/florimondmanca/httpx-unixsocket-poc) happen:

- Allow to customize the connection class used by the `ConnectionPool` (by overriding a `.get_connection_factory()` method).
- Allow to customize how an `HTTPConnection` opens a socket stream (by overriding an `.open_socket_stream()` method).
- Expose the HTTPX logger as an attribute on `HTTPConnection` instances. (I think in general this is a good pattern to apply across the codebase, instead of relying on a global `logger` instance, maybe?)

Not necessarily intended for merging… although not having this would make a third-party UDS solution much less straight-forward to implement. (Applies to any third-party code that customizes a connection pool, for that matter. For example, I'd very much see proxies being provided as third-party this way, although that's not necessarily desirable.)