### PR TITLE
Fix Client Docstring and add AsyncClient to API docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -38,6 +38,8 @@
     :docstring:
     :members: headers cookies params request get head options post put patch delete build_request send close
 
+## `AsyncClient`
+
 ::: httpx.AsyncClient
     :docstring:
     :members: headers cookies params request get head options post put patch delete build_request send

--- a/docs/api.md
+++ b/docs/api.md
@@ -38,6 +38,11 @@
     :docstring:
     :members: headers cookies params request get head options post put patch delete build_request send close
 
+::: httpx.AsyncClient
+    :docstring:
+    :members: headers cookies params request get head options post put patch delete build_request send
+
+
 ## `Response`
 
 *An HTTP response.*

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -426,7 +426,7 @@ class Client(BaseClient):
     request URLs.
     * **dispatch** - *(optional)* A dispatch class to use for sending requests
     over the network.
-    * **app** - *(optional)* An ASGI application to send requests to,
+    * **app** - *(optional)* An WSGI application to send requests to,
     rather than sending actual network requests.
     * **trust_env** - *(optional)* Enables or disables usage of environment
     variables for configuration.


### PR DESCRIPTION
The Client docstring incorrectly says that it takes an ASGI app when it actually takes a WSGI app.

Also the AsyncClient's API isn't in the docs anywhere, so it is difficult to tell that you should use that instead.

It is arguable that the API of the AsyncClient should be on the Async client, and a link to it could be on the API page, but I think it makes more sense to have all the API in one place.  Happy to be corrected on this.

Fixes #879 