### PR TITLE
document RFC 3986 URL join behavior

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -143,6 +143,19 @@ For example, `base_url` allows you to prepend an URL to all outgoing requests:
 URL('http://httpbin.org/headers')
 ```
 
+Please note that the `base_url` should comply with RFC 3986. This means, 
+essentially, that the `base_url` must be be an absolute URL and any fragment 
+portion will be dropped. The following URL 'http://api/v3.0' would be 
+stripped to 'http://api' once the request is being prepared:   
+
+```python
+>>> with httpx.Client(base_url='http://api/v3.0') as client:
+...     r = client.get('/headers/')
+...
+>>> r.request.url
+URL('http://api/headers')
+```
+
 For a list of all available client parameters, see the [`Client`](/api/#client) API reference.
 
 ## Calling into Python Web Apps

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -142,18 +142,25 @@ For example, `base_url` allows you to prepend an URL to all outgoing requests:
 >>> r.request.url
 URL('http://httpbin.org/headers')
 ```
-
-Please note that the `base_url` should comply with RFC 3986. This means, 
-essentially, that the `base_url` must be be an absolute URL and any fragment 
-portion will be dropped. The following URL 'http://api/v3.0' would be 
-stripped to 'http://api' once the request is being prepared:   
+The `base_url` is meant to be an absolute URL and any appended part of the path 
+will be stripped:    
 
 ```python
 >>> with httpx.Client(base_url='http://api/v3.0') as client:
-...     r = client.get('/headers/')
+...     r = client.get('/headers')
 ...
 >>> r.request.url
 URL('http://api/headers')
+```
+If you want to use a path prefix in your `base_url`, make sure you pass 
+a relative URL to the outgoing request:
+
+```python
+>>> with httpx.Client(base_url='http://api/v3.0/') as client:
+...     r = client.get('headers/')
+...
+>>> r.request.url
+URL('http://api/v3.0/headers')
 ```
 
 For a list of all available client parameters, see the [`Client`](/api/#client) API reference.

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -152,7 +152,7 @@ will be stripped:
 >>> r.request.url
 URL('http://api/headers')
 ```
-If you want to use a path prefix in your `base_url`, make sure you pass 
+If you want to use a path prefix in your `base_url`, make sure you'll pass 
 a relative URL to the outgoing request:
 
 ```python


### PR DESCRIPTION
That the `base_url` needs to be an absolute url is missing in the docs. The reasoning behind the url join behavior could be more explicit, I thought :-)