### PR TITLE
Do not mark wheel as universal

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [flake8]
 ignore = W503, E203, B305
 max-line-length = 88


### PR DESCRIPTION
``httpx`` requires Python > 3 so its wheel must not be tagged as universal.

Fixes #850 