### PR TITLE
Fix for streaming a redirect response body with allow_redirects=False

### DIFF
--- a/httpx/client.py
+++ b/httpx/client.py
@@ -622,7 +622,8 @@ class Client(BaseClient):
             if not response.is_redirect:
                 return response
 
-            response.read()
+            if allow_redirects:
+                response.read()
             request = self.build_redirect_request(request, response)
             history = history + [response]
 
@@ -1146,7 +1147,8 @@ class AsyncClient(BaseClient):
             if not response.is_redirect:
                 return response
 
-            await response.aread()
+            if allow_redirects:
+                await response.aread()
             request = self.build_redirect_request(request, response)
             history = history + [response]
 


### PR DESCRIPTION
When making a request with `.stream(... allow_redirects=False)` any redirect response that is returned should be streamable, and not have already been read.

```python
>>> import httpx
>>> with httpx.stream("GET", "https://daringfireball.net/css/ie_sucks.php", allow_redirects=False) as response:
...     body = b''.join([chunk for chunk in response.iter_raw()])
... 
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "<stdin>", line 2, in <listcomp>
  File "/Users/tomchristie/Temp/venv/lib/python3.7/site-packages/httpx/models.py", line 939, in iter_raw
    raise StreamConsumed()
httpx.exceptions.StreamConsumed
```

