### PR TITLE
RFC: Retries

### DIFF
--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -2,7 +2,7 @@ from .__version__ import __description__, __title__, __version__
 from .api import delete, get, head, options, patch, post, put, request, stream
 from .auth import Auth, BasicAuth, DigestAuth
 from .client import AsyncClient, Client
-from .config import PoolLimits, Proxy, Timeout
+from .config import PoolLimits, Proxy, Retries, Timeout
 from .dispatch.asgi import ASGIDispatch
 from .dispatch.wsgi import WSGIDispatch
 from .exceptions import (
@@ -53,6 +53,7 @@ __all__ = [
     "DigestAuth",
     "PoolLimits",
     "Proxy",
+    "Retries",
     "Timeout",
     "ConnectTimeout",
     "CookieConflict",

--- a/httpx/backends/asyncio.py
+++ b/httpx/backends/asyncio.py
@@ -225,6 +225,9 @@ class AsyncioBackend(ConcurrencyBackend):
 
         return SocketStream(stream_reader=stream_reader, stream_writer=stream_writer)
 
+    async def sleep(self, delay: float) -> None:
+        await asyncio.sleep(delay)
+
     def time(self) -> float:
         loop = asyncio.get_event_loop()
         return loop.time()

--- a/httpx/backends/auto.py
+++ b/httpx/backends/auto.py
@@ -41,6 +41,9 @@ class AutoBackend(ConcurrencyBackend):
     ) -> BaseSocketStream:
         return await self.backend.open_uds_stream(path, hostname, ssl_context, timeout)
 
+    async def sleep(self, delay: float) -> None:
+        await self.backend.sleep(delay)
+
     def time(self) -> float:
         return self.backend.time()
 

--- a/httpx/backends/base.py
+++ b/httpx/backends/base.py
@@ -111,6 +111,9 @@ class ConcurrencyBackend:
     ) -> BaseSocketStream:
         raise NotImplementedError()  # pragma: no cover
 
+    async def sleep(self, delay: float) -> None:
+        raise NotImplementedError()  # pragma: no cover
+
     def time(self) -> float:
         raise NotImplementedError()  # pragma: no cover
 

--- a/httpx/backends/trio.py
+++ b/httpx/backends/trio.py
@@ -131,6 +131,9 @@ class TrioBackend(ConcurrencyBackend):
 
         raise ConnectTimeout()
 
+    async def sleep(self, delay: float) -> None:
+        await trio.sleep(delay)
+
     def time(self) -> float:
         return trio.current_time()
 

--- a/httpx/exceptions.py
+++ b/httpx/exceptions.py
@@ -17,6 +17,12 @@ class HTTPError(Exception):
         super().__init__(*args)
 
 
+class RetryableError(HTTPError):
+    """
+    Exceptions that represent errors we can retry on by issuing another request.
+    """
+
+
 # Timeout exceptions...
 
 
@@ -26,13 +32,13 @@ class TimeoutException(HTTPError):
     """
 
 
-class ConnectTimeout(TimeoutException):
+class ConnectTimeout(RetryableError, TimeoutException):
     """
     Timeout while establishing a connection.
     """
 
 
-class ReadTimeout(TimeoutException):
+class ReadTimeout(RetryableError, TimeoutException):
     """
     Timeout while reading response data.
     """
@@ -44,13 +50,13 @@ class WriteTimeout(TimeoutException):
     """
 
 
-class PoolTimeout(TimeoutException):
+class PoolTimeout(RetryableError, TimeoutException):
     """
     Timeout while waiting to acquire a connection from the pool.
     """
 
 
-class ProxyError(HTTPError):
+class ProxyError(RetryableError, HTTPError):
     """
     Error from within a proxy
     """
@@ -74,7 +80,7 @@ class DecodingError(HTTPError):
 # Network exceptions...
 
 
-class NetworkError(HTTPError):
+class NetworkError(RetryableError, HTTPError):
     """
     A failure occurred while trying to access the network.
     """

