### PR TITLE
Attempt to resolve test flakiness

### DIFF
--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -146,10 +146,3 @@ def test_merge_url():
 
     assert url.scheme == "https"
     assert url.is_ssl
-
-
-def test_elapsed_delay(server):
-    url = server.url.copy_with(path="/slow_response/100")
-    with httpx.Client() as client:
-        response = client.get(url)
-    assert response.elapsed.total_seconds() > 0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,12 +102,7 @@ async def hello_world(scope, receive, send):
 
 
 async def slow_response(scope, receive, send):
-    delay_ms_str: str = scope["path"].replace("/slow_response/", "")
-    try:
-        delay_ms = float(delay_ms_str)
-    except ValueError:
-        delay_ms = 100
-    await sleep(delay_ms / 1000.0)
+    await sleep(1.0)
     await send(
         {
             "type": "http.response.start",


### PR DESCRIPTION
Refs #943

* We've already got a test that ensures `response.elapsed > datetime.timedelta(0)`, so let's not try to enforce a "this should end up as more than one second" case.
* Let's bump the slow response default to a more reliably noticable 1 second delay.
