### PR TITLE
Fix erroneous `Any` member in `HTTPError.request` type hint

### DIFF
--- a/httpx/_exceptions.py
+++ b/httpx/_exceptions.py
@@ -12,8 +12,10 @@ class HTTPError(Exception):
     def __init__(
         self, *args: typing.Any, request: "Request" = None, response: "Response" = None
     ) -> None:
+        if request is None and response is not None:
+            request = response.request
         self.response = response
-        self.request = request or getattr(self.response, "request", None)
+        self.request = request
         super().__init__(*args)
 
 


### PR DESCRIPTION
Currently `exc.request` is treated as `Union[Request, Any]` by type checkers, instead of just `Request`:

```python
import httpx

try:
    pass
except httpx.NetworkError as exc:
    reveal_type(exc.request)
```

```console
$ mypy debug/exc.py
debug/exc.py:6: note: Revealed type is 'Union[httpx._models.Request, Any]'
```

As a result users can't benefit from type checking of attributes on `exc.request`, because eg any missing request attributes is treated as `Any` (because it's supposed to come from the `Any` part of the union).

This was because of the usage of `getattr`, which is actually unecessary as responses are always guaranteed to have a `.request` attached (since #666).

This PR fixes the type hint to be `Optional[Request]`.