### PR TITLE
Avoid hasattr in hot loop in brotli decoder

### DIFF
--- a/httpx/_decoders.py
+++ b/httpx/_decoders.py
@@ -105,15 +105,17 @@ class BrotliDecoder(Decoder):
         ), "The 'brotlipy' or 'brotli' library must be installed to use 'BrotliDecoder'"
         self.decompressor = brotli.Decompressor()
         self.seen_data = False
+        if hasattr(self.decompressor, "decompress"):
+            self._decompress = self.decompressor.decompress
+        else:
+            self._decompress = self.decompressor.process  # pragma: nocover
 
     def decode(self, data: bytes) -> bytes:
         if not data:
             return b""
         self.seen_data = True
         try:
-            if hasattr(self.decompressor, "decompress"):
-                return self.decompressor.decompress(data)
-            return self.decompressor.process(data)  # pragma: nocover
+            return self._decompress(data)
         except brotli.error as exc:
             raise DecodingError from exc
 


### PR DESCRIPTION
`hasattr` has a nasty performance penalty when it returns false: in the background it is actually a try/except AttributeError.  Since we know the method we want won't change, by instead caching the bound method object we can amortise the cost across an entire encoded body.