### PR TITLE
Tweak scheme handling in client

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -108,6 +108,13 @@ class BaseClient:
             return new_proxies
 
     @property
+    def accepted_schemes(self) -> typing.Collection[str]:
+        """
+        Collection of URL schemes the client will handle.
+        """
+        return ("http", "https")
+
+    @property
     def headers(self) -> Headers:
         """
         HTTP headers to include when sending requests.
@@ -588,8 +595,11 @@ class Client(BaseClient):
         allow_redirects: bool = True,
         timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
     ) -> Response:
-        if request.url.scheme not in ("http", "https"):
-            raise InvalidURL('URL scheme must be "http" or "https".')
+        if request.url.scheme not in self.accepted_schemes:
+            raise InvalidURL(
+                "URL scheme must be one of "
+                + " or ".join(map(repr, self.accepted_schemes))
+            )
 
         timeout = self.timeout if isinstance(timeout, UnsetType) else Timeout(timeout)
 

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -58,6 +58,9 @@ if typing.TYPE_CHECKING:  # pragma: no cover
     from ._dispatch.base import AsyncDispatcher  # noqa: F401
 
 
+_port_registry = {"https": 443, "http": 80}
+
+
 class URL:
     def __init__(
         self,
@@ -102,7 +105,7 @@ class URL:
     @property
     def authority(self) -> str:
         port_str = self._uri_reference.port
-        default_port_str = {"https": "443", "http": "80"}.get(self.scheme, "")
+        default_port_str = str(_port_registry.get(self.scheme, ""))
         if port_str is None or port_str == default_port_str:
             return self._uri_reference.host or ""
         return self._uri_reference.authority or ""
@@ -129,7 +132,7 @@ class URL:
     def port(self) -> int:
         port = self._uri_reference.port
         if port is None:
-            return {"https": 443, "http": 80}[self.scheme]
+            return _port_registry[self.scheme]
         return int(port)
 
     @property


### PR DESCRIPTION
Remove hardcoded expectation that a scheme must be either 'http' or 'https' in `BaseClient` and `URL` classes. This moves towards being able to write dispatch handlers that have specific handling for differently named http-like schemes.

New `BaseClient.accepted_schemes` property that gives the collection of schemes a client can handle.

Test coverage for InvalidURL exception on unsupported schemes.

Motivation for the change comes from some test porting to `httpx` - where I found two cases where the current expectations made adapting existing code difficult:

* Use of a `test:` scheme in unit tests for session handling.
* Use of `http+thing:` custom schemes that enable additional behaviours at the transport level.

It may be doing this above the level of `httpx` client is wiser, but this branch as proposed seems reasonably harmless. Whether the (currently private) registry added for `URL` port mappings should be exposed for additions can be a question for later.
