### PR TITLE
Close proxy dispatch classes on Client.close()

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -862,6 +862,8 @@ class Client(BaseClient):
 
     def close(self) -> None:
         self.dispatch.close()
+        for proxy in self.proxies.values():
+            proxy.close()
 
     def __enter__(self) -> "Client":
         return self
@@ -1388,6 +1390,8 @@ class AsyncClient(BaseClient):
 
     async def aclose(self) -> None:
         await self.dispatch.close()
+        for proxy in self.proxies.values():
+            await proxy.close()
 
     async def __aenter__(self) -> "AsyncClient":
         return self


### PR DESCRIPTION
Closes #824

Actually it would be *better* for us to gracefully handle the case where one or more `close()` calls error, and still end up calling all of them, only raising an exception at the end, however there's no reason that we can treat that as an incremental improvement on top of this.