### PR TITLE
Reorganize __init__ modules

### DIFF
--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -1,86 +1,15 @@
-from .__version__ import __description__, __title__, __version__
-from ._api import delete, get, head, options, patch, post, put, request, stream
-from ._auth import Auth, BasicAuth, DigestAuth
-from ._client import AsyncClient, Client
-from ._config import PoolLimits, Proxy, Timeout
-from ._dispatch.asgi import ASGIDispatch
-from ._dispatch.wsgi import WSGIDispatch
-from ._exceptions import (
-    ConnectionClosed,
-    ConnectTimeout,
-    CookieConflict,
-    DecodingError,
-    HTTPError,
-    InvalidURL,
-    NotRedirectResponse,
-    PoolTimeout,
-    ProtocolError,
-    ProxyError,
-    ReadTimeout,
-    RedirectLoop,
-    RequestBodyUnavailable,
-    RequestNotRead,
-    ResponseClosed,
-    ResponseNotRead,
-    StreamConsumed,
-    TimeoutException,
-    TooManyRedirects,
-    WriteTimeout,
-)
-from ._models import URL, Cookies, Headers, QueryParams, Request, Response
-from ._status_codes import StatusCode, codes
+# NOTE: The modules imported here and the elements declared there via '__all__'
+# define the public API of HTTPX.
+# Users are expected to 'import httpx', and then access elements from that top-level
+# namespace.
+# Anything else than what is exposed here is private API.
 
-__all__ = [
-    "__description__",
-    "__title__",
-    "__version__",
-    "delete",
-    "get",
-    "head",
-    "options",
-    "patch",
-    "post",
-    "patch",
-    "put",
-    "request",
-    "stream",
-    "codes",
-    "ASGIDispatch",
-    "AsyncClient",
-    "Auth",
-    "BasicAuth",
-    "Client",
-    "DigestAuth",
-    "PoolLimits",
-    "Proxy",
-    "Timeout",
-    "ConnectTimeout",
-    "CookieConflict",
-    "ConnectionClosed",
-    "DecodingError",
-    "HTTPError",
-    "InvalidURL",
-    "NotRedirectResponse",
-    "PoolTimeout",
-    "ProtocolError",
-    "ReadTimeout",
-    "RedirectLoop",
-    "RequestBodyUnavailable",
-    "ResponseClosed",
-    "ResponseNotRead",
-    "RequestNotRead",
-    "StreamConsumed",
-    "ProxyError",
-    "TooManyRedirects",
-    "WriteTimeout",
-    "URL",
-    "StatusCode",
-    "Cookies",
-    "Headers",
-    "QueryParams",
-    "Request",
-    "TimeoutException",
-    "Response",
-    "DigestAuth",
-    "WSGIDispatch",
-]
+from .__version__ import *  # noqa: F401, F403
+from ._api import *  # noqa: F401, F403
+from ._auth import *  # noqa: F401, F403
+from ._client import *  # noqa: F401, F403
+from ._config import *  # noqa: F401, F403
+from ._dispatch import *  # noqa: F401, F403
+from ._exceptions import *  # noqa: F401, F403
+from ._models import *  # noqa: F401, F403
+from ._status_codes import *  # noqa: F401, F403

--- a/httpx/__version__.py
+++ b/httpx/__version__.py
@@ -1,3 +1,5 @@
 __title__ = "httpx"
 __description__ = "A next generation HTTP client, for Python 3."
 __version__ = "0.11.1"
+
+__all__ = ["__description__", "__title__", "__version__"]

--- a/httpx/_api.py
+++ b/httpx/_api.py
@@ -14,6 +14,18 @@ from ._models import (
     URLTypes,
 )
 
+__all__ = [
+    "delete",
+    "get",
+    "head",
+    "options",
+    "patch",
+    "post",
+    "put",
+    "request",
+    "stream",
+]
+
 
 def request(
     method: str,

--- a/httpx/_auth.py
+++ b/httpx/_auth.py
@@ -10,6 +10,12 @@ from ._exceptions import ProtocolError, RequestBodyUnavailable
 from ._models import Request, Response
 from ._utils import to_bytes, to_str, unquote
 
+__all__ = [
+    "Auth",
+    "BasicAuth",
+    "DigestAuth",
+]
+
 AuthTypes = typing.Union[
     typing.Tuple[typing.Union[str, bytes], typing.Union[str, bytes]],
     typing.Callable[["Request"], "Request"],

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -52,6 +52,8 @@ from ._models import (
 from ._status_codes import codes
 from ._utils import NetRCInfo, get_environment_proxies, get_logger
 
+__all__ = ["AsyncClient", "Client"]
+
 logger = get_logger(__name__)
 
 

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -9,6 +9,8 @@ import certifi
 from ._models import URL, Headers, HeaderTypes, URLTypes
 from ._utils import get_ca_bundle_from_env, get_logger
 
+__all__ = ["PoolLimits", "Proxy", "Timeout"]
+
 CertTypes = typing.Union[str, typing.Tuple[str, str], typing.Tuple[str, str, str]]
 VerifyTypes = typing.Union[str, bool, ssl.SSLContext]
 TimeoutTypes = typing.Union[

--- a/httpx/_dispatch/__init__.py
+++ b/httpx/_dispatch/__init__.py
@@ -1,0 +1,4 @@
+from .asgi import ASGIDispatch
+from .wsgi import WSGIDispatch
+
+__all__ = ["ASGIDispatch", "WSGIDispatch"]

--- a/httpx/_exceptions.py
+++ b/httpx/_exceptions.py
@@ -3,6 +3,29 @@ import typing
 if typing.TYPE_CHECKING:
     from ._models import Request, Response  # pragma: nocover
 
+__all__ = [
+    "ConnectTimeout",
+    "ConnectionClosed",
+    "CookieConflict",
+    "DecodingError",
+    "HTTPError",
+    "InvalidURL",
+    "NotRedirectResponse",
+    "PoolTimeout",
+    "ProtocolError",
+    "ProxyError",
+    "ReadTimeout",
+    "RedirectLoop",
+    "RequestBodyUnavailable",
+    "RequestNotRead",
+    "ResponseClosed",
+    "ResponseNotRead",
+    "StreamConsumed",
+    "TimeoutException",
+    "TooManyRedirects",
+    "WriteTimeout",
+]
+
 
 class HTTPError(Exception):
     """

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -54,6 +54,8 @@ from ._utils import (
 if typing.TYPE_CHECKING:  # pragma: no cover
     from ._dispatch.base import AsyncDispatcher  # noqa: F401
 
+__all__ = ["URL", "Cookies", "Headers", "QueryParams", "Request", "Response"]
+
 PrimitiveData = typing.Optional[typing.Union[str, int, float, bool]]
 
 URLTypes = typing.Union["URL", str]

--- a/httpx/_status_codes.py
+++ b/httpx/_status_codes.py
@@ -1,5 +1,7 @@
 from enum import IntEnum
 
+__all__ = ["StatusCode", "codes"]
+
 
 class StatusCode(IntEnum):
     """HTTP status codes and reason phrases


### PR DESCRIPTION
Builds on #785 (which is currently the base here for the sake of review).

This PR moves the declarations from the top-level `__init__.py` to `__all__` variables in each module that contains public API elements.

I figured the consistency of adding an `__all__` everywhere (even though we only expose a small selection of elements) was nicer than mixing `from _foo import *`/`from _bar import A, B, C` in the top-level `__init__.py`. :-)