### PR TITLE
Remove stitches in `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,5 @@ trio
 trustme
 uvicorn
 seed-isort-config
+
+attrs>=19.2  # See: https://github.com/encode/httpx/pull/566#issuecomment-559862665

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,7 @@
 brotlipy==0.7.*
 
 autoflake
-# See: https://github.com/encode/httpx/pull/639#issuecomment-566235998
-black --no-binary=regex
+black
 cryptography
 flake8
 flake8-bugbear
@@ -23,5 +22,3 @@ trio
 trustme
 uvicorn
 seed-isort-config
-
-attrs>=19.2  # See: https://github.com/encode/httpx/pull/566#issuecomment-559862665


### PR DESCRIPTION
We had a few hot fixes in our `requirements.txt` file due to transient failures in certain of our test dependencies — dropping them as these failures should be fixed by now.