### PR TITLE
When setting headers, fallback to `utf-8` if no encoding is specified yet.

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -515,13 +515,8 @@ class Headers(typing.MutableMapping[str, str]):
         Set the header `key` to `value`, removing any duplicate entries.
         Retains insertion order.
         """
-        try:
-            set_key = key.lower().encode(self.encoding)
-            set_value = value.encode(self.encoding)
-        except UnicodeEncodeError:
-            self.encoding = "utf8"
-            set_key = key.lower().encode(self.encoding)
-            set_value = value.encode(self.encoding)
+        set_key = key.lower().encode(self._encoding or "utf-8")
+        set_value = value.encode(self._encoding or "utf-8")
 
         found_indexes = []
         for idx, (item_key, _) in enumerate(self._list):

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -515,8 +515,13 @@ class Headers(typing.MutableMapping[str, str]):
         Set the header `key` to `value`, removing any duplicate entries.
         Retains insertion order.
         """
-        set_key = key.lower().encode(self.encoding)
-        set_value = value.encode(self.encoding)
+        try:
+            set_key = key.lower().encode(self.encoding)
+            set_value = value.encode(self.encoding)
+        except UnicodeEncodeError:
+            self.encoding = "utf8"
+            set_key = key.lower().encode(self.encoding)
+            set_value = value.encode(self.encoding)
 
         found_indexes = []
         for idx, (item_key, _) in enumerate(self._list):


### PR DESCRIPTION
Reproduce steps:
```python
>>> r = httpx.Client()
>>> r.headers['Velocity®Ultra'] = 'Velocity®Ultra'
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.7/site-packages/httpx-0.11.1-py3.7.egg/httpx/_models.py", line 518, in __setitem__
    set_key = key.lower().encode(self.encoding)
UnicodeEncodeError: 'ascii' codec can't encode character '\xae' in position 8: ordinal not in range(128)
```