### PR TITLE
Fix typo in 'Streaming responses' docs

### DIFF
--- a/docs/async.md
+++ b/docs/async.md
@@ -67,14 +67,14 @@ The `AsyncClient.stream(method, url, ...)` method is an async context block.
 ```python
 >>> client = httpx.AsyncClient()
 >>> async with client.stream('GET', 'https://www.example.com/') as response:
->>>     async for chunk in r.aiter_content():
+>>>     async for chunk in response.aiter_bytes():
 >>>         ...
 ```
 
 The async response streaming methods are:
 
 * `Response.aread()` - For conditionally reading a response inside a stream block.
-* `Response.aiter_content()` - For streaming the response content as bytes.
+* `Response.aiter_bytes()` - For streaming the response content as bytes.
 * `Response.aiter_text()` - For streaming the response content as text.
 * `Response.aiter_lines()` - For streaming the response content as lines of text.
 * `Response.aiter_raw()` - For streaming the raw response bytes, without applying content decoding.


### PR DESCRIPTION
```python
>>> import httpx
>>> import asyncio
>>> async def stream():
  client = httpx.AsyncClient()
  async with client.stream('GET', 'https://www.example.com/') as response:
    async for chunk in response.aiter_content():
      print(chunk)

>>> asyncio.run(stream())
```

```
Traceback (most recent call last):
  File "<pyshell#7>", line 1, in <module>
    asyncio.run(stream())
  File "C:\Program Files\Python37\lib\asyncio\runners.py", line 43, in run
    return loop.run_until_complete(main)
  File "C:\Program Files\Python37\lib\asyncio\base_events.py", line 583, in run_until_complete
    return future.result()
  File "<pyshell#6>", line 4, in stream
    async for chunk in r.aiter_content():
NameError: name 'r' is not defined

Traceback (most recent call last):
  File "<pyshell#4>", line 1, in <module>
    asyncio.run(stream())
  File "C:\Program Files\Python37\lib\asyncio\runners.py", line 43, in run
    return loop.run_until_complete(main)
  File "C:\Program Files\Python37\lib\asyncio\base_events.py", line 583, in run_until_complete
    return future.result()
  File "<pyshell#3>", line 4, in stream
    async for chunk in response.aiter_content():
AttributeError: 'Response' object has no attribute 'aiter_content'
```