### PR TITLE
Document cleaning up streaming responses without block usage

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -22,7 +22,7 @@ HTTPX provides a `.stream()` interface rather than using `stream=True`. This ens
 For example:
 
 ```python
-with request.stream("GET", "https://www.example.com") as response:
+with httpx.stream("GET", "https://www.example.com") as response:
     ...
 ```
 
@@ -33,6 +33,8 @@ Within a `stream()` block request data is made available with:
 * `.iter_lines()` - Corresponding to `response.iter_lines()`
 * `.iter_raw()` - Use this instead of `response.raw`
 * `.read()` - Read the entire response body, making `request.text` and `response.content` available.
+
+For more information, see [Streaming Responses](/quickstart#streaming-responses).
 
 ## SSL configuration
 


### PR DESCRIPTION
Fixes #830 

Update the documentation on streaming responses (both in the sync and async cases) to indicate how users can clean use the `.stream()` context manager when block usage via `with ...` is not possible.