### PR TITLE
Mark `Response.json()` as returning `Any`

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -838,7 +838,7 @@ class Response:
             message = message.format(self, error_type="Server Error")
             raise HTTPError(message, response=self)
 
-    def json(self, **kwargs: typing.Any) -> typing.Union[dict, list]:
+    def json(self, **kwargs: typing.Any) -> typing.Any:
         if self.charset_encoding is None and self.content and len(self.content) > 3:
             encoding = guess_json_utf(self.content)
             if encoding is not None:


### PR DESCRIPTION
Anytime I process the returned `json()` data from an API call, I run into mypy issues because the return type is currently `Union[dict, list]`:

```python
data = response.json()
_ = data["items"]
```

```console
debug/client.py:4: error: No overload variant of "__getitem__" of "list" matches argument type "str"
debug/client.py:4: note: Possible overload variants:
debug/client.py:4: note:     def __getitem__(self, int) -> Any
debug/client.py:4: note:     def __getitem__(self, slice) -> List[Any]
```

The workaround is this… (Note that marking as `: dict` is not enough, as mypy just won't let us down-grade a `Union` via a simple annotation.)

```
data: dict= response.json()  # type: ignore
```

But it's a pain, so this PR just marks the return type as `Any` — which is in line with `json.loads()`. This means we can freely annotate the data as seems fit, eg `list`, `dict`, etc.