### PR TITLE
Add docs and repo to project_urls metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,10 @@ setup(
     python_requires=">=3.6",
     version=get_version("httpx"),
     url="https://github.com/encode/httpx",
+    project_urls={
+        "Documentation": "https://www.python-httpx.org",
+        "Source": "https://github.com/encode/httpx",
+    },
     license="BSD",
     description="The next generation HTTP client.",
     long_description=get_long_description(),

--- a/setup.py
+++ b/setup.py
@@ -78,5 +78,6 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3 :: Only",
     ],
 )


### PR DESCRIPTION
For programmatic access to metadata on PyPI.

Also add the "Python 3 Only" Trove classifier, which can also be useful for programmatic use.