### PR TITLE
Export more private modules

### DIFF
--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -27,6 +27,25 @@ from ._exceptions import (
 )
 from ._models import URL, Cookies, Headers, QueryParams, Request, Response
 from ._status_codes import StatusCode, codes
+from ._content_streams import (
+    ContentStream,
+    ByteStream,
+    IteratorStream,
+    AsyncIteratorStream,
+    JSONStream,
+    URLEncodedStream,
+    MultipartStream,
+)
+from ._types import (
+    CookieTypes,
+    HeaderTypes,
+    PrimitiveData,
+    QueryParamTypes,
+    RequestData,
+    RequestFiles,
+    URLTypes,
+)
+
 
 __all__ = [
     "__description__",
@@ -79,4 +98,18 @@ __all__ = [
     "Response",
     "DigestAuth",
     "WSGIDispatch",
+    "ContentStream",
+    "ByteStream",
+    "IteratorStream",
+    "AsyncIteratorStream",
+    "JSONStream",
+    "URLEncodedStream",
+    "MultipartStream",
+    "CookieTypes",
+    "HeaderTypes",
+    "PrimitiveData",
+    "QueryParamTypes",
+    "RequestData",
+    "RequestFiles",
+    "URLTypes",
 ]

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -15,8 +15,9 @@ from httpx import (
     Request,
     RequestBodyUnavailable,
     Response,
+    ContentStream,
+    JSONStream,
 )
-from httpx._content_streams import ContentStream, JSONStream
 
 
 def get_header_value(headers, key, default=None):

--- a/tests/client/test_cookies.py
+++ b/tests/client/test_cookies.py
@@ -5,7 +5,7 @@ import httpcore
 import pytest
 
 from httpx import AsyncClient, Cookies
-from httpx._content_streams import ByteStream, ContentStream, JSONStream
+from httpx import ByteStream, ContentStream, JSONStream
 
 
 def get_header_value(headers, key, default=None):

--- a/tests/client/test_headers.py
+++ b/tests/client/test_headers.py
@@ -6,7 +6,7 @@ import httpcore
 import pytest
 
 from httpx import AsyncClient, Headers, __version__
-from httpx._content_streams import ContentStream, JSONStream
+from httpx import ContentStream, JSONStream
 
 
 class MockDispatch(httpcore.AsyncHTTPTransport):

--- a/tests/client/test_queryparams.py
+++ b/tests/client/test_queryparams.py
@@ -4,7 +4,7 @@ import httpcore
 import pytest
 
 from httpx import URL, AsyncClient, Headers, QueryParams
-from httpx._content_streams import ContentStream, JSONStream
+from httpx import ContentStream, JSONStream
 
 
 class MockDispatch(httpcore.AsyncHTTPTransport):

--- a/tests/client/test_redirects.py
+++ b/tests/client/test_redirects.py
@@ -13,7 +13,7 @@ from httpx import (
     TooManyRedirects,
     codes,
 )
-from httpx._content_streams import AsyncIteratorStream, ByteStream, ContentStream
+from httpx import AsyncIteratorStream, ByteStream, ContentStream
 
 
 def get_header_value(headers, key, default=None):

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -5,7 +5,7 @@ from unittest import mock
 import pytest
 
 import httpx
-from httpx._content_streams import AsyncIteratorStream, IteratorStream
+from httpx import AsyncIteratorStream, IteratorStream
 
 REQUEST = httpx.Request("GET", "https://example.org")
 

--- a/tests/test_content_streams.py
+++ b/tests/test_content_streams.py
@@ -2,8 +2,8 @@ import io
 
 import pytest
 
-from httpx import StreamConsumed
-from httpx._content_streams import ContentStream, encode
+from httpx import StreamConsumed, ContentStream
+from httpx._content_streams import encode
 
 
 @pytest.mark.asyncio

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -4,7 +4,7 @@ import brotli
 import pytest
 
 import httpx
-from httpx._content_streams import AsyncIteratorStream
+from httpx import AsyncIteratorStream
 from httpx._decoders import (
     BrotliDecoder,
     DeflateDecoder,

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -9,7 +9,8 @@ import httpcore
 import pytest
 
 import httpx
-from httpx._content_streams import AsyncIteratorStream, encode
+from httpx import AsyncIteratorStream
+from httpx._content_streams import encode
 from httpx._utils import format_form_param
 
 


### PR DESCRIPTION
1. class in `_content_streams` are very useful, we should allow people to use them.
2. class in `_types` are helpful for type hint, they should be public to developers.

Related issues:

- https://github.com/lepture/authlib/pull/209
- https://github.com/lepture/authlib/pull/219