### PR TITLE
Fix urllib3 proxy instantiation

### DIFF
--- a/httpx/dispatch/urllib3.py
+++ b/httpx/dispatch/urllib3.py
@@ -77,7 +77,7 @@ class URLLib3Dispatcher(SyncDispatcher):
             )
         else:
             return urllib3.ProxyManager(
-                proxy_url=proxy.url,
+                proxy_url=str(proxy.url),
                 proxy_headers=dict(proxy.headers),
                 ssl_context=ssl_context,
                 num_pools=num_pools,


### PR DESCRIPTION
Closes #762

The `urllib3.ProxyManager` instantiation wa broken because it was passing an `httpx.URL()` instance as the `url` argument, instead of the plain string representation.