### PR TITLE
Improve type hinting for `HTTPError.request`

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -680,8 +680,8 @@ class Client(BaseClient):
             # Add the original request to any HTTPError unless
             # there'a already a request attached in the case of
             # a ProxyError.
-            if exc.request is None:
-                exc.request = request
+            if exc._request is None:
+                exc._request = request
             raise
 
         self.cookies.extract_cookies(response)
@@ -1198,8 +1198,8 @@ class AsyncClient(BaseClient):
             # Add the original request to any HTTPError unless
             # there'a already a request attached in the case of
             # a ProxyError.
-            if exc.request is None:
-                exc.request = request
+            if exc._request is None:
+                exc._request = request
             raise
 
         self.cookies.extract_cookies(response)

--- a/httpx/_exceptions.py
+++ b/httpx/_exceptions.py
@@ -12,9 +12,16 @@ class HTTPError(Exception):
     def __init__(
         self, *args: typing.Any, request: "Request" = None, response: "Response" = None
     ) -> None:
-        self.response = response
-        self.request = request or getattr(self.response, "request", None)
         super().__init__(*args)
+        self._request = request or (response.request if response is not None else None)
+        self.response = response
+
+    @property
+    def request(self) -> "Request":
+        # NOTE: this property exists so that a `Request` is exposed to type
+        # checkers, instead of `Optional[Request]`.
+        assert self._request is not None  # Populated by the client.
+        return self._request
 
 
 # Timeout exceptions...


### PR DESCRIPTION
A small quality-of-life improvement to our typing coverage: make sure that type checkers are aware that `HTTPError.request` always refers to a well-defined `Request` instance.

With the current state of things, assuming the issue described in #885 was fixed (it is addressed here too), mypy wouldn't let users access the `request` without casting it to a non-`None` first, which is bad UX.

There's also a hidden assumption that `exc.request` always has a request set, but it's not enforced anywhere in the code.

This PR updates `HTTPError` and the population of the request to reflect these points.