### PR TITLE
Version 0.13.0.dev0

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -23,5 +23,7 @@ jobs:
         run: "scripts/install"
       - name: "Run linting checks"
         run: "scripts/check"
+      - name: "Build package & docs"
+        run: "scripts/build"
       - name: "Run tests"
         run: "scripts/test"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,25 @@ This release switches to `httpcore` for all the internal networking, which means
 
 It also means we've had to remove our UDS support, since maintaining that would have meant having to push back our work towards a 1.0 release, which isn't a trade-off we wanted to make.
 
+### Changed
+
+* Use `httpcore` for underlying HTTP transport. Drop `urllib3` requirement. (Pull #804)
+
+### Added
+
+* Added `URLLib3Dispatcher` class for optional `urllib3` transport support. (Pull #804)
+* Streaming multipart uploads. (Pull #857)
+
+### Fixed
+
+* Performance improvement in brotli decoder. (Pull #906)
+* Proper warning level of deprecation notice in `Response.stream` and `Response.raw`. (Pull #908)
+* Fix support for generator based WSGI apps. (Pull #887)
+
+### Removed
+
+* Dropped support for `Client(uds=...)` (Pull #804)
+
 ## 0.12.1 (March 19th, 2020)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.13.0.dev0 (April 30th, 2020)
+
+The 0.13.0.dev0 is a *pre-release* version. To install it, use `pip install httpx --pre`.
+
+This release switches to `httpcore` for all the internal networking, which means:
+
+* We're using the same codebase for both our sync and async clients.
+* HTTP/2 support is now available with the sync client.
+* We no longer have a `urllib3` dependancy for our sync client, although there is still an *optional* `URLLib3Dispatcher` class.
+
 ## 0.12.1 (March 19th, 2020)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ This release switches to `httpcore` for all the internal networking, which means
 
 * We're using the same codebase for both our sync and async clients.
 * HTTP/2 support is now available with the sync client.
-* We no longer have a `urllib3` dependancy for our sync client, although there is still an *optional* `URLLib3Dispatcher` class.
+* We no longer have a `urllib3` dependency for our sync client, although there is still an *optional* `URLLib3Dispatcher` class.
+
+It also means we've had to remove our UDS support, since maintaining that would have meant having to push back our work towards a 1.0 release, which isn't a trade-off we wanted to make.
 
 ## 0.12.1 (March 19th, 2020)
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ HTTPX is a fully featured HTTP client for Python 3, which provides sync and asyn
 
 **Note**: _HTTPX should be considered in beta. We believe we've got the public API to
 a stable point now, but would strongly recommend pinning your dependencies to the `0.12.*`
-release, so that you're able to properly review [API changes between package updates](https://github.com/encode/httpx/blob/master/CHANGELOG.md). A 1.0 release is expected to be issued sometime on or before April 2020._
+release, so that you're able to properly review [API changes between package updates](https://github.com/encode/httpx/blob/master/CHANGELOG.md). A 1.0 release is expected to be issued sometime around mid-2020._
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ HTTPX is a fully featured HTTP client for Python 3, which provides sync and asyn
 
     We believe we've got the public API to a stable point now, but would strongly recommend pinning your dependencies to the `0.12.*` release, so that you're able to properly review [API changes between package updates](https://github.com/encode/httpx/blob/master/CHANGELOG.md).
 
-    A 1.0 release is expected to be issued sometime on or before April 2020.
+    A 1.0 release is expected to be issued sometime around mid-2020.
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,16 @@
 # Optional
 brotlipy==0.7.*
 
+# Documentation
+mkdocs
+mkautodoc
+mkdocs-material
+
+# Packaging
+twine
+wheel
+
+# Tests & Linting
 autoflake
 black
 cryptography
@@ -10,9 +20,6 @@ flake8
 flake8-bugbear
 flake8-pie
 isort
-mkdocs
-mkautodoc
-mkdocs-material
 mypy
 pytest
 pytest-asyncio

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         "chardet==3.*",
         "idna==2.*",
         "rfc3986>=1.3,<2",
-        "httpcore==0.7.*",
+        "httpcore==0.8.*",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         "chardet==3.*",
         "idna==2.*",
         "rfc3986>=1.3,<2",
-        "httpcore==0.8.*",
+        "httpcore>=0.8.1",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
The 0.13.0.dev0 is a *pre-release* version. To install it, use `pip install httpx --pre`.

This release switches to `httpcore` for all the internal networking, which means:

* We're using the same codebase for both our sync and async clients.
* HTTP/2 support is now available with the sync client.
* We no longer have a `urllib3` dependancy for our sync client, although there is still an *optional* `URLLib3Dispatcher` class.
