### PR TITLE
Deprecate passing DEFAULT proxy mode to HTTPCore

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -94,18 +94,21 @@ class BaseClient:
             }
         else:
             new_proxies = {}
-            for key in ("http", "https"):
-                if key in proxies:
+            for key, value in proxies.items():
+                # if the key starts with all, split into http and https
+                key = str(key)
+                if key.startswith("all"):
+                    for scheme in ("https", "http"):
+                        scheme_key = key.replace("all", scheme)
+                        if scheme_key not in new_proxies:
+                            new_proxies[
+                                scheme_key
+                            ] = self._get_proxy_for_config_value(value, scheme=scheme)
+                else:
+                    scheme = key if "://" not in key else key[: key.rfind("://")]
                     new_proxies[key] = self._get_proxy_for_config_value(
-                        proxies[key], scheme=key
+                        value, scheme=scheme
                     )
-
-            if "all" in proxies:
-                for key in ("http", "https"):
-                    if key not in new_proxies:
-                        new_proxies[key] = self._get_proxy_for_config_value(
-                            proxies["all"], scheme=key
-                        )
 
             return new_proxies
 

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -1,3 +1,4 @@
+import copy
 import functools
 import typing
 from types import TracebackType
@@ -124,6 +125,12 @@ class BaseClient:
             mode = "TUNNEL_ONLY" if scheme == "https" else "FORWARD_ONLY"
             return Proxy(url=value, mode=mode)
         elif isinstance(value, Proxy):
+            # If the user specified a Proxy without an explict mode
+            # copy the Proxy and set the mode based on the request scheme
+            if value.mode == "DEFAULT":
+                proxy = copy.copy(value)
+                proxy.mode = "TUNNEL_ONLY" if scheme == "https" else "FORWARD_ONLY"
+                return proxy
             return value
 
         raise RuntimeError("Unsupported value for proxy configuration")

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -572,10 +572,7 @@ class Client(BaseClient):
             proxy_keys = (
                 f"{url.scheme}://{hostname}",
                 f"{url.scheme}://{url.host}" if is_default_port else None,
-                f"all://{hostname}",
-                f"all://{url.host}" if is_default_port else None,
                 url.scheme,
-                "all",
             )
             for proxy_key in proxy_keys:
                 if proxy_key and proxy_key in self.proxies:

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -101,9 +101,9 @@ class BaseClient:
                     for scheme in ("https", "http"):
                         scheme_key = key.replace("all", scheme)
                         if scheme_key not in new_proxies:
