### PR TITLE
Enable NO_PROXY environment variable support 

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -43,7 +43,12 @@ from ._models import (
     URLTypes,
 )
 from ._status_codes import codes
-from ._utils import NetRCInfo, get_environment_proxies, get_logger, should_not_be_proxied
+from ._utils import (
+    NetRCInfo,
+    get_environment_proxies,
+    get_logger,
+    should_not_be_proxied,
+)
 
 logger = get_logger(__name__)
 

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -43,7 +43,7 @@ from ._models import (
     URLTypes,
 )
 from ._status_codes import codes
-from ._utils import NetRCInfo, get_environment_proxies, get_logger
+from ._utils import NetRCInfo, get_environment_proxies, get_logger, should_not_be_proxied
 
 logger = get_logger(__name__)
 
@@ -517,7 +517,7 @@ class Client(BaseClient):
         Returns the SyncDispatcher instance that should be used for a given URL.
         This will either be the standard connection pool, or a proxy.
         """
-        if self.proxies:
+        if self.proxies and not should_not_be_proxied(url):
             is_default_port = (url.scheme == "http" and url.port == 80) or (
                 url.scheme == "https" and url.port == 443
             )
@@ -1032,7 +1032,7 @@ class AsyncClient(BaseClient):
         Returns the AsyncDispatcher instance that should be used for a given URL.
         This will either be the standard connection pool, or a proxy.
         """
-        if self.proxies:
+        if self.proxies and not should_not_be_proxied(url):
             is_default_port = (url.scheme == "http" and url.port == 80) or (
                 url.scheme == "https" and url.port == 443
             )

--- a/tests/client/test_proxies.py
+++ b/tests/client/test_proxies.py
@@ -1,6 +1,7 @@
 import pytest
 
 import httpx
+from httpx import URL
 
 
 @pytest.mark.parametrize(
@@ -87,3 +88,18 @@ def test_dispatcher_for_request(url, proxies, expected):
 def test_unsupported_proxy_scheme():
     with pytest.raises(ValueError):
         httpx.AsyncClient(proxies="ftp://127.0.0.1")
+
+
+def test_no_proxy_returns_correct_dispatcher(monkeypatch):
+    monkeypatch.setenv("HTTP_PROXY", "http://example.com")
+    monkeypatch.setenv("NO_PROXY", "google.com")
+    client = httpx.AsyncClient()
+    dispatcher = client.dispatcher_for_url(URL("http://google.com"))
+    assert dispatcher == client.dispatch
+
+
+def test_no_proxy_not_set_returns_correct_dispatcher(monkeypatch):
+    monkeypatch.setenv("HTTP_PROXY", "http://example.com")
+    client = httpx.AsyncClient()
+    dispatcher = client.dispatcher_for_url(URL("http://google.com"))
+    assert dispatcher == client.proxies["http"]

--- a/tests/client/test_proxies.py
+++ b/tests/client/test_proxies.py
@@ -1,7 +1,6 @@
 import pytest
 
 import httpx
-from httpx import URL
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR addresses issue https://github.com/encode/httpx/issues/360. I found this issue by attempting to use httpx in a environment that had both endpoints that needed to be proxied and ones that needed to stay in the local network. That is when I found out that there was no "NO_PROXY" support. 