### PR TITLE
Fix multipart edge cases with `data={}` and/or `files={}`

### DIFF
--- a/httpx/_content_streams.py
+++ b/httpx/_content_streams.py
@@ -330,7 +330,7 @@ def encode(
         else:
             return ByteStream(body=b"")
     elif isinstance(data, dict):
-        if files is not None:
+        if files:
             return MultipartStream(data=data, files=files, boundary=boundary)
         else:
             return URLEncodedStream(data=data)

--- a/httpx/_content_streams.py
+++ b/httpx/_content_streams.py
@@ -323,7 +323,7 @@ def encode(
     Handles encoding the given `data`, `files`, and `json`, returning
     a `ContentStream` implementation.
     """
-    if data is None:
+    if not data:
         if json is not None:
             return JSONStream(json=json)
         elif files:

--- a/tests/test_content_streams.py
+++ b/tests/test_content_streams.py
@@ -196,9 +196,7 @@ async def test_empty_request():
     async_content = b"".join([part async for part in stream])
 
     assert stream.can_replay()
-    assert stream.get_headers() == {
-        "Content-Length": "0",
-    }
+    assert stream.get_headers() == {}
     assert sync_content == b""
     assert async_content == b""
 

--- a/tests/test_content_streams.py
+++ b/tests/test_content_streams.py
@@ -198,7 +198,6 @@ async def test_empty_request():
     assert stream.can_replay()
     assert stream.get_headers() == {
         "Content-Length": "0",
-        "Content-Type": "application/x-www-form-urlencoded",
     }
     assert sync_content == b""
     assert async_content == b""

--- a/tests/test_content_streams.py
+++ b/tests/test_content_streams.py
@@ -190,15 +190,15 @@ async def test_multipart_data_and_files_content():
 
 
 @pytest.mark.asyncio
-async def test_empty_multipart():
-    stream = encode(data={}, files={}, boundary=b"+++")
+async def test_empty_request():
+    stream = encode(data={}, files={})
     sync_content = b"".join([part for part in stream])
     async_content = b"".join([part async for part in stream])
 
     assert stream.can_replay()
     assert stream.get_headers() == {
         "Content-Length": "0",
-        "Content-Type": "multipart/form-data; boundary=+++",
+        "Content-Type": "application/x-www-form-urlencoded",
     }
     assert sync_content == b""
     assert async_content == b""

--- a/tests/test_content_streams.py
+++ b/tests/test_content_streams.py
@@ -189,6 +189,21 @@ async def test_multipart_data_and_files_content():
     )
 
 
+@pytest.mark.asyncio
+async def test_empty_multipart():
+    stream = encode(data={}, files={}, boundary=b"+++")
+    sync_content = b"".join([part for part in stream])
+    async_content = b"".join([part async for part in stream])
+
+    assert stream.can_replay()
+    assert stream.get_headers() == {
+        "Content-Length": "0",
+        "Content-Type": "multipart/form-data; boundary=+++",
+    }
+    assert sync_content == b""
+    assert async_content == b""
+
+
 def test_invalid_argument():
     with pytest.raises(TypeError):
         encode(123)


### PR DESCRIPTION
Fix #862 

Could have conflict with #857 