### PR TITLE
Use a base_url in app dispatcher examples

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -99,8 +99,8 @@ app = Flask(__name__)
 def hello():
     return "Hello World!"
 
-with httpx.Client(app=app) as client:
-    r = client.get('http://example/')
+with httpx.Client(app=app, base_url="http://testserver") as client:
+    r = client.get("/")
     assert r.status_code == 200
     assert r.text == "Hello World!"
 ```
@@ -116,7 +116,7 @@ For example:
 ```python
 # Instantiate a client that makes WSGI requests with a client IP of "1.2.3.4".
 dispatch = httpx.WSGIDispatch(app=app, remote_addr="1.2.3.4")
-with httpx.Client(dispatch=dispatch) as client:
+with httpx.Client(dispatch=dispatch, base_url="http://testserver") as client:
     ...
 ```
 

--- a/docs/async.md
+++ b/docs/async.md
@@ -168,8 +168,8 @@ We can make requests directly against the application, like so:
 
 ```python
 >>> import httpx
->>> async with httpx.AsyncClient(app=app) as client:
-...     r = await client.get('http://example/')
+>>> async with httpx.AsyncClient(app=app, base_url="http://testserver") as client:
+...     r = await client.get("/")
 ...     assert r.status_code == 200
 ...     assert r.text == "Hello World!"
 ```
@@ -186,7 +186,7 @@ For example:
 # Instantiate a client that makes ASGI requests with a client IP of "1.2.3.4",
 # on port 123.
 dispatch = httpx.ASGIDispatch(app=app, client=("1.2.3.4", 123))
-async with httpx.AsyncClient(dispatch=dispatch) as client:
+async with httpx.AsyncClient(dispatch=dispatch, base_url="http://testserver") as client:
     ...
 ```
 


### PR DESCRIPTION
Refs #798 

The motivation is to make it clearer that app-based dispatchers aren't actually making network calls, and that actually the scheme/hostname/port in URLs are irrelevant in those cases…

Is this a good idea at all?