### PR TITLE
Transport API

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -628,8 +628,8 @@ sending of the requests.
 
 These Transport objects must implement some methods from
 [`httpcore`'s API](https://www.encode.io/httpcore/api/), either
-`httpcore.AsyncHTTPTransport` if you're using the asynchronous `Client`, or
-`httpcore.SyncHTTPTransport` if you're using a synchronous one.
+`httpcore.AsyncHTTPTransport` if you're using `AsyncClient`, or
+`httpcore.SyncHTTPTransport` if you're using `Client`.
 
 Specifically you *MUST* implement `request`, and `close` or `aclose` depending
 on the type of client you're using.

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -626,14 +626,11 @@ HTTPX's `Client` also accepts a `transport` argument. This argument allows you
 to provide a custom Transport object that will be used to perform the actual
 sending of the requests.
 
-These Transport objects must implement at least one method from
-[`httpcore`'s API](https://www.encode.io/httpcore/api/), either
-`httpcore.AsyncHTTPTransport` if you're using `AsyncClient`, or
-`httpcore.SyncHTTPTransport` if you're using `Client`.
-
-Specifically you *MUST* implement `request`. If you need additional logic for
-closing the transport you can also implement `close` or `aclose` depending on
-the type of client you're using.
+A transport instance must implement the Transport API defined by
+[`httpcore`](https://www.encode.io/httpcore/api/). You
+should either subclass `httpcore.AsyncHTTPTransport` to implement a transport to
+use with `AsyncClient`, or subclass `httpcore.SyncHTTPTransport` to implement a
+transport to use with `Client`.
 
 For example, HTTPX ships with a transport that uses the excellent
 [`urllib3` library](https://urllib3.readthedocs.io/en/latest/):

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -639,8 +639,7 @@ For example, HTTPX ships with a transport that uses the excellent
 
 ```python
 >>> import httpx
->>> from httpx._dispatch.urllib3 import URLLib3Dispatcher
->>> client = httpx.Client(transport=URLLib3Dispatcher())
+>>> client = httpx.Client(transport=httpx.URLLib3Transport())
 >>> client.get("https://example.org")
 <Response [200 OK]>
 ```

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -619,3 +619,28 @@ If you do need to make HTTPS connections to a local server, for example to test 
 >>> r
 Response <200 OK>
 ```
+
+## Custom Transports
+
+HTTPX's `Client` also accepts a `transport` argument. This argument allows you
+to inject a custom Transport objects that will be used to perform the actual
+sending of the requests.
+
+These Transport objects must implement some methods from
+[`httpcore`'s API](https://www.encode.io/httpcore/api/), either
+`httpcore.AsyncHTTPTransport` if you're using the asynchronous `Client`, or
+`httpcore.SyncHTTPTransport` if you're using a synchronous one.
+
+Specifically you *MUST* implement `request`, and `close` or `aclose` depending
+on the type of client you're using.
+
+For example, HTTPX ships with a transport that uses the excellent
+[`urllib3` library](https://urllib3.readthedocs.io/en/latest/):
+
+```python
+>>> import httpx
+>>> from httpx._dispatch.urllib3 import URLLib3Dispatcher
+>>> client = httpx.Client(transport=URLLib3Dispatcher())
+>>> client.get("https://example.org")
+<Response [200 OK]>
+```

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -623,7 +623,7 @@ Response <200 OK>
 ## Custom Transports
 
 HTTPX's `Client` also accepts a `transport` argument. This argument allows you
-to inject a custom Transport objects that will be used to perform the actual
+to provide a custom Transport object that will be used to perform the actual
 sending of the requests.
 
 These Transport objects must implement some methods from

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -173,7 +173,7 @@ with httpx.Client(app=app, base_url="http://testserver") as client:
     assert r.text == "Hello World!"
 ```
 
-For some more complex cases you might need to customize the WSGI dispatch. This allows you to:
+For some more complex cases you might need to customize the WSGI transport. This allows you to:
 
 * Inspect 500 error responses rather than raise exceptions by setting `raise_app_exceptions=False`.
 * Mount the WSGI application at a subpath by setting `script_name` (WSGI).
@@ -183,8 +183,8 @@ For example:
 
 ```python
 # Instantiate a client that makes WSGI requests with a client IP of "1.2.3.4".
-dispatch = httpx.WSGIDispatch(app=app, remote_addr="1.2.3.4")
-with httpx.Client(dispatch=dispatch, base_url="http://testserver") as client:
+transport = httpx.WSGITransport(app=app, remote_addr="1.2.3.4")
+with httpx.Client(transport=transport, base_url="http://testserver") as client:
     ...
 ```
 

--- a/docs/async.md
+++ b/docs/async.md
@@ -165,7 +165,7 @@ We can make requests directly against the application, like so:
 ...     assert r.text == "Hello World!"
 ```
 
-For some more complex cases you might need to customise the ASGI dispatch. This allows you to:
+For some more complex cases you might need to customise the ASGI transport. This allows you to:
 
 * Inspect 500 error responses rather than raise exceptions by setting `raise_app_exceptions=False`.
 * Mount the ASGI application at a subpath by setting `root_path`.
@@ -176,8 +176,8 @@ For example:
 ```python
 # Instantiate a client that makes ASGI requests with a client IP of "1.2.3.4",
 # on port 123.
-dispatch = httpx.ASGIDispatch(app=app, client=("1.2.3.4", 123))
-async with httpx.AsyncClient(dispatch=dispatch, base_url="http://testserver") as client:
+transport = httpx.ASGITransport(app=app, client=("1.2.3.4", 123))
+async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
     ...
 ```
 

--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -3,8 +3,6 @@ from ._api import delete, get, head, options, patch, post, put, request, stream
 from ._auth import Auth, BasicAuth, DigestAuth
 from ._client import AsyncClient, Client
 from ._config import PoolLimits, Proxy, Timeout
-from ._transports.asgi import ASGIDispatch, ASGITransport
-from ._transports.wsgi import WSGIDispatch, WSGITransport
 from ._exceptions import (
     ConnectTimeout,
     CookieConflict,
@@ -27,6 +25,8 @@ from ._exceptions import (
 )
 from ._models import URL, Cookies, Headers, QueryParams, Request, Response
 from ._status_codes import StatusCode, codes
+from ._transports.asgi import ASGIDispatch, ASGITransport
+from ._transports.wsgi import WSGIDispatch, WSGITransport
 
 __all__ = [
     "__description__",

--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -3,8 +3,8 @@ from ._api import delete, get, head, options, patch, post, put, request, stream
 from ._auth import Auth, BasicAuth, DigestAuth
 from ._client import AsyncClient, Client
 from ._config import PoolLimits, Proxy, Timeout
-from ._dispatch.asgi import ASGIDispatch
-from ._dispatch.wsgi import WSGIDispatch
+from ._transports.asgi import ASGIDispatch, ASGITransport
+from ._transports.wsgi import WSGIDispatch, WSGITransport
 from ._exceptions import (
     ConnectTimeout,
     CookieConflict,
@@ -44,6 +44,7 @@ __all__ = [
     "stream",
     "codes",
     "ASGIDispatch",
+    "ASGITransport",
     "AsyncClient",
     "Auth",
     "BasicAuth",
@@ -79,4 +80,5 @@ __all__ = [
     "Response",
     "DigestAuth",
     "WSGIDispatch",
+    "WSGITransport",
 ]

--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -26,8 +26,8 @@ from ._exceptions import (
 from ._models import URL, Cookies, Headers, QueryParams, Request, Response
 from ._status_codes import StatusCode, codes
 from ._transports.asgi import ASGIDispatch, ASGITransport
-from ._transports.wsgi import WSGIDispatch, WSGITransport
 from ._transports.urllib3 import URLLib3Transport
+from ._transports.wsgi import WSGIDispatch, WSGITransport
 
 __all__ = [
     "__description__",

--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -27,6 +27,7 @@ from ._models import URL, Cookies, Headers, QueryParams, Request, Response
 from ._status_codes import StatusCode, codes
 from ._transports.asgi import ASGIDispatch, ASGITransport
 from ._transports.wsgi import WSGIDispatch, WSGITransport
+from ._transports.urllib3 import URLLib3Transport
 
 __all__ = [
     "__description__",
@@ -72,6 +73,7 @@ __all__ = [
     "TooManyRedirects",
     "WriteTimeout",
     "URL",
+    "URLLib3Transport",
     "StatusCode",
     "Cookies",
     "Headers",

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -461,23 +461,24 @@ class Client(BaseClient):
 
         proxy_map = self.get_proxy_map(proxies, trust_env)
 
-        if transport is None and dispatch is not None:
+        if dispatch is not None:
             warnings.warn(
                 "The dispatch argument is deprecated since v0.13 and will be "
                 "removed in a future release, please use 'transport'"
             )
-            transport = dispatch
+            if transport is None:
+                transport = dispatch
 
         self.transport = self.init_transport(
             verify=verify,
             cert=cert,
             pool_limits=pool_limits,
-            dispatch=transport,
+            transport=transport,
             app=app,
             trust_env=trust_env,
         )
         self.proxies: typing.Dict[str, httpcore.SyncHTTPTransport] = {
-            key: self.init_proxy_dispatch(
+            key: self.init_proxy_transport(
                 proxy,
                 verify=verify,
                 cert=cert,
@@ -492,12 +493,12 @@ class Client(BaseClient):
         verify: VerifyTypes = True,
         cert: CertTypes = None,
         pool_limits: PoolLimits = DEFAULT_POOL_LIMITS,
-        dispatch: httpcore.SyncHTTPTransport = None,
+        transport: httpcore.SyncHTTPTransport = None,
         app: typing.Callable = None,
         trust_env: bool = True,
     ) -> httpcore.SyncHTTPTransport:
-        if dispatch is not None:
-            return dispatch
+        if transport is not None:
+            return transport
 
         if app is not None:
             return WSGIDispatch(app=app)
@@ -514,7 +515,7 @@ class Client(BaseClient):
             max_connections=max_connections,
         )
 
-    def init_proxy_dispatch(
+    def init_proxy_transport(
         self,
         proxy: Proxy,
         verify: VerifyTypes = True,
@@ -1003,12 +1004,13 @@ class AsyncClient(BaseClient):
             trust_env=trust_env,
         )
 
-        if transport is None and dispatch is not None:
+        if dispatch is not None:
             warnings.warn(
                 "The dispatch argument is deprecated since v0.13 and will be "
                 "removed in a future release, please use 'transport'"
             )
-            transport = dispatch
+            if transport is None:
+                transport = dispatch
 
         proxy_map = self.get_proxy_map(proxies, trust_env)
 
@@ -1017,12 +1019,12 @@ class AsyncClient(BaseClient):
             cert=cert,
             http2=http2,
             pool_limits=pool_limits,
-            dispatch=dispatch,
+            transport=transport,
             app=app,
             trust_env=trust_env,
         )
         self.proxies: typing.Dict[str, httpcore.AsyncHTTPTransport] = {
-            key: self.init_proxy_dispatch(
+            key: self.init_proxy_transport(
                 proxy,
                 verify=verify,
                 cert=cert,
@@ -1039,12 +1041,12 @@ class AsyncClient(BaseClient):
         cert: CertTypes = None,
         http2: bool = False,
         pool_limits: PoolLimits = DEFAULT_POOL_LIMITS,
-        dispatch: httpcore.AsyncHTTPTransport = None,
+        transport: httpcore.AsyncHTTPTransport = None,
         app: typing.Callable = None,
         trust_env: bool = True,
     ) -> httpcore.AsyncHTTPTransport:
-        if dispatch is not None:
-            return dispatch
+        if transport is not None:
+            return transport
 
         if app is not None:
             return ASGIDispatch(app=app)
@@ -1062,7 +1064,7 @@ class AsyncClient(BaseClient):
             http2=http2,
         )
 
-    def init_proxy_dispatch(
+    def init_proxy_transport(
         self,
         proxy: Proxy,
         verify: VerifyTypes = True,

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -19,8 +19,8 @@ from ._config import (
     UnsetType,
 )
 from ._content_streams import ContentStream
-from ._dispatch.asgi import ASGIDispatch
-from ._dispatch.wsgi import WSGIDispatch
+from ._transports.asgi import ASGITransport
+from ._transports.wsgi import WSGITransport
 from ._exceptions import HTTPError, InvalidURL, RequestBodyUnavailable, TooManyRedirects
 from ._models import URL, Cookies, Headers, Origin, QueryParams, Request, Response
 from ._status_codes import codes
@@ -501,7 +501,7 @@ class Client(BaseClient):
             return transport
 
         if app is not None:
-            return WSGIDispatch(app=app)
+            return WSGITransport(app=app)
 
         ssl_context = SSLConfig(
             verify=verify, cert=cert, trust_env=trust_env
@@ -1049,7 +1049,7 @@ class AsyncClient(BaseClient):
             return transport
 
         if app is not None:
-            return ASGIDispatch(app=app)
+            return ASGITransport(app=app)
 
         ssl_context = SSLConfig(
             verify=verify, cert=cert, trust_env=trust_env

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -421,8 +421,6 @@ class Client(BaseClient):
     * **transport** - *(optional)* A transport class to use for sending requests
     over the network.
     * **dispatch** - *(optional)* A deprecated alias for transport.
-    * **transport** - *(optional)* A transport class to use for sending requests
-    over the network.
     * **app** - *(optional)* An WSGI application to send requests to,
     rather than sending actual network requests.
     * **trust_env** - *(optional)* Enables or disables usage of environment
@@ -962,8 +960,6 @@ class AsyncClient(BaseClient):
     that should be followed.
     * **base_url** - *(optional)* A URL to use as the base when building
     request URLs.
-    * **dispatch** - *(optional)* A dispatch class to use for sending requests
-    over the network.
     * **transport** - *(optional)* A transport class to use for sending requests
     over the network.
     * **dispatch** - *(optional)* A deprecated alias for transport.
@@ -988,8 +984,8 @@ class AsyncClient(BaseClient):
         pool_limits: PoolLimits = DEFAULT_POOL_LIMITS,
         max_redirects: int = DEFAULT_MAX_REDIRECTS,
         base_url: URLTypes = None,
-        dispatch: httpcore.AsyncHTTPTransport = None,
         transport: httpcore.AsyncHTTPTransport = None,
+        dispatch: httpcore.AsyncHTTPTransport = None,
         app: typing.Callable = None,
         trust_env: bool = True,
     ):

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -462,7 +462,8 @@ class Client(BaseClient):
         if dispatch is not None:
             warnings.warn(
                 "The dispatch argument is deprecated since v0.13 and will be "
-                "removed in a future release, please use 'transport'"
+                "removed in a future release, please use 'transport'",
+                DeprecationWarning,
             )
             if transport is None:
                 transport = dispatch
@@ -1003,7 +1004,8 @@ class AsyncClient(BaseClient):
         if dispatch is not None:
             warnings.warn(
                 "The dispatch argument is deprecated since v0.13 and will be "
-                "removed in a future release, please use 'transport'"
+                "removed in a future release, please use 'transport'",
+                DeprecationWarning,
             )
             if transport is None:
                 transport = dispatch

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -19,11 +19,11 @@ from ._config import (
     UnsetType,
 )
 from ._content_streams import ContentStream
-from ._transports.asgi import ASGITransport
-from ._transports.wsgi import WSGITransport
 from ._exceptions import HTTPError, InvalidURL, RequestBodyUnavailable, TooManyRedirects
 from ._models import URL, Cookies, Headers, Origin, QueryParams, Request, Response
 from ._status_codes import codes
+from ._transports.asgi import ASGITransport
+from ._transports.wsgi import WSGITransport
 from ._types import (
     AuthTypes,
     CertTypes,

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -1,6 +1,5 @@
 import functools
 import typing
-import warnings
 from types import TracebackType
 
 import hstspreload
@@ -42,6 +41,7 @@ from ._utils import (
     get_environment_proxies,
     get_logger,
     should_not_be_proxied,
+    warn_deprecated,
 )
 
 logger = get_logger(__name__)
@@ -460,10 +460,9 @@ class Client(BaseClient):
         proxy_map = self.get_proxy_map(proxies, trust_env)
 
         if dispatch is not None:
-            warnings.warn(
+            warn_deprecated(
                 "The dispatch argument is deprecated since v0.13 and will be "
-                "removed in a future release, please use 'transport'",
-                DeprecationWarning,
+                "removed in a future release, please use 'transport'"
             )
             if transport is None:
                 transport = dispatch
@@ -1002,10 +1001,9 @@ class AsyncClient(BaseClient):
         )
 
         if dispatch is not None:
-            warnings.warn(
+            warn_deprecated(
                 "The dispatch argument is deprecated since v0.13 and will be "
                 "removed in a future release, please use 'transport'",
-                DeprecationWarning,
             )
             if transport is None:
                 transport = dispatch

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -4,7 +4,6 @@ import email.message
 import json as jsonlib
 import typing
 import urllib.request
-import warnings
 from collections.abc import MutableMapping
 from http.cookiejar import Cookie, CookieJar
 from urllib.parse import parse_qsl, urlencode
@@ -52,6 +51,7 @@ from ._utils import (
     obfuscate_sensitive_headers,
     parse_header_links,
     str_query_param,
+    warn_deprecated,
 )
 
 if typing.TYPE_CHECKING:  # pragma: no cover
@@ -874,19 +874,17 @@ class Response:
 
     @property
     def stream(self):  # type: ignore
-        warnings.warn(  # pragma: nocover
+        warn_deprecated(  # pragma: nocover
             "Response.stream() is due to be deprecated. "
             "Use Response.aiter_bytes() instead.",
-            DeprecationWarning,
         )
         return self.aiter_bytes  # pragma: nocover
 
     @property
     def raw(self):  # type: ignore
-        warnings.warn(  # pragma: nocover
+        warn_deprecated(  # pragma: nocover
             "Response.raw() is due to be deprecated. "
             "Use Response.aiter_raw() instead.",
-            DeprecationWarning,
         )
         return self.aiter_raw  # pragma: nocover
 

--- a/httpx/_transports/asgi.py
+++ b/httpx/_transports/asgi.py
@@ -1,5 +1,6 @@
 import typing
 from typing import Callable, Dict, List, Optional, Tuple
+import warnings
 
 import httpcore
 import sniffio
@@ -24,9 +25,9 @@ def create_event() -> "Event":
         return asyncio.Event()
 
 
-class ASGIDispatch(httpcore.AsyncHTTPTransport):
+class ASGITransport(httpcore.AsyncHTTPTransport):
     """
-    A custom AsyncDispatcher that handles sending requests directly to an ASGI app.
+    A custom AsyncTransport that handles sending requests directly to an ASGI app.
     The simplest way to use this functionality is to use the `app` argument.
 
     ```
@@ -35,10 +36,10 @@ class ASGIDispatch(httpcore.AsyncHTTPTransport):
 
     Alternatively, you can setup the dispatch instance explicitly.
     This allows you to include any additional configuration arguments specific
-    to the ASGIDispatch class:
+    to the ASGITransport class:
 
     ```
-    dispatch = httpx.ASGIDispatch(
+    dispatch = httpx.ASGITransport(
         app=app,
         root_path="/submount",
         client=("1.2.3.4", 123)
@@ -153,3 +154,20 @@ class ASGIDispatch(httpcore.AsyncHTTPTransport):
         stream = ByteStream(b"".join(body_parts))
 
         return (b"HTTP/1.1", status_code, b"", response_headers, stream)
+
+
+class ASGIDispatch(ASGITransport):
+    def __init__(
+        self,
+        app: Callable,
+        raise_app_exceptions: bool = True,
+        root_path: str = "",
+        client: Tuple[str, int] = ("127.0.0.1", 123),
+    ) -> None:
+        warnings.warn("ASGIDispatch is deprecated, please use ASGITransport")
+        super().__init__(
+            app=app,
+            raise_app_exceptions=raise_app_exceptions,
+            root_path=root_path,
+            client=client,
+        )

--- a/httpx/_transports/asgi.py
+++ b/httpx/_transports/asgi.py
@@ -1,11 +1,11 @@
 import typing
-import warnings
 from typing import Callable, Dict, List, Optional, Tuple
 
 import httpcore
 import sniffio
 
 from .._content_streams import ByteStream
+from .._utils import warn_deprecated
 
 if typing.TYPE_CHECKING:  # pragma: no cover
     import asyncio
@@ -164,7 +164,7 @@ class ASGIDispatch(ASGITransport):
         root_path: str = "",
         client: Tuple[str, int] = ("127.0.0.1", 123),
     ) -> None:
-        warnings.warn("ASGIDispatch is deprecated, please use ASGITransport")
+        warn_deprecated("ASGIDispatch is deprecated, please use ASGITransport")
         super().__init__(
             app=app,
             raise_app_exceptions=raise_app_exceptions,

--- a/httpx/_transports/asgi.py
+++ b/httpx/_transports/asgi.py
@@ -1,6 +1,6 @@
 import typing
-from typing import Callable, Dict, List, Optional, Tuple
 import warnings
+from typing import Callable, Dict, List, Optional, Tuple
 
 import httpcore
 import sniffio

--- a/httpx/_transports/urllib3.py
+++ b/httpx/_transports/urllib3.py
@@ -1,8 +1,8 @@
 import math
 import socket
 import ssl
-from typing import Dict, Iterator, List, Optional, Tuple, Union
 import warnings
+from typing import Dict, Iterator, List, Optional, Tuple, Union
 
 import httpcore
 import urllib3

--- a/httpx/_transports/urllib3.py
+++ b/httpx/_transports/urllib3.py
@@ -5,13 +5,17 @@ import warnings
 from typing import Dict, Iterator, List, Optional, Tuple, Union
 
 import httpcore
-import urllib3
-from urllib3.exceptions import MaxRetryError, SSLError
 
 from .._config import DEFAULT_POOL_LIMITS, PoolLimits, Proxy, SSLConfig
 from .._content_streams import ByteStream, IteratorStream
 from .._types import CertTypes, VerifyTypes
 from .._utils import as_network_error
+
+try:
+    import urllib3
+    from urllib3.exceptions import MaxRetryError, SSLError
+except ImportError:  # pragma: nocover
+    urllib3 = None
 
 
 class URLLib3Transport(httpcore.SyncHTTPTransport):
@@ -24,6 +28,10 @@ class URLLib3Transport(httpcore.SyncHTTPTransport):
         trust_env: bool = None,
         pool_limits: PoolLimits = DEFAULT_POOL_LIMITS,
     ):
+        assert (
+            urllib3 is not None
+        ), "urllib3 must be installed separately in order to use URLLib3Transport"
+
         ssl_config = SSLConfig(
             verify=verify, cert=cert, trust_env=trust_env, http2=False
         )

--- a/httpx/_transports/urllib3.py
+++ b/httpx/_transports/urllib3.py
@@ -1,7 +1,6 @@
 import math
 import socket
 import ssl
-import warnings
 from typing import Dict, Iterator, List, Optional, Tuple, Union
 
 import httpcore
@@ -9,7 +8,7 @@ import httpcore
 from .._config import DEFAULT_POOL_LIMITS, PoolLimits, Proxy, SSLConfig
 from .._content_streams import ByteStream, IteratorStream
 from .._types import CertTypes, VerifyTypes
-from .._utils import as_network_error
+from .._utils import as_network_error, warn_deprecated
 
 try:
     import urllib3
@@ -174,7 +173,7 @@ class URLLib3Dispatch(URLLib3Transport):
         trust_env: bool = None,
         pool_limits: PoolLimits = DEFAULT_POOL_LIMITS,
     ):
-        warnings.warn("URLLib3Dispatch is deprecated, please use URLLib3Transport")
+        warn_deprecated("URLLib3Dispatch is deprecated, please use URLLib3Transport")
         super().__init__(
             proxy=proxy,
             verify=verify,

--- a/httpx/_transports/urllib3.py
+++ b/httpx/_transports/urllib3.py
@@ -2,6 +2,7 @@ import math
 import socket
 import ssl
 from typing import Dict, Iterator, List, Optional, Tuple, Union
+import warnings
 
 import httpcore
 import urllib3
@@ -13,7 +14,7 @@ from .._types import CertTypes, VerifyTypes
 from .._utils import as_network_error
 
 
-class URLLib3Dispatcher(httpcore.SyncHTTPTransport):
+class URLLib3Transport(httpcore.SyncHTTPTransport):
     def __init__(
         self,
         *,
@@ -153,3 +154,23 @@ class URLLib3Dispatcher(httpcore.SyncHTTPTransport):
 
     def close(self) -> None:
         self.pool.clear()
+
+
+class URLLib3Dispatch(URLLib3Transport):
+    def __init__(
+        self,
+        *,
+        proxy: Proxy = None,
+        verify: VerifyTypes = True,
+        cert: CertTypes = None,
+        trust_env: bool = None,
+        pool_limits: PoolLimits = DEFAULT_POOL_LIMITS,
+    ):
+        warnings.warn("URLLib3Dispatch is deprecated, please use URLLib3Transport")
+        super().__init__(
+            proxy=proxy,
+            verify=verify,
+            cert=cert,
+            trust_env=trust_env,
+            pool_limits=pool_limits,
+        )

--- a/httpx/_transports/wsgi.py
+++ b/httpx/_transports/wsgi.py
@@ -1,6 +1,7 @@
 import io
 import itertools
 import typing
+import warnings
 
 import httpcore
 
@@ -15,7 +16,7 @@ def _skip_leading_empty_chunks(body: typing.Iterable) -> typing.Iterable:
     return []
 
 
-class WSGIDispatch(httpcore.SyncHTTPTransport):
+class WSGITransport(httpcore.SyncHTTPTransport):
     """
     A custom transport that handles sending requests directly to an WSGI app.
     The simplest way to use this functionality is to use the `app` argument.
@@ -26,10 +27,10 @@ class WSGIDispatch(httpcore.SyncHTTPTransport):
 
     Alternatively, you can setup the dispatch instance explicitly.
     This allows you to include any additional configuration arguments specific
-    to the WSGIDispatch class:
+    to the WSGITransport class:
 
     ```
-    dispatch = httpx.WSGIDispatch(
+    dispatch = httpx.WSGITransport(
         app=app,
         script_name="/submount",
         remote_addr="1.2.3.4"
@@ -131,3 +132,20 @@ class WSGIDispatch(httpcore.SyncHTTPTransport):
         stream = IteratorStream(chunk for chunk in result)
 
         return (b"HTTP/1.1", status_code, b"", headers, stream)
+
+
+class WSGIDispatch(WSGITransport):
+    def __init__(
+        self,
+        app: typing.Callable,
+        raise_app_exceptions: bool = True,
+        script_name: str = "",
+        remote_addr: str = "127.0.0.1",
+    ) -> None:
+        warnings.warn("WSGIDispatch is deprecated, please use WSGITransport")
+        super().__init__(
+            app=app,
+            raise_app_exceptions=raise_app_exceptions,
+            script_name=script_name,
+            remote_addr=remote_addr,
+        )

--- a/httpx/_transports/wsgi.py
+++ b/httpx/_transports/wsgi.py
@@ -1,11 +1,11 @@
 import io
 import itertools
 import typing
-import warnings
 
 import httpcore
 
 from .._content_streams import ByteStream, IteratorStream
+from .._utils import warn_deprecated
 
 
 def _skip_leading_empty_chunks(body: typing.Iterable) -> typing.Iterable:
@@ -142,7 +142,7 @@ class WSGIDispatch(WSGITransport):
         script_name: str = "",
         remote_addr: str = "127.0.0.1",
     ) -> None:
-        warnings.warn("WSGIDispatch is deprecated, please use WSGITransport")
+        warn_deprecated("WSGIDispatch is deprecated, please use WSGITransport")
         super().__init__(
             app=app,
             raise_app_exceptions=raise_app_exceptions,

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -8,6 +8,7 @@ import os
 import re
 import sys
 import typing
+import warnings
 from datetime import timedelta
 from pathlib import Path
 from time import perf_counter
@@ -400,3 +401,7 @@ def as_network_error(*exception_classes: type) -> typing.Iterator[None]:
             if isinstance(exc, cls):
                 raise NetworkError(exc) from exc
         raise
+
+
+def warn_deprecated(message: str) -> None:
+    warnings.warn(message, DeprecationWarning)

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -484,7 +484,7 @@ async def test_digest_auth_unavailable_streaming_body():
     client = AsyncClient(dispatch=MockDispatch())
 
     async def streaming_body():
-        yield b"Example request body"
+        yield b"Example request body"  # pragma: nocover
 
     with pytest.raises(RequestBodyUnavailable):
         await client.post(url, data=streaming_body(), auth=auth)

--- a/tests/client/test_proxies.py
+++ b/tests/client/test_proxies.py
@@ -74,14 +74,14 @@ PROXY_URL = "http://[::1]"
         ),
     ],
 )
-def test_dispatcher_for_request(url, proxies, expected):
+def test_transport_for_request(url, proxies, expected):
     client = httpx.AsyncClient(proxies=proxies)
-    dispatcher = client.dispatcher_for_url(httpx.URL(url))
+    transport = client.transport_for_url(httpx.URL(url))
 
     if expected is None:
-        assert dispatcher is client.dispatch
+        assert transport is client.transport
     else:
-        assert dispatcher.proxy_origin == httpx.URL(expected).raw[:3]
+        assert transport.proxy_origin == httpx.URL(expected).raw[:3]
 
 
 def test_unsupported_proxy_scheme():
@@ -110,9 +110,9 @@ def test_proxies_environ(monkeypatch, url, env, expected):
         monkeypatch.setenv(name, value)
 
     client = httpx.AsyncClient()
-    dispatcher = client.dispatcher_for_url(httpx.URL(url))
+    transport = client.transport_for_url(httpx.URL(url))
 
     if expected is None:
-        assert dispatcher == client.dispatch
+        assert transport == client.transport
     else:
-        assert dispatcher.proxy_origin == httpx.URL(expected).raw[:3]
+        assert transport.proxy_origin == httpx.URL(expected).raw[:3]


### PR DESCRIPTION
Closes https://github.com/encode/httpx/issues/768

~I did some `dispatch > transport` renaming but did not rename the `_dispatch` package and the `*Dispatch` classes in it. I considered renaming the package to `_transports` and all classes to `*Transport` with `*Dispatch` aliases but thought it might be better to check first.~

Edit: Pipelines failed for some reason so I went for it while I gave GH actions some time to sort themselves out.