### PR TITLE
Fix VERSION_FILE in publish script.

### DIFF
--- a/scripts/publish
+++ b/scripts/publish
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-VERSION_FILE="httpx/__init__.py"
+VERSION_FILE="httpx/__version__.py"
 
 if [ -d 'venv' ] ; then
     PREFIX="venv/bin/"


### PR DESCRIPTION
I've published 0.13.dev0 manually.

Unintentionally it's published as "0.13.dev0" rather than 0.13.0.dev0 - if the publish script hadn't been broken in the first place then it would have errored on that clearly, rather than just failing without useful output.