### PR TITLE
Add retries

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -475,50 +475,81 @@ The default behavior is to retry at most 3 times on connection and network error
 
 ### Setting and disabling retries
 
-You can set retries for an individual request:
+You can set the retry behavior on a client instance, which results in the given behavior being used for all requests made with this client:
 
 ```python
-# Using the top-level API:
-httpx.get('https://www.example.org', retries=5)
-
-# Using a client instance:
-with httpx.Client() as client:
-    client.get("https://www.example.org", retries=5)
-```
-
-Or disable retries for an individual request:
-
-```python
-# Using the top-level API:
-httpx.get('https://www.example.org', retries=None)
-
-# Using a client instance:
-with httpx.Client() as client:
-    client.get("https://www.example.org", retries=None)
-```
-
-### Setting default retries on the client
-
-You can set the retry behavior on a client instance, which results in the given behavior being used as the default for requests made with this client:
-
-```python
-client = httpx.Client()              # Default behavior: retry at most 3 times.
-client = httpx.Client(retries=5)     # Retry at most 5 times.
-client = httpx.Client(retries=None)  # Disable retries by default.
+client = httpx.Client()           # Retry at most 3 times on connection failures.
+client = httpx.Client(retries=5)  # Retry at most 5 times on connection failures.
+client = httpx.Client(retries=0)  # Disable retries.
 ```
 
 ### Fine-tuning the retries configuration
 
-The `retries` argument also accepts an instance of `httpx.Retries()`, in case you need more fine-grained control over the retries behavior. It accepts the following parameters:
+When instantiating a client, the `retries` argument may be one of the following...
 
-- `limit`: the maximum number of retryable errors to retry on.
-- `backoff_factor`: a number representing how fast to increase the retry delay. For example, a value of `0.2` (the default) corresponds to this sequence of delays: `(0s, 0.2s, 0.4s, 0.8s, 1.6s, ...)`.
+* An integer, representing the maximum number connection failures to retry on. Use `0` to disable retries entirely.
+
+```python
+client = httpx.Client(retries=5)
+```
+
+* An `httpx.Retries()` instance. It accepts the number of connection failures to retry on as a positional argument. The `backoff_factor` keyword argument that specifies how fast the time to wait before issuing a retry request should be increased. By default this is `0.2`, which corresponds to issuing a new request after `(0s, 0.2s, 0.4s, 0.8s, ...)`. (Note that a lot of errors are immediately resolved after retrying, so HTTPX will always issue the initial retry right away.)
+
+```python
+# Retry at most 5 times on connection failures,
+# and issue new requests after `(0s, 0.5s, 1s, 2s, 4s, ...)`
+retries = httpx.Retries(5, backoff_factor=0.5)
+client = httpx.Client(retries=retries)
+```
+
+### Advanced retries customization
+
+The first argument to `httpx.Retries()` can also be a subclass of `httpx.RetryLimits`. This is useful if you want to replace or extend the default behavior of retrying on connection failures.
+
+The `httpx.RetryLimits` subclass should implement the `.retry_flow()` method, `yield` any request to be made, and prepare for the following situations...
+
+* (A) The request resulted in an `httpx.HTTPError`. If it shouldn't be retried on, `raise` the error as-is. If it should be retried on, you should make any necessary modifications to the request, and continue yielding. If you've exceeded a maximum number of retries, wrap the error in `httpx.TooManyRetries()`, and raise the result.
+* (B) The request went through and resulted in the client sending back a `response`. If it shouldn't be retried on, `return` to terminate the retry flow. If it should be retried on (e.g. because it is an error response), you should make any necessary modifications to the request, and continue yielding. If you've exceeded a maximum number of retries, wrap the response in `httpx.TooManyRetries()`, and raise the result.
+
+As an example, here's how you could implement a custom retry limiting policy that retries on certain status codes:
 
 ```python
 import httpx
 
-# Retry at most 5 times, and space out retries further away
-# in time than the default (0s, 1s, 2s, 4s, ...).
-retries = httpx.Retries(limit=5, backoff_factor=1.0)
-response = httpx.get('https://www.example.com', retries=retries)
+class RetryOnStatusCodes(httpx.RetryLimits):
+    def __init__(self, limit, status_codes):
+        self.limit = limit
+        self.status_codes = status_codes
+
+    def retry_flow(self, request):
+        retries_left = self.limit
+
+        while True:
+            response = yield request
+
+            if response.status_code not in self.status_codes:
+                return
+
+            if retries_left == 0:
+                try:
+                    response.raise_for_status()
+                except httpx.HTTPError as exc:
+                    raise httpx.TooManyRetries(exc, response=response)
+                else:
+                    raise httpx.TooManyRetries(response=response)
+
+            retries_left -= 1
+```
+
+To use a custom policy:
+
+* Explicitly pass the number of times to retry on connection failures as a first positional argument to `httpx.Retries()`. (Use `0` to not retry on these failures.)
+* Pass the custom policy as a second positional argument.
+
+For example...
+
+```python
+# Retry at most 3 times on connection failures, and at most three times
+# on '429 Too Many Requests', '502 Bad Gateway', or '503 Service Unavailable'.
+retries = httpx.Retries(3, RetryOnStatusCodes(3, status_codes={429, 502, 503}))
 ```

