### PR TITLE
Added adapter to convert requests.Session to httpx.AsyncClient

### DIFF
--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -29,6 +29,7 @@ from ._exceptions import (
 )
 from ._models import URL, Cookies, Headers, QueryParams, Request, Response
 from ._status_codes import StatusCode, codes
+from ._requests import from_requests
 
 __all__ = [
     "__description__",

--- a/httpx/_requests.py
+++ b/httpx/_requests.py
@@ -1,0 +1,30 @@
+import importlib
+import httpx
+
+
+def from_requests(session) -> httpx.AsyncClient:
+    """
+    Converts session object from requests libarary to AsyncClient
+        :param session: session object of type requests.Session
+        :return: httpx.AsyncClient
+    """
+    requests_spec = importlib.util.find_spec("requests")
+    if not requests_spec:
+        raise Exception("requrests library is requried for this functionality")
+
+    import requests
+
+    if not isinstance(session, requests.Session):
+        raise Exception("session is not an instance of requests.Session")
+
+    headers = dict(session.headers)
+    cookies = httpx.Cookies()
+    for c in session.cookies:
+        cookies.set(name=c.name, value=c.value, domain=c.domain, path=c.path)
+
+    return httpx.AsyncClient(
+        headers=headers,
+        cookies=cookies,
+        verify=session.verify,
+        trust_env=session.trust_env,
+    )


### PR DESCRIPTION
As httpx supports requests compatible API, it would be great to convert requests Session to AsyncClient, this will results in easy migrations / interoperability between these two libraries. 

To achieve this conversion this adapter will take requests session as argument as returns AsyncClient

following is a snippet of usage
```
async with httpx.from_requests(session) as client:
```