### PR TITLE
Add Auth.requires_response_body attribute

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -421,6 +421,30 @@ class MyCustomAuth(httpx.Auth):
         ...
 ```
 
+Similarly, if you are implementing a scheme that requires access to the response body, then use the `requires_response_body` property.
+
+```python
+class MyCustomAuth(httpx.Auth):
+    requires_response_body = True
+
+    def __init__(self, token, refresh_url):
+        self.token = token
+        self.refresh_url = refresh_url
+
+    def auth_flow(self, request):
+        request.headers["X-Auth"] = self.token["access"]
+        if response.status_code == 401:
+            # refresh the token
+            refresh_request = httpx.Request(
+                "POST", refresh_url, data={"refresh_token": self.token["refresh"]}
+            )
+            response = yield refresh_request
+            self.token = response.json()
+
+            request.headers["X-Auth"] = self.token["access"]
+            yield requestclass MyCustomAuth(httpx.Auth):
+```
+
 ## SSL certificates
 
 When making a request over HTTPS, HTTPX needs to verify the identity of the requested host. To do this, it uses a bundle of SSL certificates (a.k.a. CA bundle) delivered by a trusted certificate authority (CA).

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -421,7 +421,7 @@ class MyCustomAuth(httpx.Auth):
         ...
 ```
 
-Similarly, if you are implementing a scheme that requires access to the response body, then use the `requires_response_body` property.   You will then be able to access response body properties and methods such as `response.text`, `response.json()`, `response.iter_lines()`, etc.
+Similarly, if you are implementing a scheme that requires access to the response body, then use the `requires_response_body` property.   You will then be able to access response body properties and methods such as `response.content`, `response.text`, `response.json()`, etc.
 
 ```python
 class MyCustomAuth(httpx.Auth):

--- a/httpx/_auth.py
+++ b/httpx/_auth.py
@@ -23,6 +23,7 @@ class Auth:
     """
 
     requires_request_body = False
+    requires_response_body = False
 
     def auth_flow(self, request: Request) -> typing.Generator[Request, Response, None]:
         """

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -657,6 +657,8 @@ class Client(BaseClient):
         request = next(auth_flow)
         while True:
             response = self.send_single_request(request, timeout)
+            if auth.requires_response_body:
+                response.read()
             try:
                 next_request = auth_flow.send(response)
             except StopIteration:
@@ -1182,6 +1184,8 @@ class AsyncClient(BaseClient):
         request = next(auth_flow)
         while True:
             response = await self.send_single_request(request, timeout)
+            if auth.requires_response_body:
+                await response.aread()
             try:
                 next_request = auth_flow.send(response)
             except StopIteration:

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -467,3 +467,37 @@ async def test_digest_auth_unavailable_streaming_body():
 
     with pytest.raises(RequestBodyUnavailable):
         await client.post(url, data=streaming_body(), auth=auth)
+
+
+@pytest.mark.asyncio
+async def test_auth_reads_response_body() -> None:
+    """
+    Test that we can read the response body in an auth flow if `requires_response_body`
+    is set.
+    """
+
+    class ResponseBodyAuth(Auth):
+        """
+        A mock authentication scheme that requires clients to send an 'Authorization'
+        header, then send back the contents of the response in the 'Authorization'
+        header.
+        """
+
+        requires_response_body = True
+
+        def auth_flow(
+            self, request: Request
+        ) -> typing.Generator[Request, Response, None]:
+            request.headers["Authorization"] = "xyz"
+            response = yield request
+            data = response.text
+            request.headers["Authorization"] = data
+            yield request
+
+    url = "https://example.org/"
+    auth = ResponseBodyAuth()
+    client = AsyncClient(dispatch=MockDispatch())
+
+    response = await client.get(url, auth=auth)
+    assert response.status_code == 200
+    assert response.json() == {"auth": '{"auth": "xyz"}'}

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -485,17 +485,20 @@ async def test_auth_reads_response_body() -> None:
 
         requires_response_body = True
 
+        def __init__(self, token):
+            self.token = token
+
         def auth_flow(
             self, request: Request
         ) -> typing.Generator[Request, Response, None]:
-            request.headers["Authorization"] = "xyz"
+            request.headers["Authorization"] = self.token
             response = yield request
             data = response.text
             request.headers["Authorization"] = data
             yield request
 
     url = "https://example.org/"
-    auth = ResponseBodyAuth()
+    auth = ResponseBodyAuth("xyz")
     client = AsyncClient(dispatch=MockDispatch())
 
     response = await client.get(url, auth=auth)


### PR DESCRIPTION
If set then responses are read by the client before being sent back into the auth flow.

This is a work-in-progress. This branch has no test coverage right now because I don't fully understand the implications of this change. Currently there are five tests which fail if `requires_response_body` is set to `True`. These are all asserting that the response hasn't yet been read, or it isn't closed.

I can't figure out a way to ensure these tests all pass with `requires_response_body=True`. It's difficult because the response needs to be read before passing it back to `auth_flow`, but we need to pass it back in order to get the `StopIteration` to determine when to return.

Fixes #802 