### PR TITLE
Version 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.12.1 (March 19th, 2020)
+
+### Fixed
+
+* Resolved packaging issue, where additional files were being included.
+
 ## 0.12.0 (March 9th, 2020)
 
 The 0.12 release tightens up the API expectations for `httpx` by switching to private module names to enforce better clarity around public API.

--- a/httpx/__version__.py
+++ b/httpx/__version__.py
@@ -1,3 +1,3 @@
 __title__ = "httpx"
 __description__ = "A next generation HTTP client, for Python 3."
-__version__ = "0.12.0"
+__version__ = "0.12.1"


### PR DESCRIPTION
To close #864

Will issue a PyPI release from this, ensuring that `__pycache__` is properly clean first.