### PR TITLE
If `scripts/check` fails then prompt and autofix.

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -1,14 +1,24 @@
-#!/bin/sh -e
+#!/bin/sh
 
 export PREFIX=""
 if [ -d 'venv' ] ; then
     export PREFIX="venv/bin/"
 fi
 
-set -x
-
 if [ -z $GITHUB_ACTIONS ]; then
+    set +e
     scripts/check
+    while [ $? -ne 0 ]; do
+        read -p "Running 'scripts/check' failed. Do you want to run 'scripts/lint' now? " yn
+        case $yn in
+           [Yy]* ) :;;
+           * ) exit;;
+        esac
+        scripts/lint
+        scripts/check
+    done
 fi
+
+set -ex
 
 ${PREFIX}pytest $@

--- a/scripts/test
+++ b/scripts/test
@@ -9,7 +9,7 @@ if [ -z $GITHUB_ACTIONS ]; then
     set +e
     scripts/check
     while [ $? -ne 0 ]; do
-        read -p "Running 'scripts/check' failed. Do you want to run 'scripts/lint' now? [y/N]" yn
+        read -p "Running 'scripts/check' failed. Do you want to run 'scripts/lint' now? [y/N]  " yn
         case $yn in
            [Yy]* ) :;;
            * ) exit;;

--- a/scripts/test
+++ b/scripts/test
@@ -9,7 +9,7 @@ if [ -z $GITHUB_ACTIONS ]; then
     set +e
     scripts/check
     while [ $? -ne 0 ]; do
-        read -p "Running 'scripts/check' failed. Do you want to run 'scripts/lint' now? " yn
+        read -p "Running 'scripts/check' failed. Do you want to run 'scripts/lint' now? [y/N]" yn
         case $yn in
            [Yy]* ) :;;
            * ) exit;;


### PR DESCRIPTION
When running `scripts/test` locally, we check the return result of the linting checks.
If they fail then prompt the user, and optionally run `scripts/lint`, then re-run the checks.

We *might?* still want to consider dropping `scripts/lint` in favour of `scripts/check --fix` in order to keep the two sets of linting/fixup in the same script, but let's treat that separately if so.