### PR TITLE
Fix type checking breakage

### DIFF
--- a/httpx/_content_streams.py
+++ b/httpx/_content_streams.py
@@ -263,6 +263,7 @@ class MultipartStream(ContentStream):
             return b"".join(parts)
 
         def render_data(self) -> bytes:
+            content: typing.Union[str, bytes]
             if isinstance(self.file, str):
                 content = self.file
             else:


### PR DESCRIPTION
Probably due to the mypy 0.770 release very recently (https://github.com/python/mypy/issues/8437)…

Discovered as this is affecting https://github.com/encode/httpx/pull/861, which was reproducible if upgrading to `mypy==0.770` locally.