### PR TITLE
Preserve header casing

### DIFF
--- a/httpx/auth.py
+++ b/httpx/auth.py
@@ -108,12 +108,12 @@ class DigestAuth(Auth):
             raise RequestBodyUnavailable("Request body is no longer available.")
         response = yield request
 
-        if response.status_code != 401 or "www-authenticate" not in response.headers:
+        if response.status_code != 401 or "WWW-Authenticate" not in response.headers:
             # If the response is not a 401 WWW-Authenticate, then we don't
             # need to build an authenticated request.
             return
 
-        header = response.headers["www-authenticate"]
+        header = response.headers["WWW-Authenticate"]
         try:
             challenge = DigestAuthChallenge.from_header(header)
         except ValueError:

--- a/httpx/dispatch/http2.py
+++ b/httpx/dispatch/http2.py
@@ -233,9 +233,9 @@ class HTTP2Stream:
             (b":scheme", request.url.scheme.encode("ascii")),
             (b":path", request.url.full_path.encode("ascii")),
         ] + [
-            (k, v)
+            (k.lower(), v)
             for k, v in request.headers.raw
-            if k not in (b"host", b"transfer-encoding")
+            if k.lower() not in (b"host", b"transfer-encoding")
         ]
         end_stream = not has_body
 

--- a/httpx/models.py
+++ b/httpx/models.py
@@ -469,7 +469,7 @@ class Headers(typing.MutableMapping[str, str]):
         values = [
             item_value.decode(self.encoding)
             for item_key, item_value in self._list
-            if item_key == get_header_key
+            if item_key.lower() == get_header_key
         ]
 
         if not split_commas:
@@ -499,7 +499,7 @@ class Headers(typing.MutableMapping[str, str]):
 
         items = []
         for header_key, header_value in self._list:
-            if header_key == normalized_key:
+            if header_key.lower() == normalized_key:
                 items.append(header_value.decode(self.encoding))
 
         if items:
@@ -512,12 +512,13 @@ class Headers(typing.MutableMapping[str, str]):
         Set the header `key` to `value`, removing any duplicate entries.
         Retains insertion order.
         """
-        set_key = key.lower().encode(self.encoding)
+        set_key = key.encode(self.encoding)
         set_value = value.encode(self.encoding)
+        lower_key = set_key.lower()
 
         found_indexes = []
         for idx, (item_key, _) in enumerate(self._list):
-            if item_key == set_key:
+            if item_key.lower() == lower_key:
                 found_indexes.append(idx)
 
         for idx in reversed(found_indexes[1:]):
@@ -537,7 +538,7 @@ class Headers(typing.MutableMapping[str, str]):
 
         pop_indexes = []
         for idx, (item_key, _) in enumerate(self._list):
-            if item_key == del_key:
+            if item_key.lower() == del_key:
                 pop_indexes.append(idx)
         if not pop_indexes:
             raise KeyError(key)
@@ -548,7 +549,7 @@ class Headers(typing.MutableMapping[str, str]):
     def __contains__(self, key: typing.Any) -> bool:
         get_header_key = key.lower().encode(self.encoding)
         for header_key, _ in self._list:
-            if header_key == get_header_key:
+            if header_key.lower() == get_header_key:
                 return True
         return False
 
@@ -619,25 +620,25 @@ class Request:
 
         auto_headers: typing.List[typing.Tuple[bytes, bytes]] = []
 
-        has_host = "host" in self.headers
-        has_user_agent = "user-agent" in self.headers
-        has_accept = "accept" in self.headers
-        has_accept_encoding = "accept-encoding" in self.headers
-        has_connection = "connection" in self.headers
+        has_host = "Host" in self.headers
+        has_user_agent = "User-Agent" in self.headers
+        has_accept = "Accept" in self.headers
+        has_accept_encoding = "Accept-Encoding" in self.headers
+        has_connection = "Connection" in self.headers
 
         if not has_host:
             url = self.url
             if url.userinfo:
                 url = url.copy_with(username=None, password=None)
-            auto_headers.append((b"host", url.authority.encode("ascii")))
+            auto_headers.append((b"Host", url.authority.encode("ascii")))
         if not has_user_agent:
-            auto_headers.append((b"user-agent", USER_AGENT.encode("ascii")))
+            auto_headers.append((b"User-Agent", USER_AGENT.encode("ascii")))
         if not has_accept:
-            auto_headers.append((b"accept", b"*/*"))
+            auto_headers.append((b"Accept", b"*/*"))
         if not has_accept_encoding:
-            auto_headers.append((b"accept-encoding", ACCEPT_ENCODING.encode()))
+            auto_headers.append((b"Accept-Encoding", ACCEPT_ENCODING.encode()))
         if not has_connection:
-            auto_headers.append((b"connection", b"keep-alive"))
+            auto_headers.append((b"Connection", b"keep-alive"))
 
         for item in reversed(auto_headers):
             self.headers.raw.insert(0, item)

--- a/httpx/utils.py
+++ b/httpx/utils.py
@@ -34,8 +34,8 @@ def normalize_header_key(value: typing.AnyStr, encoding: str = None) -> bytes:
     Coerce str/bytes into a strictly byte-wise HTTP header key.
     """
     if isinstance(value, bytes):
