### PR TITLE
Detect credentials in proxy URLs and create Proxy-authorization header

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -176,7 +176,7 @@ client = httpx.Client(trust_env=False)
 
 ## HTTP Proxying
 
-HTTPX supports setting up proxies the same way that Requests does via the `proxies` parameter.
+HTTPX supports setting up HTTP proxies the same way that Requests does via the `proxies` parameter.
 For example to forward all HTTP traffic to `http://127.0.0.1:3080` and all HTTPS traffic
 to `http://127.0.0.1:3081` your `proxies` config would look like this:
 
@@ -188,6 +188,9 @@ to `http://127.0.0.1:3081` your `proxies` config would look like this:
 >>> with httpx.Client(proxies=proxies) as client:
 ...     ...
 ```
+
+Credentials may be passed in as part of the URL in the standard way, i.e.
+`http://username:password@127.0.0.1:3080`.
 
 Proxies can be configured for a specific scheme and host, all schemes of a host,
 all hosts for a scheme, or for all requests. When determining which proxy configuration
@@ -233,6 +236,8 @@ with httpx.Client(proxies=proxy) as client:
 
     To use proxies you must pass the proxy information at `Client` initialization,
     rather than on the `.get(...)` call or other request methods.
+
+SOCKS proxies are *not* supported yet.
 
 ## Timeout Configuration
 

--- a/httpx/config.py
+++ b/httpx/config.py
@@ -333,8 +333,7 @@ class Proxy:
             )
             # Remove userinfo from the URL authority, e.g.:
             # 'username:password@proxy_host:proxy_port' -> 'proxy_host:proxy_port'
-            credentials, _, authority = url.authority.rpartition("@")
-            url = url.copy_with(authority=authority)
+            url = url.copy_with(username=None, password=None)
 
         self.url = url
         self.headers = headers

--- a/httpx/config.py
+++ b/httpx/config.py
@@ -1,6 +1,7 @@
 import os
 import ssl
 import typing
+from base64 import b64encode
 from pathlib import Path
 
 import certifi
@@ -325,9 +326,24 @@ class Proxy:
         if mode not in ("DEFAULT", "CONNECT_ONLY", "TUNNEL_ONLY"):
             raise ValueError(f"Unknown proxy mode {mode!r}")
 
+        if url.username or url.password:
+            headers.setdefault(
+                "Proxy-Authorization",
+                self.build_auth_header(url.username, url.password),
+            )
+            # Remove userinfo from the URL authority, e.g.:
+            # 'username:password@proxy_host:proxy_port' -> 'proxy_host:proxy_port'
+            credentials, _, authority = url.authority.rpartition("@")
+            url = url.copy_with(authority=authority)
+
         self.url = url
         self.headers = headers
         self.mode = mode
+
+    def build_auth_header(self, username: str, password: str) -> str:
+        userpass = (username.encode("utf-8"), password.encode("utf-8"))
+        token = b64encode(b":".join(userpass)).decode().strip()
+        return f"Basic {token}"
 
     def __repr__(self) -> str:
         return (

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -214,7 +214,7 @@ def test_ssl_config_support_for_keylog_file(tmpdir, monkeypatch):  # pragma: noc
         ("https://example.com", "https://example.com", {}, "DEFAULT"),
         (
             "https://user:pass@example.com",
-            "https://example.com",
+            "https://example.com:443",
             {"proxy-authorization": "Basic dXNlcjpwYXNz"},
             "DEFAULT",
         ),
@@ -223,7 +223,7 @@ def test_ssl_config_support_for_keylog_file(tmpdir, monkeypatch):  # pragma: noc
 def test_proxy_from_url(url, expected_url, expected_headers, expected_mode):
     proxy = httpx.Proxy(url)
 
-    assert proxy.url == expected_url
+    assert str(proxy.url) == expected_url
     assert dict(proxy.headers) == expected_headers
     assert proxy.mode == expected_mode
     assert repr(proxy) == "Proxy(url='{}', headers={}, mode='{}')".format(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -208,9 +208,27 @@ def test_ssl_config_support_for_keylog_file(tmpdir, monkeypatch):  # pragma: noc
         assert ssl_config.ssl_context.keylog_filename is None
 
 
-def test_proxy_from_url():
-    proxy = httpx.Proxy("https://example.com")
-    assert repr(proxy) == "Proxy(url='https://example.com', headers={}, mode='DEFAULT')"
+@pytest.mark.parametrize(
+    "url,expected_url,expected_headers,expected_mode",
+    [
+        ("https://example.com", "https://example.com", {}, "DEFAULT"),
+        (
+            "https://user:pass@example.com",
+            "https://example.com",
+            {"proxy-authorization": "Basic dXNlcjpwYXNz"},
+            "DEFAULT",
+        ),
+    ],
+)
+def test_proxy_from_url(url, expected_url, expected_headers, expected_mode):
+    proxy = httpx.Proxy(url)
+
+    assert proxy.url == expected_url
+    assert dict(proxy.headers) == expected_headers
+    assert proxy.mode == expected_mode
+    assert repr(proxy) == "Proxy(url='{}', headers={}, mode='{}')".format(
+        expected_url, str(expected_headers), expected_mode
+    )
 
 
 def test_invalid_proxy_scheme():


### PR DESCRIPTION
Fixes https://github.com/encode/httpx/issues/779

Use the [same logic from `proxy_http`](https://github.com/encode/httpx/blob/master/httpx/dispatch/proxy_http.py#L83-L96) in the `Proxy` config, e.g. detects if credentials are present in the proxy URL and adds the authorization header accordingly. Also remove the credentials for the URL.