### PR TITLE
Use URLLib3 configuration options for URLLib3 transport

### DIFF
--- a/httpx/_transports/urllib3.py
+++ b/httpx/_transports/urllib3.py
@@ -25,7 +25,9 @@ class URLLib3Transport(httpcore.SyncHTTPTransport):
         verify: VerifyTypes = True,
         cert: CertTypes = None,
         trust_env: bool = None,
-        pool_limits: PoolLimits = DEFAULT_POOL_LIMITS,
+        pool_connections: int = 10,
+        pool_maxsize: int = 10,
+        pool_block: bool = False,
     ):
         assert (
             urllib3 is not None
@@ -55,34 +57,34 @@ class URLLib3Transport(httpcore.SyncHTTPTransport):
         self.pool = self.init_pool_manager(
             proxy=proxy,
             ssl_context=ssl_config.ssl_context,
-            num_pools=num_pools,
-            maxsize=maxsize,
-            block=block,
+            pool_connections=pool_connections,
+            pool_maxsize=pool_maxsize,
+            pool_block=pool_block,
         )
 
     def init_pool_manager(
         self,
         proxy: Optional[Proxy],
         ssl_context: ssl.SSLContext,
-        num_pools: int,
-        maxsize: int,
-        block: bool,
+        pool_connections: int,
+        pool_maxsize: int,
+        pool_block: bool,
     ) -> Union[urllib3.PoolManager, urllib3.ProxyManager]:
         if proxy is None:
             return urllib3.PoolManager(
                 ssl_context=ssl_context,
-                num_pools=num_pools,
-                maxsize=maxsize,
-                block=block,
+                num_pools=pool_connections,
+                maxsize=pool_maxsize,
+                block=pool_block,
             )
         else:
             return urllib3.ProxyManager(
                 proxy_url=str(proxy.url),
                 proxy_headers=dict(proxy.headers),
                 ssl_context=ssl_context,
-                num_pools=num_pools,
-                maxsize=maxsize,
-                block=block,
+                num_pools=pool_connections,
+                maxsize=pool_maxsize,
+                block=pool_block,
             )
 
     def request(


### PR DESCRIPTION
Refs #966

Instead of using `pool_limits` with `URLLib3Transport` this PR switches us to instead using their native pool limiting configuration options. I've taken the external naming and defaults in line with how `requests` adapter classes use `urllib3`.

One other thing we could consider here is if we'd like the external interface to be `URLLib3Transport` and `URLLib3ProxyTransport` for symmetry with the `httpcore` classes, and with the `urllib3` interface itself, bu t let's consider that independently.