### PR TITLE
Version 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 * Fixed usage of `proxies=...` on `Client()`. (Pull #763)
-* Support both `zlib` and `deflate` style encodings on `Content-Encoding: deflate`. (Pull #763)
+* Support both `zlib` and `deflate` style encodings on `Content-Encoding: deflate`. (Pull #758)
 * Fix for streaming a redirect response body with `allow_redirects=False`. (Pull #766)
 * Handle redirect with malformed Location headers missing host. (Pull #774)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.11.1 (January 17th, 2020)
+
+### Fixed
+
+* Fixed usage of `proxies=...` on `Client()`. (Pull #763)
+* Support both `zlib` and `deflate` style encodings on `Content-Encoding: deflate`. (Pull #763)
+* Fix for streaming a redirect response body with `allow_redirects=False`. (Pull #766)
+
 ## 0.11.0 (January 9th, 2020)
 
 The 0.11 release reintroduces our sync support, so that `httpx` now supports both a standard thread-concurrency API, and an async API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Fixed usage of `proxies=...` on `Client()`. (Pull #763)
 * Support both `zlib` and `deflate` style encodings on `Content-Encoding: deflate`. (Pull #763)
 * Fix for streaming a redirect response body with `allow_redirects=False`. (Pull #766)
+* Handle redirect with malformed Location headers missing host. (Pull #774)
 
 ## 0.11.0 (January 9th, 2020)
 

--- a/httpx/__version__.py
+++ b/httpx/__version__.py
@@ -1,3 +1,3 @@
 __title__ = "httpx"
 __description__ = "A next generation HTTP client, for Python 3."
-__version__ = "0.11.0"
+__version__ = "0.11.1"


### PR DESCRIPTION
## 0.11.1 (January 17th, 2020)

### Fixed

* Fixed usage of `proxies=...` on `Client()`. (Pull #763)
* Support both `zlib` and `deflate` style encodings on `Content-Encoding: deflate`. (Pull #758)
* Fix for streaming a redirect response body with `allow_redirects=False`. (Pull #766)
* Handle redirect with malformed Location headers missing host. (Pull #774)