### PR TITLE
Test on Python 3.9-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ python:
   - 3.6
   - 3.7
   - 3.8
+  - 3.9-dev
 
 stages:
   - check


### PR DESCRIPTION
Python 3.9 is due for beta release in May and full release in October:

* https://www.python.org/dev/peps/pep-0596/#schedule

Testing `3.9-dev` on Travis CI can help avoid any surprises.