### PR TITLE
do not count original request for RedirectLoop protection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ site/
 *.egg-info/
 venv*/
 .python-version
+build/
+dist/

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -615,7 +615,7 @@ class Client(BaseClient):
         while True:
             if len(history) > self.max_redirects:
                 raise TooManyRedirects()
-            urls = ((resp.request.method, resp.url) for resp in history)
+            urls = ((resp.request.method, resp.url) for resp in history[1:])
             if (request.method, request.url) in urls:
                 raise RedirectLoop()
 
@@ -1142,7 +1142,7 @@ class AsyncClient(BaseClient):
         while True:
             if len(history) > self.max_redirects:
                 raise TooManyRedirects()
-            urls = ((resp.request.method, resp.url) for resp in history)
+            urls = ((resp.request.method, resp.url) for resp in history[1:])
             if (request.method, request.url) in urls:
                 raise RedirectLoop()
 


### PR DESCRIPTION
There are many situations when servers redirects to other resource and back so we cannot be so strict here. For example:
https://some.url/protected -> 302 your login token has expired so you have to refresh it
https://some.url/refreshToken -> 302 new token is set in cookies, redirecting back to original url
https://some.url/protected -> 200, request complete

I know this isn't good approach and servers probably should be doing this without asking client/browser but this is life and currently there is no way to use httpx for this kind of sites.