### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-question.md
+++ b/.github/ISSUE_TEMPLATE/1-question.md
@@ -1,0 +1,17 @@
+---
+name: Question
+about: Ask a question
+---
+
+### Checklist
+
+<!-- To help keep this issue tracker clean and focused, please make sure you tried *all* the following resources before submitting your question. -->
+
+- [ ] I looked through similar issues on GitHub, but didn't find anything.
+- [ ] I searched the [HTTPX documentation](https://www.python-httpx.org).
+- [ ] I looked up "How to do ... in HTTPX" on a search engine and didn't find any information.
+- [ ] I asked the [community chat](https://gitter.im/encode/community) for help but didn't get an answer.
+
+### Question
+
+<!-- Please ask your question here. -->

--- a/.github/ISSUE_TEMPLATE/1-question.md
+++ b/.github/ISSUE_TEMPLATE/1-question.md
@@ -7,8 +7,8 @@ about: Ask a question
 
 <!-- To help keep this issue tracker clean and focused, please make sure you tried *all* the following resources before submitting your question. -->
 
-- [ ] I looked through similar issues on GitHub, but didn't find anything.
 - [ ] I searched the [HTTPX documentation](https://www.python-httpx.org) but couldn't find what I'm looking for.
+- [ ] I looked through similar issues on GitHub, but didn't find anything.
 - [ ] I looked up "How to do ... in HTTPX" on a search engine and didn't find any information.
 - [ ] I asked the [community chat](https://gitter.im/encode/community) for help but didn't get an answer.
 

--- a/.github/ISSUE_TEMPLATE/1-question.md
+++ b/.github/ISSUE_TEMPLATE/1-question.md
@@ -8,7 +8,7 @@ about: Ask a question
 <!-- To help keep this issue tracker clean and focused, please make sure you tried *all* the following resources before submitting your question. -->
 
 - [ ] I looked through similar issues on GitHub, but didn't find anything.
-- [ ] I searched the [HTTPX documentation](https://www.python-httpx.org).
+- [ ] I searched the [HTTPX documentation](https://www.python-httpx.org) but couldn't find what I'm looking for.
 - [ ] I looked up "How to do ... in HTTPX" on a search engine and didn't find any information.
 - [ ] I asked the [community chat](https://gitter.im/encode/community) for help but didn't get an answer.
 

--- a/.github/ISSUE_TEMPLATE/2-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/2-bug-report.md
@@ -1,0 +1,84 @@
+---
+name: Bug report
+about: Report a bug to help improve this project
+---
+
+### Checklist
+
+<!-- Please make sure you check all these items before submitting your bug report. -->
+
+- [ ] The bug is reproducible against the latest release and/or `master`.
+- [ ] There are no similar issues or pull requests to fix it yet.
+
+### Describe the bug
+
+<!-- A clear and concise description of what the bug is. -->
+
+### To reproduce
+
+<!--
+Provide steps to reproduce the bug locally.
+
+An example is provided below, feel free to adapt it.
+-->
+
+1. Create and start a local server:
+
+```python
+# $ pip install starlette uvicorn
+import uvicorn
+from starlette import Starlette
+from starlette.routing import Route
+from starlette.responses import PlainTextResponse
+
+async def home(request):
+    return PlainTextResponse("Hello, world!")
+
+app = Starlette(route=[Route("/", home)])
+
+uvicorn.run(app)
+```
+
+2. Create a test script:
+
+```python
+import httpx
+
+r = httpx.get("http://localhost:8000")
+print(r)
+```
+
+4. Run the test script.
+5. It raises an error (see traceback below).
+
+### Expected behavior
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+### Actual behavior
+
+<!-- A clear and concise description of what actually happens. -->
+
+### Additional material
+
+<!--
+Any tracebacks, screenshots, etc. that can help understanding the problem.
+
+NOTE: if relevant, consider turning on DEBUG or TRACE logs for additional detail.
+See: https://www.python-httpx.org/environment_variables/#httpx_log_level
+-->
+
+### Environment
+
+- OS: <!-- eg Linux/Windows/macOS. -->
+- Python version: <!-- eg 3.8.2 (get it with `$ python -V`). -->
+- HTTPX version: <!-- eg 0.12.0 (get it with `$ pip show httpx`). -->
+- HTTP proxies: <!-- yes/no/irrelevant, if yes please try reproducing without first. -->
+- Custom certificates: <!-- yes/no/irrelevant, if yes please try reproducing without first. -->
+
+### Additional context
+
+<!--
+Any additional information that can help understanding the problem,
+eg. linked issues, or a description of what you were trying to achieve.
+-->

--- a/.github/ISSUE_TEMPLATE/2-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/2-bug-report.md
@@ -21,7 +21,7 @@ about: Report a bug to help improve this project
 NOTE: try to keep any external dependencies *at an absolute minimum* (servers, proxies, certificates...).
 In other words, remove anything that doesn't make the bug go away.
 
-If you need a local server to replicate against, you can build one using eg. Starlette [0] and Uvicorn [1], or any tool you feel comfortable with. Remember to share setup instructions here. :-)
+If you need a local server to replicate against, you can build one using eg. Starlette [0] and Uvicorn [1], or any tool you feel comfortable with. Check out other issues for examples and remember to share setup instructions here. :-)
 
 [0]: https://www.starlette.io
 [1]: https://www.uvicorn.org

--- a/.github/ISSUE_TEMPLATE/2-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/2-bug-report.md
@@ -18,39 +18,14 @@ about: Report a bug to help improve this project
 
 <!-- Provide a *minimal* example with steps to reproduce the bug locally.
 
-If you are requesting an external host, please try to setup a local server that allows reproducing the issue.
+NOTE: try to keep any external dependencies *at an absolute minimum* (servers, proxies, certificates...).
+In other words, remove anything that doesn't make the bug go away.
 
-An example is provided below, feel free to adapt it to your needs. -->
+If you need a local server to replicate against, you can build one using eg. Starlette [0] and Uvicorn [1], or any tool you feel comfortable with. Remember to share setup instructions here. :-)
 
-1. Create and start a local server:
-
-```python
-# $ pip install starlette uvicorn
-import uvicorn
-from starlette import Starlette
-from starlette.routing import Route
-from starlette.responses import PlainTextResponse
-
-async def home(request):
-    return PlainTextResponse("Hello, world!")
-
-app = Starlette(routes=[Route("/", home)])
-
-uvicorn.run(app)
-```
-
-2. Create a test script:
-
-```python
-import httpx
-
-r = httpx.get("http://localhost:8000")
-print(r)
-```
-
-4. Run the test script.
-5. It raises an error.
-6. But I expected it to successfully print the response.
+[0]: https://www.starlette.io
+[1]: https://www.uvicorn.org
+-->
 
 ### Expected behavior
 

--- a/.github/ISSUE_TEMPLATE/2-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/2-bug-report.md
@@ -16,11 +16,11 @@ about: Report a bug to help improve this project
 
 ### To reproduce
 
-<!--
-Provide steps to reproduce the bug locally.
+<!-- Provide a *minimal* example with steps to reproduce the bug locally.
 
-An example is provided below, feel free to adapt it.
--->
+If you are requesting an external host, please try to setup a local server that allows reproducing the issue.
+
+An example is provided below, feel free to adapt it to your needs. -->
 
 1. Create and start a local server:
 
@@ -34,7 +34,7 @@ from starlette.responses import PlainTextResponse
 async def home(request):
     return PlainTextResponse("Hello, world!")
 
-app = Starlette(route=[Route("/", home)])
+app = Starlette(routes=[Route("/", home)])
 
 uvicorn.run(app)
 ```
@@ -49,7 +49,8 @@ print(r)
 ```
 
 4. Run the test script.
-5. It raises an error (see traceback below).
+5. It raises an error.
+6. But I expected it to successfully print the response.
 
 ### Expected behavior
 
@@ -59,13 +60,14 @@ print(r)
 
 <!-- A clear and concise description of what actually happens. -->
 
-### Additional material
+### Debugging material
 
-<!--
-Any tracebacks, screenshots, etc. that can help understanding the problem.
+<!-- Any tracebacks, screenshots, etc. that can help understanding the problem.
 
-NOTE: if relevant, consider turning on DEBUG or TRACE logs for additional detail.
-See: https://www.python-httpx.org/environment_variables/#httpx_log_level
+NOTE:
+- Please list tracebacks in full (don't truncate them).
+- If relevant, consider turning on DEBUG or TRACE logs for additional details (see https://www.python-httpx.org/environment_variables/#httpx_log_level).
+- Consider using `<details>` to make tracebacks/logs collapsible if they're very large (see https://gist.github.com/ericclemmons/b146fe5da72ca1f706b2ef72a20ac39d).
 -->
 
 ### Environment
@@ -73,12 +75,12 @@ See: https://www.python-httpx.org/environment_variables/#httpx_log_level
 - OS: <!-- eg Linux/Windows/macOS. -->
 - Python version: <!-- eg 3.8.2 (get it with `$ python -V`). -->
 - HTTPX version: <!-- eg 0.12.0 (get it with `$ pip show httpx`). -->
-- HTTP proxies: <!-- yes/no/irrelevant, if yes please try reproducing without first. -->
-- Custom certificates: <!-- yes/no/irrelevant, if yes please try reproducing without first. -->
+- Async environment: <!-- eg asyncio/trio. If using asyncio, include whether the bug reproduces on trio (and vice versa). -->
+- HTTP proxy: <!-- yes/no, if yes please try reproducing without it. -->
+- Custom certificates: <!-- yes/no, if yes please try reproducing without them. If the bug is related to SSL/TLS, you can setup HTTPS on a local server using these instructions: https://www.python-httpx.org/advanced/#making-https-requests-to-a-local-server. -->
 
 ### Additional context
 
-<!--
-Any additional information that can help understanding the problem,
-eg. linked issues, or a description of what you were trying to achieve.
--->
+<!-- Any additional information that can help understanding the problem.
+
+Eg. linked issues, or a description of what you were trying to achieve. -->

--- a/.github/ISSUE_TEMPLATE/3-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/3-feature-request.md
@@ -1,0 +1,33 @@
+---
+name: Feature request
+about: Suggest an idea for this project.
+---
+
+### Checklist
+
+<!-- Please make sure you check all these items before submitting your feature request. -->
+
+- [ ] There are no similar issues or pull requests for this yet.
+- [ ] I discussed this idea on the [community chat](https://gitter.im/encode/community).
+
+### Is your feature related to a problem? Please describe.
+
+<!-- A clear and concise description of what you are trying to achieve.
+Eg "I want to be able to [...] but I can't because [...]". -->
+
+## Describe the solution you would like.
+
+<!-- A clear and concise description of what you would want to happen.
+
+For API changes, try to provide a code snippet of what you would like the API to look like.
+-->
+
+## Describe alternatives you considered
+
+<!-- Please describe any alternative solutions or features you've considered to solve
+your problem and why they wouldn't solve it. -->
+
+## Additional context
+
+<!-- Provide any additional context, screenshots, tracebacks, etc. about the feature here. -->
+

--- a/.github/ISSUE_TEMPLATE/3-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/3-feature-request.md
@@ -8,11 +8,12 @@ about: Suggest an idea for this project.
 <!-- Please make sure you check all these items before submitting your feature request. -->
 
 - [ ] There are no similar issues or pull requests for this yet.
-- [ ] I discussed this idea on the [community chat](https://gitter.im/encode/community).
+- [ ] I discussed this idea on the [community chat](https://gitter.im/encode/community) and feedback is positive.
 
 ### Is your feature related to a problem? Please describe.
 
 <!-- A clear and concise description of what you are trying to achieve.
+
 Eg "I want to be able to [...] but I can't because [...]". -->
 
 ## Describe the solution you would like.


### PR DESCRIPTION
A second iteration over #741, with templates for questions, bug reports and feature requests.

I think with these in place we can hope to reduce maintainer burden, as contributors will *think* more thoroughly about alternatives to opening an issue, possible solutions, etc.

This should help improve the contributing experience for all. :-)

(I based these off of the default GitHub templates, as well as those we can find on the [FastAPI repo](https://github.com/tiangolo/fastapi/issues/new/choose).)