### PR TITLE
Drop usage of `AnyStr`

### DIFF
--- a/httpx/_content_streams.py
+++ b/httpx/_content_streams.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from urllib.parse import urlencode
 
 from ._exceptions import StreamConsumed
+from ._types import StrOrBytes
 from ._utils import format_form_param
 
 RequestData = typing.Union[
@@ -18,15 +19,16 @@ RequestFiles = typing.Dict[
     str,
     typing.Union[
         # file (or str)
-        typing.Union[typing.IO[typing.AnyStr], typing.AnyStr],
+        typing.Union[typing.IO[str], typing.IO[bytes], StrOrBytes],
         # (filename, file (or str))
         typing.Tuple[
-            typing.Optional[str], typing.Union[typing.IO[typing.AnyStr], typing.AnyStr],
+            typing.Optional[str],
+            typing.Union[typing.IO[str], typing.IO[bytes], StrOrBytes],
         ],
         # (filename, file (or str), content_type)
         typing.Tuple[
             typing.Optional[str],
-            typing.Union[typing.IO[typing.AnyStr], typing.AnyStr],
+            typing.Union[typing.IO[str], typing.IO[bytes], StrOrBytes],
             typing.Optional[str],
         ],
     ],
@@ -224,7 +226,9 @@ class MultipartStream(ContentStream):
         """
 
         def __init__(
-            self, name: str, value: typing.Union[typing.IO[typing.AnyStr], tuple]
+            self,
+            name: str,
+            value: typing.Union[typing.IO[str], typing.IO[bytes], tuple],
         ) -> None:
             self.name = name
             if not isinstance(value, tuple):

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -39,6 +39,7 @@ from ._exceptions import (
     StreamConsumed,
 )
 from ._status_codes import StatusCode
+from ._types import StrOrBytes
 from ._utils import (
     ElapsedTimer,
     flatten_queryparams,
@@ -67,8 +68,8 @@ QueryParamTypes = typing.Union[
 
 HeaderTypes = typing.Union[
     "Headers",
-    typing.Dict[typing.AnyStr, typing.AnyStr],
-    typing.List[typing.Tuple[typing.AnyStr, typing.AnyStr]],
+    typing.Dict[StrOrBytes, StrOrBytes],
+    typing.Sequence[typing.Tuple[StrOrBytes, StrOrBytes]],
 ]
 
 CookieTypes = typing.Union["Cookies", CookieJar, typing.Dict[str, str]]

--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -1,0 +1,7 @@
+"""
+Type definitions for type checking purposes.
+"""
+
+from typing import Union
+
+StrOrBytes = Union[str, bytes]

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -14,6 +14,7 @@ from types import TracebackType
 from urllib.request import getproxies
 
 from ._exceptions import NetworkError
+from ._types import StrOrBytes
 
 if typing.TYPE_CHECKING:  # pragma: no cover
     from ._models import PrimitiveData
@@ -29,7 +30,7 @@ _HTML5_FORM_ENCODING_RE = re.compile(
 )
 
 
-def normalize_header_key(value: typing.AnyStr, encoding: str = None) -> bytes:
+def normalize_header_key(value: StrOrBytes, encoding: str = None) -> bytes:
     """
     Coerce str/bytes into a strictly byte-wise HTTP header key.
     """
@@ -38,7 +39,7 @@ def normalize_header_key(value: typing.AnyStr, encoding: str = None) -> bytes:
     return value.encode(encoding or "ascii").lower()
 
 
-def normalize_header_value(value: typing.AnyStr, encoding: str = None) -> bytes:
+def normalize_header_value(value: StrOrBytes, encoding: str = None) -> bytes:
     """
     Coerce str/bytes into a strictly byte-wise HTTP header value.
     """
@@ -204,8 +205,8 @@ SENSITIVE_HEADERS = {"authorization", "proxy-authorization"}
 
 
 def obfuscate_sensitive_headers(
-    items: typing.Iterable[typing.Tuple[typing.AnyStr, typing.AnyStr]]
-) -> typing.Iterator[typing.Tuple[typing.AnyStr, typing.AnyStr]]:
+    items: typing.Iterable[typing.Tuple[StrOrBytes, StrOrBytes]]
+) -> typing.Iterator[typing.Tuple[StrOrBytes, StrOrBytes]]:
     for k, v in items:
         if to_str(k.lower()) in SENSITIVE_HEADERS:
             v = to_bytes_or_str("[secure]", match_type_of=v)
@@ -301,7 +302,7 @@ def to_str(value: typing.Union[str, bytes], encoding: str = "utf-8") -> str:
     return value if isinstance(value, str) else value.decode(encoding)
 
 
-def to_bytes_or_str(value: str, match_type_of: typing.AnyStr) -> typing.AnyStr:
+def to_bytes_or_str(value: str, match_type_of: StrOrBytes) -> StrOrBytes:
     return value if isinstance(match_type_of, str) else value.encode()
 
 


### PR DESCRIPTION
Extracted of #881 to reduce its scope.

We're using `AnyStr` in several places to refer to "either bytes or str", i.e. `Union[str, bytes]`.

But `AnyStr` is not a synonym for `Union[str, bytes]`, so we should really just be using `Union[str, bytes]`.

(For details: `AnyStr` is meant to be used when we can accept either, but don't allow them to mix, so eg `(s1: AnyStr, s2: AnyStr) -> AnyStr)` would either accept str/str and return str, or accept bytes/bytes and return bytes. See [typing docs](https://docs.python.org/3/library/typing.html#typing.AnyStr).)

This PR introduces a `StrOrBytes` util type to use across the codebase.