### PR TITLE
Version 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.11.0 (January 9th, 2019)
+
+The 0.11 release reintroduces our sync support, so that `httpx` now supports both a standard thread-concurrency API, and an async API.
+
+Existing async `httpx` users that are upgrading to 0.11 should ensure that:
+
+* Async codebases should always use a client instance to make requests.
+* The async client is named as `httpx.AsyncClient()`.
+* When instantiating proxy configurations use the `httpx.Proxy()` class, instead of the previous `httpx.HTTPProxy()`. This new configuration class works for configuring both sync and async clients.
+
+We believe the API is now pretty much stable, and are aiming for a 1.0 release sometime on or before April 2020.
+
+### Changed
+
+- Top level API such as `httpx.get(url, ...)`, `httpx.post(url, ...)`, `httpx.request(method, url, ...)` becomes synchronous.
+- Added `httpx.Client()` for synchronous clients, with `httpx.AsyncClient` being used for async clients.
+- Switched to `proxies=httpx.Proxy(...)` for proxy configuration.
+- Network connection errors are wrapped in `httpx.NetworkError`, rather than exposing lower-level exception types directly.
+
+### Removed
+
+- The `request.origin` property and `httpx.Origin` class are no longer available.
+- The per-request `cert`, `verify`, and `trust_env` arguments are escalated from raising errors if used, to no longer being available. These arguments should be used on a per-client instance instead, or in the top-level API.
+- The `stream` argument has escalated from raising an error when used, to no longer being available. Use the `client.stream(...)` or `httpx.stream()` streaming API instead.
+
 ## 0.10.1 (December 31st, 2019)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 0.11.0 (January 9th, 2019)
+## 0.11.0 (January 8th, 2019)
 
 The 0.11 release reintroduces our sync support, so that `httpx` now supports both a standard thread-concurrency API, and an async API.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ We believe the API is now pretty much stable, and are aiming for a 1.0 release s
 
 ### Removed
 
-- The `request.origin` property and `httpx.Origin` class are no longer available.
+- The `request.url.origin` property and `httpx.Origin` class are no longer available.
 - The per-request `cert`, `verify`, and `trust_env` arguments are escalated from raising errors if used, to no longer being available. These arguments should be used on a per-client instance instead, or in the top-level API.
 - The `stream` argument has escalated from raising an error when used, to no longer being available. Use the `client.stream(...)` or `httpx.stream()` streaming API instead.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The 0.11 release reintroduces our sync support, so that `httpx` now supports bot
 
 Existing async `httpx` users that are upgrading to 0.11 should ensure that:
 
-* Async codebases should always use a client instance to make requests.
+* Async codebases should always use a client instance to make requests, instead of the top-level API.
 * The async client is named as `httpx.AsyncClient()`, instead of `httpx.Client()`.
 * When instantiating proxy configurations use the `httpx.Proxy()` class, instead of the previous `httpx.HTTPProxy()`. This new configuration class works for configuring both sync and async clients.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The 0.11 release reintroduces our sync support, so that `httpx` now supports bot
 Existing async `httpx` users that are upgrading to 0.11 should ensure that:
 
 * Async codebases should always use a client instance to make requests.
-* The async client is named as `httpx.AsyncClient()`.
+* The async client is named as `httpx.AsyncClient()`, instead of `httpx.Client()`.
 * When instantiating proxy configurations use the `httpx.Proxy()` class, instead of the previous `httpx.HTTPProxy()`. This new configuration class works for configuring both sync and async clients.
 
 We believe the API is now pretty much stable, and are aiming for a 1.0 release sometime on or before April 2020.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 0.11.0 (January 8th, 2019)
+## 0.11.0 (January 9th, 2019)
 
 The 0.11 release reintroduces our sync support, so that `httpx` now supports both a standard thread-concurrency API, and an async API.
 
@@ -28,6 +28,10 @@ We believe the API is now pretty much stable, and are aiming for a 1.0 release s
 - The `request.url.origin` property and `httpx.Origin` class are no longer available.
 - The per-request `cert`, `verify`, and `trust_env` arguments are escalated from raising errors if used, to no longer being available. These arguments should be used on a per-client instance instead, or in the top-level API.
 - The `stream` argument has escalated from raising an error when used, to no longer being available. Use the `client.stream(...)` or `httpx.stream()` streaming API instead.
+
+### Fixed
+
+- Redirect loop detection matches against `(method, url)` rather than `url`. (Pull #734)
 
 ## 0.10.1 (December 31st, 2019)
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -433,7 +433,7 @@ You can also disable the timeout behavior completely...
 >>> await httpx.get('https://github.com/', timeout=None)
 ```
 
-For advanced timeout management, see [Timeout fine-tuning](https://www.encode.io/httpx/advanced/#fine-tuning-the-configuration).
+For advanced timeout management, see [Timeout fine-tuning](advanced.md#fine-tuning-the-configuration).
 
 ## Authentication
 

--- a/httpx/__version__.py
+++ b/httpx/__version__.py
@@ -1,3 +1,3 @@
 __title__ = "httpx"
 __description__ = "A next generation HTTP client, for Python 3."
-__version__ = "0.10.1"
+__version__ = "0.11.0"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ theme:
     name: 'material'
 
 repo_name: encode/httpx
-repo_url: https://github.com/encode/httpx
+repo_url: https://www.python-httpx.org/
 edit_uri: ""
 
 nav:

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         "sniffio==1.*",
     ],
     classifiers=[
-        "Development Status :: 3 - Alpha",
+        "Development Status :: 4 - Beta",
         "Environment :: Web Environment",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
Closes #724

Also requires the following, before merge:

- [x] #727 
- [x] #735

I've currently listed the release date here as tomorrow (Thursday 9th January). I don't *think* we've got any blockers left at this point, @florimondmanca?

## 0.11.0 (January 9th, 2019)

The 0.11 release reintroduces our sync support, so that `httpx` now supports both a standard thread-concurrency API, and an async API.

Existing async `httpx` users that are upgrading to 0.11 should ensure that:

* Async codebases should always use a client instance to make requests.
* The async client is named as `httpx.AsyncClient()`.
* When instantiating proxy configurations use the `httpx.Proxy()` class, instead of the previous `httpx.HTTPProxy()`. This new configuration class works for configuring both sync and async clients.

We believe the API is now pretty much stable, and are aiming for a 1.0 release sometime on or before April 2020.

### Changed

- Top level API such as `httpx.get(url, ...)`, `httpx.post(url, ...)`, `httpx.request(method, url, ...)` becomes synchronous.
- Added `httpx.Client()` for synchronous clients, with `httpx.AsyncClient` being used for async clients.
- Switched to `proxies=httpx.Proxy(...)` for proxy configuration.
- Network connection errors are wrapped in `httpx.NetworkError`, rather than exposing lower-level exception types directly.

### Removed

- The `request.origin` property and `httpx.Origin` class are no longer available.
- The per-request `cert`, `verify`, and `trust_env` arguments are escalated from raising errors if used, to no longer being available. These arguments should be used on a per-client instance instead, or in the top-level API.
- The `stream` argument has escalated from raising an error when used, to no longer being available. Use the `client.stream(...)` or `httpx.stream()` streaming API instead.