### PR TITLE
Don't support broken dict-of-dicts case for data argument.

### DIFF
--- a/httpx/_content_streams.py
+++ b/httpx/_content_streams.py
@@ -291,7 +291,7 @@ class MultipartStream(ContentStream):
         self, data: dict, files: dict
     ) -> typing.Iterator[typing.Union["FileField", "DataField"]]:
         for name, value in data.items():
-            if isinstance(value, (list, dict)):
+            if isinstance(value, list):
                 for item in value:
                     yield self.DataField(name=name, value=item)
             else:

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -99,8 +99,7 @@ def test_multipart_encode():
         "a": "1",
         "b": b"C",
         "c": ["11", "22", "33"],
-        "d": {"ff": ["1", b"2", "3"], "fff": ["11", b"22", "33"]},
-        "f": "",
+        "d": "",
     }
     files = {"file": ("name.txt", io.BytesIO(b"<file content>"))}
 
@@ -114,9 +113,7 @@ def test_multipart_encode():
             '--{0}\r\nContent-Disposition: form-data; name="c"\r\n\r\n11\r\n'
             '--{0}\r\nContent-Disposition: form-data; name="c"\r\n\r\n22\r\n'
             '--{0}\r\nContent-Disposition: form-data; name="c"\r\n\r\n33\r\n'
-            '--{0}\r\nContent-Disposition: form-data; name="d"\r\n\r\nff\r\n'
-            '--{0}\r\nContent-Disposition: form-data; name="d"\r\n\r\nfff\r\n'
-            '--{0}\r\nContent-Disposition: form-data; name="f"\r\n\r\n\r\n'
+            '--{0}\r\nContent-Disposition: form-data; name="d"\r\n\r\n\r\n'
             '--{0}\r\nContent-Disposition: form-data; name="file";'
             ' filename="name.txt"\r\n'
             "Content-Type: text/plain\r\n\r\n<file content>\r\n"


### PR DESCRIPTION
Noticed this looking in to #777.

We're allowing `data={"a": ["1", "2", "3"]}`, which makes sense, but also `data={"a": {"1": ["ignore", "this"], "2": ["ignore", "this"]}}` which doesn't.