### PR TITLE
Move types definitions to a dedicated module

### DIFF
--- a/httpx/_api.py
+++ b/httpx/_api.py
@@ -1,17 +1,19 @@
 import typing
 
-from ._auth import AuthTypes
 from ._client import Client, StreamContextManager
-from ._config import DEFAULT_TIMEOUT_CONFIG, CertTypes, TimeoutTypes, VerifyTypes
-from ._models import (
+from ._config import DEFAULT_TIMEOUT_CONFIG
+from ._models import Request, Response
+from ._types import (
+    AuthTypes,
+    CertTypes,
     CookieTypes,
     HeaderTypes,
     QueryParamTypes,
-    Request,
     RequestData,
     RequestFiles,
-    Response,
+    TimeoutTypes,
     URLTypes,
+    VerifyTypes,
 )
 
 

--- a/httpx/_auth.py
+++ b/httpx/_auth.py
@@ -10,12 +10,6 @@ from ._exceptions import ProtocolError, RequestBodyUnavailable
 from ._models import Request, Response
 from ._utils import to_bytes, to_str, unquote
 
-AuthTypes = typing.Union[
-    typing.Tuple[typing.Union[str, bytes], typing.Union[str, bytes]],
-    typing.Callable[["Request"], "Request"],
-    "Auth",
-]
-
 
 class Auth:
     """

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -5,42 +5,37 @@ from types import TracebackType
 import hstspreload
 import httpcore
 
-from ._auth import Auth, AuthTypes, BasicAuth, FunctionAuth
+from ._auth import Auth, BasicAuth, FunctionAuth
 from ._config import (
     DEFAULT_MAX_REDIRECTS,
     DEFAULT_POOL_LIMITS,
     DEFAULT_TIMEOUT_CONFIG,
     UNSET,
-    CertTypes,
     PoolLimits,
-    ProxiesTypes,
     Proxy,
     SSLConfig,
     Timeout,
-    TimeoutTypes,
     UnsetType,
-    VerifyTypes,
 )
 from ._content_streams import ContentStream
 from ._dispatch.asgi import ASGIDispatch
 from ._dispatch.wsgi import WSGIDispatch
 from ._exceptions import HTTPError, InvalidURL, RequestBodyUnavailable, TooManyRedirects
-from ._models import (
-    URL,
-    Cookies,
+from ._models import URL, Cookies, Headers, Origin, QueryParams, Request, Response
+from ._status_codes import codes
+from ._types import (
+    AuthTypes,
+    CertTypes,
     CookieTypes,
-    Headers,
     HeaderTypes,
-    Origin,
-    QueryParams,
+    ProxiesTypes,
     QueryParamTypes,
-    Request,
     RequestData,
     RequestFiles,
-    Response,
+    TimeoutTypes,
     URLTypes,
+    VerifyTypes,
 )
-from ._status_codes import codes
 from ._utils import (
     NetRCInfo,
     get_environment_proxies,

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -6,18 +6,9 @@ from pathlib import Path
 
 import certifi
 
-from ._models import URL, Headers, HeaderTypes, URLTypes
+from ._models import URL, Headers
+from ._types import CertTypes, HeaderTypes, TimeoutTypes, URLTypes, VerifyTypes
 from ._utils import get_ca_bundle_from_env, get_logger
-
-CertTypes = typing.Union[str, typing.Tuple[str, str], typing.Tuple[str, str, str]]
-VerifyTypes = typing.Union[str, bool, ssl.SSLContext]
-TimeoutTypes = typing.Union[
-    None, float, typing.Tuple[float, float, float, float], "Timeout"
-]
-ProxiesTypes = typing.Union[
-    URLTypes, "Proxy", typing.Dict[URLTypes, typing.Union[URLTypes, "Proxy"]]
-]
-
 
 DEFAULT_CIPHERS = ":".join(
     [

--- a/httpx/_content_streams.py
+++ b/httpx/_content_streams.py
@@ -8,36 +8,13 @@ from urllib.parse import urlencode
 import httpcore
 
 from ._exceptions import StreamConsumed
-from ._types import StrOrBytes
+from ._types import RequestData, RequestFiles
 from ._utils import (
     format_form_param,
     guess_content_type,
     peek_filelike_length,
     to_bytes,
 )
-
-RequestData = typing.Union[
-    dict, str, bytes, typing.Iterator[bytes], typing.AsyncIterator[bytes]
-]
-
-RequestFiles = typing.Dict[
-    str,
-    typing.Union[
-        # file (or str)
-        typing.Union[typing.IO[str], typing.IO[bytes], StrOrBytes],
-        # (filename, file (or str))
-        typing.Tuple[
-            typing.Optional[str],
-            typing.Union[typing.IO[str], typing.IO[bytes], StrOrBytes],
-        ],
-        # (filename, file (or str), content_type)
-        typing.Tuple[
-            typing.Optional[str],
-            typing.Union[typing.IO[str], typing.IO[bytes], StrOrBytes],
-            typing.Optional[str],
-        ],
-    ],
-]
 
 
 class ContentStream(httpcore.AsyncByteStream, httpcore.SyncByteStream):

--- a/httpx/_dispatch/urllib3.py
+++ b/httpx/_dispatch/urllib3.py
@@ -7,15 +7,9 @@ import httpcore
 import urllib3
 from urllib3.exceptions import MaxRetryError, SSLError
 
-from .._config import (
-    DEFAULT_POOL_LIMITS,
-    CertTypes,
-    PoolLimits,
-    Proxy,
-    SSLConfig,
-    VerifyTypes,
-)
+from .._config import DEFAULT_POOL_LIMITS, PoolLimits, Proxy, SSLConfig
 from .._content_streams import ByteStream, IteratorStream
+from .._types import CertTypes, VerifyTypes
 from .._utils import as_network_error
 
 

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -13,13 +13,7 @@ import chardet
 import rfc3986
 
 from .__version__ import __version__
-from ._content_streams import (
-    ByteStream,
-    ContentStream,
-    RequestData,
-    RequestFiles,
-    encode,
-)
+from ._content_streams import ByteStream, ContentStream, encode
 from ._decoders import (
     SUPPORTED_DECODERS,
     Decoder,
@@ -39,7 +33,15 @@ from ._exceptions import (
     StreamConsumed,
 )
 from ._status_codes import StatusCode
-from ._types import StrOrBytes
+from ._types import (
+    CookieTypes,
+    HeaderTypes,
+    PrimitiveData,
+    QueryParamTypes,
+    RequestData,
+    RequestFiles,
+    URLTypes,
+)
 from ._utils import (
     ElapsedTimer,
     flatten_queryparams,
@@ -54,25 +56,6 @@ from ._utils import (
 
 if typing.TYPE_CHECKING:  # pragma: no cover
     from ._dispatch.base import AsyncDispatcher  # noqa: F401
-
-PrimitiveData = typing.Optional[typing.Union[str, int, float, bool]]
-
-URLTypes = typing.Union["URL", str]
-
-QueryParamTypes = typing.Union[
-    "QueryParams",
-    typing.Mapping[str, typing.Union[PrimitiveData, typing.Sequence[PrimitiveData]]],
-    typing.List[typing.Tuple[str, PrimitiveData]],
-    str,
-]
-
-HeaderTypes = typing.Union[
-    "Headers",
-    typing.Dict[StrOrBytes, StrOrBytes],
-    typing.Sequence[typing.Tuple[StrOrBytes, StrOrBytes]],
-]
-
-CookieTypes = typing.Union["Cookies", CookieJar, typing.Dict[str, str]]
 
 
 class URL:

--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -2,6 +2,67 @@
 Type definitions for type checking purposes.
 """
 
-from typing import Union
+import ssl
+from http.cookiejar import CookieJar
+from typing import (
+    IO,
+    TYPE_CHECKING,
+    AsyncIterator,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ._auth import Auth  # noqa: F401
+    from ._config import Proxy, Timeout  # noqa: F401
+    from ._models import URL, Cookies, Headers, QueryParams, Request  # noqa: F401
 
 StrOrBytes = Union[str, bytes]
+
+PrimitiveData = Optional[Union[str, int, float, bool]]
+
+URLTypes = Union["URL", str]
+
+QueryParamTypes = Union[
+    "QueryParams",
+    Mapping[str, Union[PrimitiveData, Sequence[PrimitiveData]]],
+    List[Tuple[str, PrimitiveData]],
+    str,
+]
+
+HeaderTypes = Union[
+    "Headers", Dict[StrOrBytes, StrOrBytes], Sequence[Tuple[StrOrBytes, StrOrBytes]],
+]
+
+CookieTypes = Union["Cookies", CookieJar, Dict[str, str]]
+
+CertTypes = Union[str, Tuple[str, str], Tuple[str, str, str]]
+VerifyTypes = Union[str, bool, ssl.SSLContext]
+TimeoutTypes = Union[None, float, Tuple[float, float, float, float], "Timeout"]
+ProxiesTypes = Union[URLTypes, "Proxy", Dict[URLTypes, Union[URLTypes, "Proxy"]]]
+
+AuthTypes = Union[
+    Tuple[Union[str, bytes], Union[str, bytes]],
+    Callable[["Request"], "Request"],
+    "Auth",
+]
+
+RequestData = Union[dict, str, bytes, Iterator[bytes], AsyncIterator[bytes]]
+
+FileContent = Union[IO[str], IO[bytes], str, bytes]
+FileTypes = Union[
+    # file (or text)
+    FileContent,
+    # (filename, file (or text))
+    Tuple[Optional[str], FileContent],
+    # (filename, file (or text), content_type)
+    Tuple[Optional[str], FileContent, Optional[str]],
+]
+RequestFiles = Dict[str, FileTypes]

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -15,10 +15,9 @@ from types import TracebackType
 from urllib.request import getproxies
 
 from ._exceptions import NetworkError
-from ._types import StrOrBytes
+from ._types import PrimitiveData, StrOrBytes
 
 if typing.TYPE_CHECKING:  # pragma: no cover
-    from ._models import PrimitiveData
     from ._models import URL
 
 


### PR DESCRIPTION
Refs https://github.com/encode/httpx/issues/789#issuecomment-578143085

Move all type definitions and aliases to a centralized `_types` module, instead of them being scattered across the code base. In line with what we do in HTTPCore. :-)

A simpler version of #881, branched off from `master`, and without any typing changes - only import changes.