### PR TITLE
Add Request.content setter

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -644,6 +644,11 @@ class Request:
             raise RequestNotRead()
         return self._content
 
+    @content.setter
+    def content(self, value: bytes) -> None:
+        self._content = value
+        self.stream = ByteStream(self._content)
+
     def read(self) -> bytes:
         """
         Read and return the request content.


### PR DESCRIPTION
Continue solution for discussion here https://github.com/lepture/authlib/pull/209/files

cc @tomchristie your solution doesn't work, there is no `body` or `content` parameter in class `Request`. The only possible key could be `data=..` from my understanding of the Request class.
But it still has a problem, because in the Authlib case, if `rebuild_request` returns a new request instance, it would raise error when accessing `.content`, since the new request instance hasn't called `.read()` or `.aread()` yet.

If you don't want to export more modules #930, my suggestion is to add a setter for `.content`.