--- a/httpx/models.py
+++ b/httpx/models.py
@@ -73,6 +73,10 @@ HeaderTypes = typing.Union[
 
 CookieTypes = typing.Union["Cookies", CookieJar, typing.Dict[str, str]]
 
+IDEMPOTENT_HTTP_METHODS = frozenset(
+    ("HEAD", "GET", "PUT", "DELETE", "OPTIONS", "PATCH")
+)
+
 
 class URL:
     def __init__(

--- a/rfc/HXEP_0001.md
+++ b/rfc/HXEP_0001.md
@@ -1,0 +1,244 @@
+# HXEP-0001: Retries
+
+Applications talking to servers via HTTP over a network need to be resilient to faults and unexpected errors, such as random network faults, hosts briefly going out of service or temporarily denying requests, etc.
+
+For this reason, HTTPX should probably have retry functionality built-in.
+
+- How much should there be in core?
+- How can we empower users to solve more advanced use cases?
+
+[Minimum viable functionality](#minimum-viable-functionality) presents what I think can be the minimum set of dials we should expose to provide basic but meaningful retry functionality to users.
+
+[A possible extension mechanism](#a-possible-extension-mechanism) explores a set of APIs that could allow us to defer any sufficiently advanced use cases to be implemented by users and third-party packages.
+
+So, let's start with…
+
+## Precedents
+
+Requests provides retries semi-officially via urllib3's `Retry` utility class. They are **off-by-default** in Requests. (But `urllib3` uses `Retry(3)` by default, i.e. retry at most three times.)
+
+Ignoring redirects (we already handle those separately), and based on https://github.com/encode/httpx/issues/108#issuecomment-509702260, there are 8 dials in the `Retry` helper class:
+
+- `respect_retry_after_header`: respecting `Retry-After` headers. Applicable to 413 Payload Too Large, 429 Too Many Requests, and 503 Service Unavailable responses only. Can be turned off.
+- `status_blocklist`: Retrying on specific status codes.
+- `method_whitelist`: retrying on specific HTTP methods only. Defaults to idempotent methods, i.e. GET, HEAD, PUT, DELETE, OPTIONS, TRACE.
+- `total`: limit the total number of errors before giving up.
+- `connect`: limit the number of connection errors before giving up.
+- `read`: limit the number of read errors before giving up.
+- `status`: limit the number of times we receive a response whose status is in `status_blocklist` and method is in `method_whitelist` before giving up.
+- `backoff_factor`: a dial for the exponential backoff algorithm used to exponentially increase the amount of time we wait before issuing a new request.
+
+## What does a retry API involve?
+
+If we take a step back and think about what fundamental questions a retry API should answer, IMO there are two:
+
+1. Given an exception that occurred while trying to receive and response, should we retry and issue a new request?
+2. If so, *when* should we retry, i.e. how far in the future? (i.e. sequence of retry delays)
+
+An important note is that these two questions are completely independant — we can vary the policy for deciding whether to retry independantly from the one deciding how long to wait for before retrying.
+
+## Minimum viable functionality
+
+Based on this model, as a first pass I think we can get a minimum viable retry functionality with **only 1 dial**:
+
+- `limit`: how many retryable `HTTPError` we're allowed to retry on until we give up. This dial is required so that users can turn retries on or off.
+
+This only answers question 1), but I think question 2) can be answered without being customizable, e.g. use an exponential backoff with a reasonable factor, e.g. {0s, 0.2s, 0.4s, 0.8s, ...}.
+
+The API would look like this…
+
+```python
+# Default: don't retry.
+r = httpx.get(url)
+
+# Retry at most 3 times.
+r = httpx.get(url, retries=3)
+client = httpx.Client(retries=3)
+```
+
+Under the hood this will probably end up being governed by a `Retries(limit: int = None)` config class, similar in spirit to `Timeout`. Not obvious that we need it right away as there will only be 1 dial, but will definitely be needed when we start introducing other dials.
+
+We'll also need to define what "retryable" means. Indeed, not all exceptions can be retried on. E.g. we definitely don't want to retry on a usage error (such as `StreamConsumed`), or an error that might imply that the server has already started processing the request (such as `WriteTimeout`). (IMO this can be done by introducing a `RetryableError(HTTPError)` base class and using multiple inheritance to mark exceptions that are retryable. But that's an implementation detail at this point.)
+
+In the end, the client would implement the actual logic for retries as a `.send_handling_retries()` method.
+
+## What we don't need to support right away, but can probably support later
+
+- Respecting `Retry-After` headers. (According to specs, clients *should* respect it, but they don't *have to*.)
+- Customizing the delaying mechanism. (E.g. we can make the backoff factor tweakable.)
+- Customizing the set of methods we can potentially retry on. (Idempotent methods are a good default, but users may need to exclude/include methods for specific use cases.)
+
+At that point the `Retries` constructor could evolve into…
+
+```python
+Retries(
+    limit=3,
+    backoff_factor=0.2,
+    respect_retry_after_headers=True,
+)
+```
+
+… But it might not need to. (See ideas on an extension mechanism below.)
+
+## What we probably don't need to support
+
+These can probably be handled by the extension mechanism described in the next section...
+
+- Fine-grained control of what type of error to retry on (e.g. `connect` vs `read`).
+- Retrying on custom status codes.
+
+## A possible extension mechanism
+
+### Motivation
+
+I think we probably don't want to end up having to increase the number of dials for ever to address a potentially infinite number of weird use cases users might need to address.
+
+So an extension mechanism for retries is probably what we should think about right away. @sethmlarson mentioned in https://github.com/encode/httpx/issues/108#issuecomment-509728486:
+
+> So I definitely want to make the new Retry object have one critical feature that actually makes sub-classing useful: Have a method that is subclassable that passes in the Request and the Response and then by some interface is allowed to decide whether a retry occurs and in addition also allows modifying the Request that will be emitted for that retry.
+
+I don't know if it can be done with just a method, but we can definitely build generator-based sans-I/O APIs to allow users to address advanced scenarios (as we did for auth classes).
+
+### `RetryLimiter` API
+
+An API to answer question 1) ("Should we retry?") might look like this (not sure about the naming):
+
+```python
+class RetryLimiter:
+    def retries(self, request: Request) -> Generator[Request, HTTPError, None]:
+        ...
+```
+
+The default behavior, "retry at most N times", could be implemented as:
+
+```python
+class MaxErrors(RetryLimiter):
+    def __init__(self, max_errors: int):
+        self.max_errors = max_errors
+
+    def retries(self, request: Request) -> Generator[Request, HTTPError, None]:
+        retries_left = self.max_errors
+
+        while True:
+           # Send the request, and get any exception back...
+            exc = yield request
+
+            # Are we out of retries?
+            if not retries_left:
+                return
+
+            # Modify the request if necessary, update any state, and repeat…
+            request.headers["X-Foo"] = "bar"
+            retries_left -= 1
+```
+
+A no-op behavior, i.e. "Never retry", would look like this:
+
+```python
+class DontRetry(RetryLimiter):
+    def retries(self, request: Request) -> Generator[Request, HTTPError, None]:
+        yield request
+```
+
+### `RetrySchedule` API
+
+As for question 2 ("How far in the future should we retry?"), essentially all we need is an unbounded sequence of numbers representing the time to wait between the `N`-th and the `N+1`-th requests. It's probably safe to assume that this time is independant of the request and the response.
+
+So the API might look like this (again, not sure about the naming):
+
+```python
+class RetrySchedule:
+    def delays(self) -> Iterator[float]:
+        ...
+```
+
+The most basic policy would be to wait for a constant time, e.g…
+
+```python
+class WaitFor(RetrySchedule):
+    def __init__(self, seconds: float):
+        self.seconds = seconds
+
+    def delays(self) -> Iterator[float]:
+        while True:
+            yield self.seconds
+```
+
+Exponential backoff could also be implemented in this fashion:
+
+```python
+import itertools
+
+class ExponentialBackoff(RetrySchedule):
+    def __init__(self, backoff: float):
+        self.factor = factor
+
+    def delays(self) -> Iterator[float]:
+        yield 0  # Retry immediately.
+        for n in itertools.count(2):
+            yield backoff_factor * (2 ** (n - 2))
+```
+
+### Impact on the `Retries` config class
+
+Provided these two APIs exist, we could reduce the `Retries` config class down to:
+
+```python
+# This...
+retries = Retries(3)
+
+# Equivalent to...
+retries = Retries(limit=3, backoff_factor=0.2)
+
+# Which is equivalent to...
+retries = Retries(limit=MaxErrors(3), schedule=ExponentialBackoff(factor=0.2))
+
+# At this level, users could pass their own classes...
+retries = Retries(
+    limit=MaxErrorResponses(3, status_codes={502, 503}),
+    schedule=WaitFor(1),
+)
+```
+
+And so `Retries` would evolve into something like this, exposing its own generator-based method for the `Client`/`AsyncClient` to consume...
+
+```python
+import __magic__  # Utilities
+
+from .exceptions 
+RetriesTypes = typing.Union[None, int, ]
+
+class Retries:
+    def __init__(
+        self,
+        retries: RetriesTypes = None,
+        *,
+        limit: typing.Union[typing.Optional[int], RetryLimiter, UnsetType] = UNSET,
+        backoff_factor: typing.Union[float, UnsetType] = UNSET,
+        schedule: typing.Union[RetrySchedule, UnsetType] = UNSET,
+        respect_retry_after_headers: bool = True,
+    ):
+        ...
+
+    def retry_flow(
+        self, request: Request,
+    ) -> Generator[Union[Request, float], HTTPError, None]:
+        ...
+```
+
+### Composing behavior
+
+The last bit of functionality we might want to add to the retries API is composition of limiters, a bit like how the Django REST Framework allows to compose permissions.
+
+This would address the issue of composing different rules or extending the default behavior, without reimplementing a bunch of code. It would allow doing things like:
+
+```python
+retries = Retries(
+    limit=(
+        # At most 5 errors in total, but only up to 3 error responses on these status codes...
+        MaxErrors(3) | MaxErrorResponses(5, status_codes={502, 503})
+    ),
+)
+```
+
+But this is really far-off, we can definitely revisit if/when the use case appears.


### PR DESCRIPTION
Retry functionality has already been discussed in #108, and a first draft was tackled in #134, but later abandoned as HTTPX was still at an early stage back then.

I think we're at a good point to start discussing the design of a potential retry functionality? I also remember @StephenBrown2 mentioned it again in one of the threads when we were preparing the 0.11 release, though I just can't find where that was again…

I submit this as a PR so that we can comment and edit the proposal interactively. Contains:

- A Markdown document describing a minimum retry functionality, and extension APIs. (The RFC look of it is mostly for fun — nothing formal!). You might want to look at the [rendered form](https://github.com/encode/httpx/blob/retries/rfc/HXEP_0001.md).
- Proof-of-concept code (doesn't include an implementation for the extension mechanism, though). You can try it out with this script...

```python
import asyncio
import httpx


async def main() -> None:
    url = "http://localhost:8000"
    retries = httpx.Retries(limit=3, backoff_factor=0.2)
    async with httpx.AsyncClient(retries=retries) as client:
        r = await client.get(url)
        print(r)


if __name__ == "__main__":
    asyncio.run(main())
```

Without even starting a server, trying running the script with:

```bash
$ HTTPX_LOG_LEVEL=debug python example.py
```

You should see output similar to...

```console
DEBUG [2020-01-14 23:49:50] httpx.client - HTTP Request failed - NetworkError(OSError("Multiple exceptions: [Errno 61] Connect call failed ('::1', 8000, 0, 0), [Errno 61] Connect call failed ('127.0.0.1', 8000), [Errno 61] Connect call failed ('fe80::1', 8000, 0, 1)"))
DEBUG [2020-01-14 23:49:50] httpx.client - Retrying in 0 seconds
DEBUG [2020-01-14 23:49:50] httpx.client - HTTP Request failed - NetworkError(OSError("Multiple exceptions: [Errno 61] Connect call failed ('::1', 8000, 0, 0), [Errno 61] Connect call failed ('127.0.0.1', 8000), [Errno 61] Connect call failed ('fe80::1', 8000, 0, 1)"))
DEBUG [2020-01-14 23:49:50] httpx.client - Retrying in 0.2 seconds
DEBUG [2020-01-14 23:49:50] httpx.client - HTTP Request failed - NetworkError(OSError("Multiple exceptions: [Errno 61] Connect call failed ('::1', 8000, 0, 0), [Errno 61] Connect call failed ('127.0.0.1', 8000), [Errno 61] Connect call failed ('fe80::1', 8000, 0, 1)"))
DEBUG [2020-01-14 23:49:50] httpx.client - Retrying in 0.4 seconds
DEBUG [2020-01-14 23:49:50] httpx.client - HTTP Request failed - NetworkError(OSError("Multiple exceptions: [Errno 61] Connect call failed ('::1', 8000, 0, 0), [Errno 61] Connect call failed ('127.0.0.1', 8000), [Errno 61] Connect call failed ('fe80::1', 8000, 0, 1)"))
Traceback (most recent call last):
  File "debug/retries.py", line 45, in <module>
    asyncio.run(main())
  File "/Users/florimond/.pyenv/versions/3.8.0/lib/python3.8/asyncio/runners.py", line 43, in run
    return loop.run_until_complete(main)
  File "/Users/florimond/.pyenv/versions/3.8.0/lib/python3.8/asyncio/base_events.py", line 608, in run_until_complete
    return future.result()
  File "debug/retries.py", line 17, in main
    r = await client.send(request)
  File "/Users/florimond/Developer/python-projects/httpx/httpx/client.py", line 1125, in send
    response = await self.send_handling_retries(
  File "/Users/florimond/Developer/python-projects/httpx/httpx/client.py", line 1171, in send_handling_retries
    raise exc from None
  File "/Users/florimond/Developer/python-projects/httpx/httpx/client.py", line 1156, in send_handling_retries
    return await self.send_handling_redirects(
  File "/Users/florimond/Developer/python-projects/httpx/httpx/client.py", line 1194, in send_handling_redirects
    response = await self.send_handling_auth(
  File "/Users/florimond/Developer/python-projects/httpx/httpx/client.py", line 1230, in send_handling_auth
    response = await self.send_single_request(request, timeout)
  File "/Users/florimond/Developer/python-projects/httpx/httpx/client.py", line 1254, in send_single_request
    response = await dispatcher.send(request, timeout=timeout)
  File "/Users/florimond/Developer/python-projects/httpx/httpx/dispatch/connection_pool.py", line 157, in send
    raise exc
  File "/Users/florimond/Developer/python-projects/httpx/httpx/dispatch/connection_pool.py", line 153, in send
    response = await connection.send(request, timeout=timeout)
  File "/Users/florimond/Developer/python-projects/httpx/httpx/dispatch/connection.py", line 42, in send
    self.connection = await self.connect(timeout=timeout)
  File "/Users/florimond/Developer/python-projects/httpx/httpx/dispatch/connection.py", line 62, in connect
    socket = await self.backend.open_tcp_stream(
  File "/Users/florimond/Developer/python-projects/httpx/httpx/backends/auto.py", line 33, in open_tcp_stream
    return await self.backend.open_tcp_stream(hostname, port, ssl_context, timeout)
  File "/Users/florimond/Developer/python-projects/httpx/httpx/backends/asyncio.py", line 197, in open_tcp_stream
    stream_reader, stream_writer = await asyncio.wait_for(  # type: ignore
  File "/Users/florimond/.pyenv/versions/3.8.0/lib/python3.8/contextlib.py", line 131, in __exit__
    self.gen.throw(type, value, traceback)
  File "/Users/florimond/Developer/python-projects/httpx/httpx/utils.py", line 368, in as_network_error
    raise NetworkError(exc) from exc
httpx.exceptions.NetworkError: Multiple exceptions: [Errno 61] Connect call failed ('::1', 8000, 0, 0), [Errno 61] Connect call failed ('127.0.0.1', 8000), [Errno 61] Connect call failed ('fe80::1', 8000, 0, 1)
```

Happy to discuss!