### PR TITLE
Version 0.13.0.dev2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.13.0.dev2 (May 12th, 2020)
+
+The 0.13.0.dev2 is a *pre-release* version. To install it, use `pip install httpx --pre`.
+
+### Added
+
+- Logging via HTTPCORE_LOG_LEVEL and HTTPX_LOG_LEVEL environment variables
+and TRACE level logging. (HTTPCore Pull #79)
+
+### Fixed
+
+- Reuse of connections on HTTP/2 in close concurrency situations. (HTTPCore Pull #81)
+
 ## 0.13.0.dev1 (May 6th, 2020)
 
 The 0.13.0.dev1 is a *pre-release* version. To install it, use `pip install httpx --pre`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and TRACE level logging. (HTTPCore Pull #79)
 ### Fixed
 
 - Reuse of connections on HTTP/2 in close concurrency situations. (HTTPCore Pull #81)
+- When using an `app=<ASGI app>` observe neater disconnect behaviour instead of sending empty body messages. (Pull #919)
 
 ## 0.13.0.dev1 (May 6th, 2020)
 

--- a/httpx/__version__.py
+++ b/httpx/__version__.py
@@ -1,3 +1,3 @@
 __title__ = "httpx"
 __description__ = "A next generation HTTP client, for Python 3."
-__version__ = "0.13.0.dev1"
+__version__ = "0.13.0.dev2"

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         "chardet==3.*",
         "idna==2.*",
         "rfc3986>=1.3,<2",
-        "httpcore>=0.8.3",
+        "httpcore>=0.8.4",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
## 0.13.0.dev2 (May 12th, 2020)

The 0.13.0.dev2 is a *pre-release* version. To install it, use `pip install httpx --pre`.

### Added

- Logging via HTTPCORE_LOG_LEVEL and HTTPX_LOG_LEVEL environment variables
and TRACE level logging. (HTTPCore Pull #79)

### Fixed

- Reuse of connections on HTTP/2 in close concurrency situations. (HTTPCore Pull #81)
- When using an `app=<ASGI app>` observe neater disconnect behaviour instead of sending empty body messages. (Pull #919)