### PR TITLE
Support both zlib and deflate encodings

### DIFF
--- a/httpx/decoders.py
+++ b/httpx/decoders.py
@@ -45,12 +45,18 @@ class DeflateDecoder(Decoder):
     """
 
     def __init__(self) -> None:
-        self.decompressor = zlib.decompressobj(-zlib.MAX_WBITS)
+        self.first_attempt = True
+        self.decompressor = zlib.decompressobj()
 
     def decode(self, data: bytes) -> bytes:
+        was_first_attempt = self.first_attempt
+        self.first_attempt = False
         try:
             return self.decompressor.decompress(data)
         except zlib.error as exc:
+            if was_first_attempt:
+                self.decompressor = zlib.decompressobj(-zlib.MAX_WBITS)
+                return self.decode(data)
             raise DecodingError from exc
 
     def flush(self) -> bytes:

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -18,8 +18,14 @@ REQUEST = httpx.Request("GET", "https://example.org")
 
 
 def test_deflate():
+    """
+    Deflate encoding may use either 'zlib' or 'deflate' in the wild.
+
+    https://stackoverflow.com/questions/1838699/how-can-i-decompress-a-gzip-stream-with-zlib#answer-22311297
+    """
     body = b"test 123"
-    compressed_body = zlib.compress(body)
+    compressor = zlib.compressobj(9, zlib.DEFLATED, -zlib.MAX_WBITS)
+    compressed_body = compressor.compress(body) + compressor.flush()
 
     headers = [(b"Content-Encoding", b"deflate")]
     response = httpx.Response(
@@ -28,10 +34,14 @@ def test_deflate():
     assert response.content == body
 
 
-def test_deflate_max_wbits():
+def test_zlib():
+    """
+    Deflate encoding may use either 'zlib' or 'deflate' in the wild.
+
+    https://stackoverflow.com/questions/1838699/how-can-i-decompress-a-gzip-stream-with-zlib#answer-22311297
+    """
     body = b"test 123"
-    compressor = zlib.compressobj(9, zlib.DEFLATED, -zlib.MAX_WBITS)
-    compressed_body = compressor.compress(body) + compressor.flush()
+    compressed_body = zlib.compress(body)
 
     headers = [(b"Content-Encoding", b"deflate")]
     response = httpx.Response(

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -19,6 +19,17 @@ REQUEST = httpx.Request("GET", "https://example.org")
 
 def test_deflate():
     body = b"test 123"
+    compressed_body = zlib.compress(body)
+
+    headers = [(b"Content-Encoding", b"deflate")]
+    response = httpx.Response(
+        200, headers=headers, content=compressed_body, request=REQUEST
+    )
+    assert response.content == body
+
+
+def test_deflate_max_wbits():
+    body = b"test 123"
     compressor = zlib.compressobj(9, zlib.DEFLATED, -zlib.MAX_WBITS)
     compressed_body = compressor.compress(body) + compressor.flush()
 


### PR DESCRIPTION
Closes #756 

`DeflateDecoder` now attempt both "deflate" decoding and "zlib" decoding.
