### PR TITLE
Setup custom domain for docs site

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+www.python-httpx.org


### PR DESCRIPTION
Add the missing `CNAME` file to the `docs` root directory.

This file is (secretly) added by GitHub when a custom domain is setup via the "Settings" page. But we need to commit it to the repo so that MkDocs keeps it when deploying.

(I deployed the docs manually to publish recent typo fixes, which is when `CNAME` was removed from the `gh-pages` branch by MkDocs.)

Thanks @lilydjwg for noticing this here: https://github.com/encode/httpx/commit/f46ac022eb11ff53f38037f21ab3d8bc8ad89b46#commitcomment-36755660