### PR TITLE
Add 'Third Party Packages' docs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ For more advanced topics, see the [Advanced Usage](https://www.python-httpx.org/
 
 The [Developer Interface](https://www.python-httpx.org/api/) provides a comprehensive API reference.
 
+To find out about tools that integrate with HTTPX, see [Third Party Packages](https://www.python-httpx.org/third-party-packages/).
+
 ## Contribute
 
 If you want to contribute with HTTPX check out the [Contributing Guide](https://www.python-httpx.org/contributing/) to learn how to start.

--- a/docs/index.md
+++ b/docs/index.md
@@ -103,6 +103,8 @@ the [async support](async.md) section, or the [HTTP/2](http2.md) section.
 
 The [Developer Interface](api.md) provides a comprehensive API reference.
 
+To find out about tools that integrate with HTTPX, see [Third Party Packages](third-party-packages.md).
+
 ## Dependencies
 
 The HTTPX project relies on these excellent libraries:

--- a/docs/third-party-packages.md
+++ b/docs/third-party-packages.md
@@ -1,0 +1,25 @@
+# Third Party Packages
+
+As HTTPX usage grows, there is an expanding community of developers building tools and libraries that integrate with HTTPX, or depend on HTTPX. Here are some of them.
+
+## Plugins
+
+<!-- NOTE: this list is in alphabetical order. -->
+
+### Authlib
+
+[GitHub](https://github.com/lepture/authlib) - [Documentation](https://docs.authlib.org/en/latest/)
+
+The ultimate Python library in building OAuth and OpenID Connect clients and servers. Includes an [OAuth HTTPX client](https://docs.authlib.org/en/latest/client/httpx.html).
+
+### Gidgethub
+
+[GitHub](https://github.com/brettcannon/gidgethub) - [Documentation](https://gidgethub.readthedocs.io/en/latest/index.html)
+
+An asynchronous GitHub API library. Includes [HTTPX support](https://gidgethub.readthedocs.io/en/latest/httpx.html).
+
+### RESPX
+
+[GitHub](https://github.com/lundberg/respx) - [Documentation](https://lundberg.github.io/respx/)
+
+A utility for mocking out the Python HTTPX library.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
     - Environment Variables: 'environment_variables.md'
     - Requests Compatibility: 'compatibility.md'
     - Developer Interface: 'api.md'
+    - Third Party Packages: 'third-party-packages.md'
     - Contributing: 'contributing.md'
 
 markdown_extensions:


### PR DESCRIPTION
Fixes #805 

This page is based on the format used in [Starlette - Third Party Packages](https://www.starlette.io/third-party-packages/) for consistency. :-)

![Screenshot 2020-03-25 at 13 21 48](https://user-images.githubusercontent.com/15911462/77536216-4af8e300-6e9c-11ea-8cb7-a9b7411ff906.png)
