### PR TITLE
Middleware API design doc

### DIFF
--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -27,6 +27,7 @@ from ._exceptions import (
     TooManyRedirects,
     WriteTimeout,
 )
+from ._middleware import Middleware
 from ._models import URL, Cookies, Headers, QueryParams, Request, Response
 from ._status_codes import StatusCode, codes
 
@@ -83,4 +84,5 @@ __all__ = [
     "Response",
     "DigestAuth",
     "WSGIDispatch",
+    "Middleware",
 ]

--- a/httpx/_middleware.py
+++ b/httpx/_middleware.py
@@ -1,0 +1,51 @@
+import typing
+
+from ._config import Timeout
+from ._models import Request, Response
+from ._utils import get_logger
+
+logger = get_logger(__name__)
+
+
+class MiddlewareInstance(typing.Protocol):
+    def __call__(
+        self, request: Request, timeout: Timeout, **kwargs: typing.Any
+    ) -> typing.Generator[typing.Any, typing.Any, Response]:
+        ...
+
+
+MiddlewareType = typing.Callable[[MiddlewareInstance], MiddlewareInstance]
+
+
+class Middleware:
+    def __init__(self, middleware: typing.Callable, **kwargs: typing.Any) -> None:
+        self.middleware = middleware
+        self.kwargs = kwargs
+
+    def __call__(self, get_response: MiddlewareInstance) -> MiddlewareInstance:
+        return self.middleware(get_response, **self.kwargs)
+
+
+class MiddlewareStack:
+    """
+    Container for representing a stack of middleware classes.
+    """
+
+    def __init__(
+        self,
+        get_response: MiddlewareInstance,
+        middleware: typing.Sequence[Middleware] = None,
+    ) -> None:
+        self.get_response = get_response
+        self.middleware = list(middleware) if middleware is not None else []
+
+    def __call__(
+        self, request: Request, timeout: Timeout, **kwargs: typing.Any
+    ) -> typing.Generator[typing.Any, typing.Any, Response]:
+        if not hasattr(self, "_stack"):
+            get_response = self.get_response
+            for middleware in self.middleware:
+                get_response = middleware(get_response)
+            self._stack = get_response
+
+        return self._stack(request, timeout, **kwargs)


### PR DESCRIPTION
Pushing a simplification of #783, focused on docs (and minimal code changes to allow example code snippets to work, i.e. hooking middleware into `Client.get()`.)

Not sure we'd want to move forward with this whole middleware idea *yet* but I wanted to make a case for it here.

I'm pretty much convinced this is the correct API if we wanted to provide a general-purpose extension mechanism for clients.

It allows the following:

- Intercepting/inspecting/modifying requests
- Intercepting/inspecting/modifying responses
- Sending multiple requests (w/o being coupled to the client or the sync/async environment).
- Handling exceptions in a predictable fashion using `try/except` blocks.

An extension mechanism has benefits in itself, even if we don't immediately use it internally (e.g. for auth/redirects as initially implemented in #783). Mainly ,it would greatly reduce any tendency towards feature creep, and help us keep our core API/feature set under control. (Many "so I have this particular feature request…" issues could be addressed as "consider building a middleware".)

For example, retries (#784) and hooks (#790) can be implemented as middleware, with a much lower impact for us, and most likely more value for users (as focused third-party packages can afford going much deeper into the feature set, whereas we'd have a tendency to keep things minimal to reduce maintenance overhead).

(Eg. it's really super interesting to me how more powerful and versatile a retries middleware built on top of [tenacity](https://github.com/jd/tenacity) would be, compared to us bringing some *very limited* built-in functionality via #784… See example in the docs here.)