-                            new_proxies[
-                                scheme_key
-                            ] = self._get_proxy_for_config_value(value, scheme=scheme)
+                            new_proxies[scheme_key] = self._get_proxy_for_config_value(
+                                value, scheme=scheme
+                            )
                 else:
                     scheme = key if "://" not in key else key[: key.rfind("://")]
                     new_proxies[key] = self._get_proxy_for_config_value(

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -115,7 +115,7 @@ class BaseClient:
     def _get_proxy_for_config_value(
         self, value: typing.Union[str, URL, Proxy], scheme: str
     ) -> Proxy:
-        if isinstance(value, httpcore.AsyncHTTPTransport):  # pragma: nocover
+        if isinstance(value, httpcore.AsyncHTTPTransport):
             raise RuntimeError(
                 "Passing a dispatcher instance to 'proxies=' is no longer "
                 "supported. Use `httpx.Proxy() instead.`"

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -330,14 +330,14 @@ class PoolLimits:
 
 class Proxy:
     def __init__(
-        self, url: URLTypes, *, headers: HeaderTypes = None, mode: str = None,
+        self, url: URLTypes, *, headers: HeaderTypes = None, mode: str = "DEFAULT",
     ):
         url = URL(url)
         headers = Headers(headers)
 
         if url.scheme not in ("http", "https"):
             raise ValueError(f"Unknown scheme for proxy URL {url!r}")
-        if mode is not None and mode not in ("DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY"):
+        if mode not in ("DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY"):
             raise ValueError(f"Unknown proxy mode {mode!r}")
 
         if url.username or url.password:
@@ -351,7 +351,7 @@ class Proxy:
 
         self.url = url
         self.headers = headers
-        self.mode = mode or "DEFAULT"
+        self.mode = mode
 
     def build_auth_header(self, username: str, password: str) -> str:
         userpass = (username.encode("utf-8"), password.encode("utf-8"))

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -1,9 +1,9 @@
 import os
 import ssl
 import typing
+import warnings
 from base64 import b64encode
 from pathlib import Path
-import warnings
 
 import certifi
 
@@ -354,7 +354,8 @@ class Proxy:
         self.headers = headers
         if mode == "DEFAULT":
             warnings.warn(
-                "DEFAULT proxy mode is deprecated, please use TUNNEL_ONLY or FORWARD_ONLY."
+                "DEFAULT proxy mode is deprecated, please use "
+                "TUNNEL_ONLY or FORWARD_ONLY."
             )
         self.mode = mode
 

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -354,8 +354,7 @@ class Proxy:
         self.headers = headers
         if mode == "DEFAULT":
             warnings.warn(
-                f"DEFAULT proxy mode is deprecated, please "
-                f"use TUNNEL_ONLY or FORWARD_ONLY. "
+                "DEFAULT proxy mode is deprecated, please use TUNNEL_ONLY or FORWARD_ONLY."
             )
         self.mode = mode
 

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -3,6 +3,7 @@ import ssl
 import typing
 from base64 import b64encode
 from pathlib import Path
+import warnings
 
 import certifi
 
@@ -351,6 +352,11 @@ class Proxy:
 
         self.url = url
         self.headers = headers
+        if mode == "DEFAULT":
+            warnings.warn(
+                f"DEFAULT proxy mode is deprecated, please "
+                f"use TUNNEL_ONLY or FORWARD_ONLY. "
+            )
         self.mode = mode
 
     def build_auth_header(self, username: str, password: str) -> str:

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -1,7 +1,6 @@
 import os
 import ssl
 import typing
-import warnings
 from base64 import b64encode
 from pathlib import Path
 
@@ -331,14 +330,14 @@ class PoolLimits:
 
 class Proxy:
     def __init__(
-        self, url: URLTypes, *, headers: HeaderTypes = None, mode: str = "DEFAULT",
+        self, url: URLTypes, *, headers: HeaderTypes = None, mode: str = None,
     ):
         url = URL(url)
         headers = Headers(headers)
 
         if url.scheme not in ("http", "https"):
             raise ValueError(f"Unknown scheme for proxy URL {url!r}")
-        if mode not in ("DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY"):
+        if mode is not None and mode not in ("DEFAULT", "FORWARD_ONLY", "TUNNEL_ONLY"):
             raise ValueError(f"Unknown proxy mode {mode!r}")
 
         if url.username or url.password:
@@ -352,12 +351,7 @@ class Proxy:
 
         self.url = url
         self.headers = headers
-        if mode == "DEFAULT":
-            warnings.warn(
-                "DEFAULT proxy mode is deprecated, please use "
-                "TUNNEL_ONLY or FORWARD_ONLY."
-            )
-        self.mode = mode
+        self.mode = mode or "DEFAULT"
 
     def build_auth_header(self, username: str, password: str) -> str:
         userpass = (username.encode("utf-8"), password.encode("utf-8"))

--- a/tests/client/test_proxies.py
+++ b/tests/client/test_proxies.py
@@ -27,6 +27,17 @@ import httpx
             {"https": httpx.Proxy("https://127.0.0.1"), "all": "http://127.0.0.1"},
             [("http", "http://127.0.0.1"), ("https", "https://127.0.0.1")],
         ),
+        (
+            {
+                "https": httpx.Proxy("https://127.0.0.1"),
+                "all://example.org": "http://127.0.0.1:8080",
+            },
+            [
+                ("https", "https://127.0.0.1"),
+                ("http://example.org", "http://127.0.0.1:8080"),
+                ("https://example.org", "http://127.0.0.1:8080"),
+            ],
+        ),
     ],
 )
 def test_proxies_parameter(proxies, expected_proxies):

