### PR TITLE
Fix `httpx.Proxy(..., mode="FORWARD_ONLY")` configuration.

### DIFF
--- a/httpx/config.py
+++ b/httpx/config.py
@@ -323,7 +323,7 @@ class Proxy:
 
         if url.scheme not in ("http", "https"):
             raise ValueError(f"Unknown scheme for proxy URL {url!r}")
-        if mode not in ("DEFAULT", "CONNECT_ONLY", "TUNNEL_ONLY"):
+        if mode not in ("DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY"):
             raise ValueError(f"Unknown proxy mode {mode!r}")
 
         if url.username or url.password:


### PR DESCRIPTION
FORWARD_ONLY seems correct

https://github.com/encode/httpx/blob/b23420392efdcc10f3d802f335739d9cb3d72d5c/httpx/dispatch/proxy_http.py#L63
and
https://github.com/encode/httpx/blob/b23420392efdcc10f3d802f335739d9cb3d72d5c/httpx/config.py#L326
seems different.