--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -2,7 +2,7 @@ from .__version__ import __description__, __title__, __version__
 from .api import delete, get, head, options, patch, post, put, request, stream
 from .auth import Auth, BasicAuth, DigestAuth
 from .client import AsyncClient, Client
-from .config import PoolLimits, Proxy, Timeout
+from .config import PoolLimits, Proxy, Retries, Timeout
 from .dispatch.asgi import ASGIDispatch
 from .dispatch.wsgi import WSGIDispatch
 from .exceptions import (
@@ -25,9 +25,11 @@ from .exceptions import (
     StreamConsumed,
     TimeoutException,
     TooManyRedirects,
+    TooManyRetries,
     WriteTimeout,
 )
 from .models import URL, Cookies, Headers, QueryParams, Request, Response
+from .retries import RetryLimits, RetryOnConnectionFailures
 from .status_codes import StatusCode, codes
 
 __all__ = [
@@ -54,6 +56,10 @@ __all__ = [
     "PoolLimits",
     "Proxy",
     "Timeout",
+    "Retries",
+    "RetryLimits",
+    "RetryOnConnectionFailures",
+    "TooManyRetries",
     "ConnectTimeout",
     "CookieConflict",
     "ConnectionClosed",

--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -29,7 +29,7 @@ from .exceptions import (
     WriteTimeout,
 )
 from .models import URL, Cookies, Headers, QueryParams, Request, Response
-from .retries import RetryLimits, RetryOnConnectionFailures
+from .retries import RetryLimits
 from .status_codes import StatusCode, codes
 
 __all__ = [
@@ -58,7 +58,6 @@ __all__ = [
     "Timeout",
     "Retries",
     "RetryLimits",
-    "RetryOnConnectionFailures",
     "TooManyRetries",
     "ConnectTimeout",
     "CookieConflict",

--- a/httpx/backends/asyncio.py
+++ b/httpx/backends/asyncio.py
@@ -225,6 +225,9 @@ class AsyncioBackend(ConcurrencyBackend):
 
         return SocketStream(stream_reader=stream_reader, stream_writer=stream_writer)
 
+    async def sleep(self, seconds: float) -> None:
+        await asyncio.sleep(seconds)
+
     def time(self) -> float:
         loop = asyncio.get_event_loop()
         return loop.time()

--- a/httpx/backends/auto.py
+++ b/httpx/backends/auto.py
@@ -41,6 +41,9 @@ class AutoBackend(ConcurrencyBackend):
     ) -> BaseSocketStream:
         return await self.backend.open_uds_stream(path, hostname, ssl_context, timeout)
 
+    async def sleep(self, seconds: float) -> None:
+        await self.backend.sleep(seconds)
+
     def time(self) -> float:
         return self.backend.time()
 

--- a/httpx/backends/base.py
+++ b/httpx/backends/base.py
@@ -111,6 +111,9 @@ class ConcurrencyBackend:
     ) -> BaseSocketStream:
         raise NotImplementedError()  # pragma: no cover
 
+    async def sleep(self, seconds: float) -> None:
+        raise NotImplementedError()  # pragma: no cover
+
     def time(self) -> float:
         raise NotImplementedError()  # pragma: no cover
 

--- a/httpx/backends/trio.py
+++ b/httpx/backends/trio.py
@@ -131,6 +131,9 @@ class TrioBackend(ConcurrencyBackend):
 
         raise ConnectTimeout()
 
+    async def sleep(self, seconds: float) -> None:
+        await trio.sleep(seconds)
+
     def time(self) -> float:
         return trio.current_time()
 

--- a/httpx/config.py
+++ b/httpx/config.py
@@ -348,11 +348,7 @@ class Retries:
     backoff algorithm.
     """
 
-    def __init__(
-        self,
-        *retries: RetriesTypes,
-        backoff_factor: float = None,
-    ) -> None:
+    def __init__(self, *retries: RetriesTypes, backoff_factor: float = None) -> None:
         limits: RetriesTypes
 
         if len(retries) == 0:

--- a/httpx/exceptions.py
+++ b/httpx/exceptions.py
@@ -113,6 +113,15 @@ class NotRedirectResponse(RedirectError):
     """
 
 
+# Retries...
+
+
+class TooManyRetries(HTTPError):
+    """
+    The maximum number of retries allowed for a request was exceeded.
+    """
+
+
 # Stream exceptions...
 
 

--- a/httpx/retries.py
+++ b/httpx/retries.py
@@ -1,0 +1,191 @@
+import typing
+
+from .exceptions import (
+    ConnectTimeout,
+    HTTPError,
+    NetworkError,
+    PoolTimeout,
+    TooManyRetries,
+)
+from .models import Request, Response
+from .utils import get_logger
+
+logger = get_logger(__name__)
+
+
+class RetryLimits:
+    """
+    Base class for retry limiting policies.
+    """
+
+    def retry_flow(self, request: Request) -> typing.Generator[Request, Response, None]:
+        """
+        Execute the retry flow.
+
+        To dispatch a request, you should `yield` it, and prepare for the following
+        situations:
+
+        * The request resulted in an `httpx.HTTPError`. If it should be retried on,
+        you should make any necessary modifications to the request, and continue
+        yielding. If you've exceeded the maximum number of retries, wrap the error
+        in `httpx.TooManyRetries()` and raise the result. If it shouldn't be retried
+        on, re-`raise` the error as-is.
+        * The request went through and resulted in the client sending back a `response`.
+        If it should be retried on (e.g. because it is an error response), you
+        should make any necessary modifications to the request, and continue yielding.
+        Otherwise, `return` to terminate the retry flow.
+
+        Note that modifying the request may cause downstream mechanisms that rely
+        on request signing to fail. For example, this could be the case of
+        certain authentication schemes.
+
+        A typical pseudo-code implementation based on a while-loop and try/except
+        blocks may look like this...
+
+        ```python
+        while True:
+            try:
+                response = yield request
+            except httpx.HTTPError as exc:
+                if not has_retries_left():
+                    raise TooManyRetries(exc)
+                if should_retry_on_exception(exc):
+                    increment_retries_left()
+                    # (Optionally modify the request here.)
+                    continue
+                else:
+                    raise
+            else:
+                if should_retry_on_response(response):
+                    # (Optionally modify the request here.)
+                    continue
+                return
+        ```
+        """
+        raise NotImplementedError
+
+    def __or__(self, other: typing.Any) -> "RetryLimits":
+        if not isinstance(other, RetryLimits):
+            raise NotImplementedError
+        return _OrRetries(self, other)
+
+
+class _OrRetries(RetryLimits):
+    """
+    Helper for composing retry limits.
+    """
+
+    def __init__(self, left: RetryLimits, right: RetryLimits) -> None:
+        self.left = left
+        self.right = right
+
+    def retry_flow(self, request: Request) -> typing.Generator[Request, Response, None]:
+        left_flow = self.left.retry_flow(request)
+        right_flow = self.right.retry_flow(request)
+
+        request = next(left_flow)
+        request = next(right_flow)
+
+        while True:
+            try:
+                response = yield request
+            except HTTPError as exc:
+                try:
+                    request = left_flow.throw(type(exc), exc, exc.__traceback__)
+                except TooManyRetries:
+                    raise
+                except HTTPError:
+                    try:
+                        request = right_flow.throw(type(exc), exc, exc.__traceback__)
+                    except TooManyRetries:
+                        raise
+                    except HTTPError:
+                        raise
+                    else:
+                        continue
+                else:
+                    continue
+            else:
+                try:
+                    request = left_flow.send(response)
+                except TooManyRetries:
+                    raise
+                except StopIteration:
+                    try:
+                        request = right_flow.send(response)
+                    except TooManyRetries:
+                        raise
+                    except StopIteration:
+                        return
+                    else:
+                        continue
+                else:
+                    continue
+
+
+class DontRetry(RetryLimits):
+    def retry_flow(self, request: Request) -> typing.Generator[Request, Response, None]:
+        # Send the initial request, and never retry.
+        # Don't raise a `TooManyRetries` exception because this should really be
+        # a no-op implementation.
+        yield request
+
+
+class RetryOnConnectionFailures(RetryLimits):
+    """
+    Retry when failing to establish a connection, or when a network
+    error occurred.
+    """
+
+    _RETRYABLE_EXCEPTIONS: typing.Sequence[typing.Type[HTTPError]] = (
+        ConnectTimeout,
+        PoolTimeout,
+        NetworkError,
+    )
+    _RETRYABLE_METHODS: typing.Container[str] = frozenset(
+        ("HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE")
+    )
+
+    def __init__(self, limit: int = 3) -> None:
+        assert limit >= 0
+        self.limit = limit
+
+    def _should_retry_on_exception(self, exc: HTTPError) -> bool:
+        for exc_cls in self._RETRYABLE_EXCEPTIONS:
+            if isinstance(exc, exc_cls):
+                break
+        else:
+            logger.debug(f"not_retryable exc_type={type(exc)}")
+            return False
+
+        assert exc.request is not None
+        method = exc.request.method.upper()
+        if method not in self._RETRYABLE_METHODS:
+            logger.debug(f"not_retryable method={method!r}")
+            return False
+
+        return True
+
+    def retry_flow(self, request: Request) -> typing.Generator[Request, Response, None]:
+        retries_left = self.limit
+
+        while True:
+            try:
+                _ = yield request
+            except HTTPError as exc:
+                # Failed to get a response...
+
+                if not retries_left:
+                    raise TooManyRetries(exc, request=request)
+
+                if self._should_retry_on_exception(exc):
+                    retries_left -= 1
+                    continue
+
+                # Raise the exception for other retry limits involved to handle,
+                # or for bubbling up to the client.
+                raise
+            else:
+                # We managed to get a response without connection/network
+                # failures, so we're done here.
+                return

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -26,7 +26,7 @@ async def test_write_timeout(server):
 async def test_connect_timeout(server):
     timeout = httpx.Timeout(connect_timeout=1e-6)
 
-    async with httpx.AsyncClient(timeout=timeout) as client:
+    async with httpx.AsyncClient(timeout=timeout, retries=0) as client:
         with pytest.raises(httpx.ConnectTimeout):
             # See https://stackoverflow.com/questions/100841/
             await client.get("http://10.255.255.1/")
@@ -37,7 +37,9 @@ async def test_pool_timeout(server):
     pool_limits = httpx.PoolLimits(hard_limit=1)
     timeout = httpx.Timeout(pool_timeout=1e-4)
 
-    async with httpx.AsyncClient(pool_limits=pool_limits, timeout=timeout) as client:
+    async with httpx.AsyncClient(
+        pool_limits=pool_limits, timeout=timeout, retries=0
+    ) as client:
         async with client.stream("GET", server.url):
             with pytest.raises(httpx.PoolTimeout):
                 await client.get("http://localhost:8000/")


### PR DESCRIPTION
I slept some more on #765, and I think I've come up with something quite nice.

Main changes compared to #765:

- We always use an exponential backoff, so no more `Schedule` API. Just a `backoff_factor` know on the retries config class.
- The default behavior is to retry on connection failures. No more `RetryableError` base class — which of our exceptions are retryable is hard-coded in the default behavior.
- Being able to override `.retry_flow()` isn't really useful *in itself*, because *extending a retry flow* (even by copy-pasting our code) *really isn't easy*, due to many generator gotchas to watch for. So this PR implements *some* extension capability, mainly via the `RetryLimits` interface and being able to pass . I guess **in an incremental approach we could restrict this PR** to `retries=<int>` and `retries=Retries(<int>[, backoff_factor=<float>])`, and move the extension mechanism to a separate/future PR. I'm putting everything in here first to get some more feedback on the direction.

Things still to do:

- Per-request `retries`.
- Sync `retries`.
- Add tests. (This won't be easy, as there are *many* code paths to account for! Hence probably the motivation for splitting this in two steps...)

Notes to reviewers:

- Read the new docs for an overview of the functionality.
- Use this script to try things out... Usage:
  - `HTTPX_LOG_LEVEL=debug python example.py` *without starting the server*, to try the behavior on connection failures.
  - Start the dummy server: `uvicorn example:app`
  - Re-run the script, to try the custom behavior implemented by `RetryOnStatusCodes`.
  - While retries are ongoing, you can turn off the server, and see that it switches to retrying on connection failures again. If you get the server back up, it will retry on status codes, etc. This continues until either policy runs out of retries. Which I think is quite nice/resilient. :-)

```python
import asyncio
import typing

import httpx
from starlette.responses import PlainTextResponse


class RetryOnStatusCodes(httpx.RetryLimits):
    def __init__(self, limit: int, status_codes: typing.Container[int]) -> None:
        self.limit = limit
        self.status_codes = status_codes

    def retry_flow(
        self, request: httpx.Request
    ) -> typing.Generator[httpx.Request, httpx.Response, None]:
        retries_left = self.limit

        while True:
            response = yield request

            if response.status_code not in self.status_codes:
                return

            if retries_left == 0:
                try:
                    response.raise_for_status()
                except httpx.HTTPError as exc:
                    raise httpx.TooManyRetries(exc, response=response)
                else:
                    raise httpx.TooManyRetries(response=response)

            retries_left -= 1


async def main() -> None:
    url = "http://localhost:8000"
    retries = httpx.Retries(
        4, RetryOnStatusCodes(limit=4, status_codes={413, 429, 503}), backoff_factor=1,
    )
    async with httpx.AsyncClient(retries=retries) as client:
        r = await client.get(url)
        print(r)


async def app(scope, receive, send):
    response = PlainTextResponse(status_code=503)
    await response(scope, receive, send)


if __name__ == "__main__":
    asyncio.run(main())
```