--- a/tests/client/test_proxies.py
+++ b/tests/client/test_proxies.py
@@ -78,7 +78,6 @@ PROXY_URL = "http://[::1]"
             PROXY_URL + ":2",
         ),
         ("http://example.com", {"http": PROXY_URL + ":1"}, PROXY_URL + ":1"),
-        ("http://example.com", {"http": PROXY_URL + ":1"}, PROXY_URL + ":1"),
     ],
 )
 def test_transport_for_request(url, proxies, expected):

--- a/tests/client/test_proxies.py
+++ b/tests/client/test_proxies.py
@@ -1,6 +1,6 @@
+import httpcore
 import pytest
 
-import httpcore
 import httpx
 
 

--- a/tests/client/test_proxies.py
+++ b/tests/client/test_proxies.py
@@ -67,38 +67,18 @@ PROXY_URL = "http://[::1]"
         ("http://example.com", {"https": PROXY_URL}, None),
         ("http://example.com", {"http://example.net": PROXY_URL}, None),
         ("http://example.com:443", {"http://example.com": PROXY_URL}, None),
-        ("http://example.com", {"all": PROXY_URL}, PROXY_URL),
         ("http://example.com", {"http": PROXY_URL}, PROXY_URL),
-        ("http://example.com", {"all://example.com": PROXY_URL}, PROXY_URL),
-        ("http://example.com", {"all://example.com:80": PROXY_URL}, PROXY_URL),
         ("http://example.com", {"http://example.com": PROXY_URL}, PROXY_URL),
         ("http://example.com", {"http://example.com:80": PROXY_URL}, PROXY_URL),
         ("http://example.com:8080", {"http://example.com:8080": PROXY_URL}, PROXY_URL),
         ("http://example.com:8080", {"http://example.com": PROXY_URL}, None),
         (
             "http://example.com",
-            {
-                "all": PROXY_URL + ":1",
-                "http": PROXY_URL + ":2",
-                "all://example.com": PROXY_URL + ":3",
-                "http://example.com": PROXY_URL + ":4",
-            },
-            PROXY_URL + ":4",
-        ),
-        (
-            "http://example.com",
-            {
-                "all": PROXY_URL + ":1",
-                "http": PROXY_URL + ":2",
-                "all://example.com": PROXY_URL + ":3",
-            },
-            PROXY_URL + ":3",
-        ),
-        (
-            "http://example.com",
-            {"all": PROXY_URL + ":1", "http": PROXY_URL + ":2"},
+            {"http": PROXY_URL + ":1", "http://example.com": PROXY_URL + ":2"},
             PROXY_URL + ":2",
         ),
+        ("http://example.com", {"http": PROXY_URL + ":1"}, PROXY_URL + ":1"),
+        ("http://example.com", {"http": PROXY_URL + ":1"}, PROXY_URL + ":1"),
     ],
 )
 def test_transport_for_request(url, proxies, expected):


### PR DESCRIPTION
Prompted by https://github.com/encode/httpcore/issues/65#issuecomment-623392777

> I'd suggest that a good tack onto getting there would be to start with a PR to httpx that no longer uses the DEFAULT mode anywhere. That'd help us thrash out & review any implementation changes required in httpx, without actually changing any API in httpcore or httpx.

The `DEFAULT` proxy mode is used to signal httpcore's proxy connection pools to use forwarding or tunnelling based on the request URL.

However, `Client.dispatcher_for_url` uses `Client.proxies` to pick a dispatcher based on the request URL, at which point HTTPX is able to choose between one proxy mode or the other. The only case where we want to delay the decision to httpcore is when the user has specified a single proxy string or URL or an `all`-prefixed proxy config key in the `proxies` dict effectively indicating both the proxy should be used for both HTTP and HTTPS.

This PR removes the use of `all`-prefixed proxy config keys in `Client.proxies` expanding them into `http` and `https` keys and mapping them to separate `Proxy` instances with `FORWARD_ONLY` and `TUNNEL_ONLY` modes respectively.