-        return value.lower()
-    return value.encode(encoding or "ascii").lower()
+        return value
+    return value.encode(encoding or "ascii")
 
 
 def normalize_header_value(value: typing.AnyStr, encoding: str = None) -> bytes:

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -31,7 +31,7 @@ class MockDispatch(AsyncDispatcher):
         cert: CertTypes = None,
         timeout: TimeoutTypes = None,
     ) -> Response:
-        headers = [("www-authenticate", self.auth_header)] if self.auth_header else []
+        headers = [("WWW-Authenticate", self.auth_header)] if self.auth_header else []
         body = json.dumps({"auth": request.headers.get("Authorization")}).encode()
         return Response(
             self.status_code, headers=headers, content=body, request=request
@@ -204,7 +204,7 @@ async def test_auth_hidden_header() -> None:
     client = AsyncClient(dispatch=MockDispatch())
     response = await client.get(url, auth=auth)
 
-    assert "'authorization': '[secure]'" in str(response.request.headers)
+    assert "'Authorization': '[secure]'" in str(response.request.headers)
 
 
 @pytest.mark.asyncio
@@ -431,7 +431,7 @@ async def test_auth_history() -> None:
             for index in range(self.repeat):
                 request.headers["Authorization"] = f"Repeat {index}"
                 response = yield request
-                nonces.append(response.headers["www-authenticate"])
+                nonces.append(response.headers["WWW-Authenticate"])
 
             key = ".".join(nonces)
             request.headers["Authorization"] = f"Repeat {key}"

--- a/tests/client/test_headers.py
+++ b/tests/client/test_headers.py
@@ -37,12 +37,12 @@ async def test_client_header():
     assert response.status_code == 200
     assert response.json() == {
         "headers": {
-            "accept": "*/*",
-            "accept-encoding": "gzip, deflate, br",
-            "connection": "keep-alive",
-            "example-header": "example-value",
-            "host": "example.org",
-            "user-agent": f"python-httpx/{__version__}",
+            "Accept": "*/*",
+            "Accept-Encoding": "gzip, deflate, br",
+            "Connection": "keep-alive",
+            "Example-Header": "example-value",
+            "Host": "example.org",
+            "User-Agent": f"python-httpx/{__version__}",
         }
     }
 
@@ -58,12 +58,12 @@ async def test_header_merge():
     assert response.status_code == 200
     assert response.json() == {
         "headers": {
-            "accept": "*/*",
-            "accept-encoding": "gzip, deflate, br",
-            "connection": "keep-alive",
-            "host": "example.org",
-            "user-agent": "python-myclient/0.2.1",
-            "x-auth-token": "FooBarBazToken",
+            "Accept": "*/*",
+            "Accept-Encoding": "gzip, deflate, br",
+            "Connection": "keep-alive",
+            "Host": "example.org",
+            "User-Agent": "python-myclient/0.2.1",
+            "X-Auth-Token": "FooBarBazToken",
         }
     }
 
@@ -79,12 +79,12 @@ async def test_header_merge_conflicting_headers():
     assert response.status_code == 200
     assert response.json() == {
         "headers": {
-            "accept": "*/*",
-            "accept-encoding": "gzip, deflate, br",
-            "connection": "keep-alive",
-            "host": "example.org",
-            "user-agent": f"python-httpx/{__version__}",
-            "x-auth-token": "BazToken",
+            "Accept": "*/*",
+            "Accept-Encoding": "gzip, deflate, br",
+            "Connection": "keep-alive",
+            "Host": "example.org",
+            "User-Agent": f"python-httpx/{__version__}",
+            "X-Auth-Token": "BazToken",
         }
     }
 
@@ -102,23 +102,23 @@ async def test_header_update():
     assert first_response.status_code == 200
     assert first_response.json() == {
         "headers": {
-            "accept": "*/*",
-            "accept-encoding": "gzip, deflate, br",
-            "connection": "keep-alive",
-            "host": "example.org",
-            "user-agent": f"python-httpx/{__version__}",
+            "Accept": "*/*",
+            "Accept-Encoding": "gzip, deflate, br",
+            "Connection": "keep-alive",
+            "Host": "example.org",
+            "User-Agent": f"python-httpx/{__version__}",
         }
     }
 
     assert second_response.status_code == 200
     assert second_response.json() == {
         "headers": {
-            "accept": "*/*",
-            "accept-encoding": "gzip, deflate, br",
-            "another-header": "AThing",
-            "connection": "keep-alive",
-            "host": "example.org",
-            "user-agent": "python-myclient/0.2.1",
+            "Accept": "*/*",
+            "Accept-Encoding": "gzip, deflate, br",
+            "Another-Header": "AThing",
+            "Connection": "keep-alive",
+            "Host": "example.org",
+            "User-Agent": "python-myclient/0.2.1",
         }
     }
 
@@ -144,12 +144,12 @@ async def test_host_with_auth_and_port_in_url():
     assert response.status_code == 200
     assert response.json() == {
         "headers": {
-            "accept": "*/*",
-            "accept-encoding": "gzip, deflate, br",
-            "connection": "keep-alive",
-            "host": "example.org",
-            "user-agent": f"python-httpx/{__version__}",
-            "authorization": "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
+            "Accept": "*/*",
+            "Accept-Encoding": "gzip, deflate, br",
+            "Connection": "keep-alive",
+            "Host": "example.org",
+            "User-Agent": f"python-httpx/{__version__}",
+            "Authorization": "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
         }
     }
 
@@ -168,11 +168,11 @@ async def test_host_with_non_default_port_in_url():
     assert response.status_code == 200
     assert response.json() == {
         "headers": {
-            "accept": "*/*",
-            "accept-encoding": "gzip, deflate, br",
-            "connection": "keep-alive",
-            "host": "example.org:123",
-            "user-agent": f"python-httpx/{__version__}",
-            "authorization": "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
+            "Accept": "*/*",
+            "Accept-Encoding": "gzip, deflate, br",
+            "Connection": "keep-alive",
+            "Host": "example.org:123",
+            "User-Agent": f"python-httpx/{__version__}",
+            "Authorization": "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
         }
     }

--- a/tests/client/test_redirects.py
+++ b/tests/client/test_redirects.py
@@ -244,7 +244,7 @@ async def test_cross_domain_redirect():
     headers = {"Authorization": "abc"}
     response = await client.get(url, headers=headers)
     assert response.url == URL("https://example.org/cross_domain_target")
-    assert "authorization" not in response.json()["headers"]
+    assert "Authorization" not in response.json()["headers"]
 
 
 @pytest.mark.usefixtures("async_environment")
@@ -254,7 +254,7 @@ async def test_same_domain_redirect():
     headers = {"Authorization": "abc"}
     response = await client.get(url, headers=headers)
     assert response.url == URL("https://example.org/cross_domain_target")
-    assert response.json()["headers"]["authorization"] == "abc"
+    assert response.json()["headers"]["Authorization"] == "abc"
 
 
 @pytest.mark.usefixtures("async_environment")
@@ -268,7 +268,7 @@ async def test_body_redirect():
     response = await client.post(url, data=data)
     assert response.url == URL("https://example.org/redirect_body_target")
     assert response.json()["body"] == "Example request body"
-    assert "content-length" in response.json()["headers"]
+    assert "Content-Length" in response.json()["headers"]
 
 
 @pytest.mark.usefixtures("async_environment")
@@ -282,7 +282,7 @@ async def test_no_body_redirect():
     response = await client.post(url, data=data)
     assert response.url == URL("https://example.org/redirect_body_target")
     assert response.json()["body"] == ""
-    assert "content-length" not in response.json()["headers"]
+    assert "Content-Length" not in response.json()["headers"]
 
 
 @pytest.mark.usefixtures("async_environment")

--- a/tests/dispatch/test_proxy_http.py
+++ b/tests/dispatch/test_proxy_http.py
@@ -202,6 +202,6 @@ def test_proxy_repr():
 
     assert repr(proxy) == (
         "HTTPProxy(proxy_url=URL('http://127.0.0.1:1080') "
-        "proxy_headers=Headers({'custom': 'Header'}) "
+        "proxy_headers=Headers({'Custom': 'Header'}) "
         "proxy_mode='DEFAULT')"
     )

--- a/tests/models/test_headers.py
+++ b/tests/models/test_headers.py
@@ -80,25 +80,25 @@ def test_headers_dict_repr():
     """
     Headers should display with a dict repr by default.
     """
-    headers = httpx.Headers({"custom": "example"})
-    assert repr(headers) == "Headers({'custom': 'example'})"
+    headers = httpx.Headers({"Custom": "example"})
+    assert repr(headers) == "Headers({'Custom': 'example'})"
 
 
 def test_headers_encoding_in_repr():
     """
     Headers should display an encoding in the repr if required.
     """
-    headers = httpx.Headers({b"custom": "example ☃".encode("utf-8")})
-    assert repr(headers) == "Headers({'custom': 'example ☃'}, encoding='utf-8')"
+    headers = httpx.Headers({b"Custom": "example ☃".encode("utf-8")})
+    assert repr(headers) == "Headers({'Custom': 'example ☃'}, encoding='utf-8')"
 
 
 def test_headers_list_repr():
     """
     Headers should display with a list repr if they include multiple identical keys.
     """
-    headers = httpx.Headers([("custom", "example 1"), ("custom", "example 2")])
+    headers = httpx.Headers([("Custom", "example 1"), ("Custom", "example 2")])
     assert (
-        repr(headers) == "Headers([('custom', 'example 1'), ('custom', 'example 2')])"
+        repr(headers) == "Headers([('Custom', 'example 1'), ('Custom', 'example 2')])"
     )
 
 
@@ -108,7 +108,7 @@ def test_headers_decode_ascii():
     """
     raw_headers = [(b"Custom", b"Example")]
     headers = httpx.Headers(raw_headers)
-    assert dict(headers) == {"custom": "Example"}
+    assert dict(headers) == {"Custom": "Example"}
     assert headers.encoding == "ascii"
 
 
@@ -118,7 +118,7 @@ def test_headers_decode_utf_8():
     """
     raw_headers = [(b"Custom", "Code point: ☃".encode("utf-8"))]
     headers = httpx.Headers(raw_headers)
-    assert dict(headers) == {"custom": "Code point: ☃"}
+    assert dict(headers) == {"Custom": "Code point: ☃"}
     assert headers.encoding == "utf-8"
 
 
@@ -128,7 +128,7 @@ def test_headers_decode_iso_8859_1():
     """
     raw_headers = [(b"Custom", "Code point: ÿ".encode("iso-8859-1"))]
     headers = httpx.Headers(raw_headers)
-    assert dict(headers) == {"custom": "Code point: ÿ"}
+    assert dict(headers) == {"Custom": "Code point: ÿ"}
     assert headers.encoding == "iso-8859-1"
 
 
@@ -140,7 +140,7 @@ def test_headers_decode_explicit_encoding():
     raw_headers = [(b"Custom", "Code point: ☃".encode("utf-8"))]
     headers = httpx.Headers(raw_headers)
     headers.encoding = "iso-8859-1"
-    assert dict(headers) == {"custom": "Code point: â\x98\x83"}
+    assert dict(headers) == {"Custom": "Code point: â\x98\x83"}
     assert headers.encoding == "iso-8859-1"
 
 


### PR DESCRIPTION
Refs #538

This pull request would change `Headers` to be a case-preserving but case-insenstive mutli dict.

This would resolve HTTP header casing in the sync case, although not for the async case. (Since `h11` currently lowercase-normalizes headers in both directions)