### PR TITLE
Version 0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and TRACE level logging. (Pull encode/httpcore#79)
 * Fix support for generator based WSGI apps. (Pull #887)
 * Reuse of connections on HTTP/2 in close concurrency situations. (Pull encode/httpcore#81)
 * Honor HTTP/2 max concurrent streams settings (Pull encode/httpcore#89, encode/httpcore#90)
+* Fix bytes support in multipart uploads. (Pull #974)
+* Improve typing support for `files=...`. (Pull #976)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,58 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.13.0 (May 22nd, 2020)
+
+This release switches to `httpcore` for all the internal networking, which means:
+
+* We're using the same codebase for both our sync and async clients.
+* HTTP/2 support is now available with the sync client.
+* We no longer have a `urllib3` dependency for our sync client, although there is still an *optional* `URLLib3Transport` class.
+
+It also means we've had to remove our UDS support, since maintaining that would have meant having to push back our work towards a 1.0 release, which isn't a trade-off we wanted to make.
+
+We also now have [a public "Transport API"](https://www.python-httpx.org/advanced/#custom-transports),
+which you can use to implement custom transport implementations against. This formalises
+and replaces our previously private "Dispatch API".
+
+### Changed
+
+* Use `httpcore` for underlying HTTP transport. Drop `urllib3` requirement. (Pull #804, #967)
+* Rename pool limit options from `soft_limit`/`hard_limit` to `max_keepalive`/`max_connections`. (Pull #968)
+* The privious private "Dispatch API" has now been promoted to a public "Transport API". (Pull #963)
+
+### Added
+
+* Added `URLLib3Transport` class for optional `urllib3` transport support. (Pull #804, #963)
+* Streaming multipart uploads. (Pull #857)
+* Logging via HTTPCORE_LOG_LEVEL and HTTPX_LOG_LEVEL environment variables
+and TRACE level logging. (Pull encode/httpcore#79)
+
+### Fixed
+
+* Performance improvement in brotli decoder. (Pull #906)
+* Proper warning level of deprecation notice in `Response.stream` and `Response.raw`. (Pull #908)
+* Fix support for generator based WSGI apps. (Pull #887)
+* Reuse of connections on HTTP/2 in close concurrency situations. (Pull encode/httpcore#81)
+* Honor HTTP/2 max concurrent streams settings (Pull encode/httpcore#89, encode/httpcore#90)
+
+### Removed
+
+* Dropped support for `Client(uds=...)` (Pull #804)
+
 ## 0.13.0.dev2 (May 12th, 2020)
 
 The 0.13.0.dev2 is a *pre-release* version. To install it, use `pip install httpx --pre`.
 
 ### Added
 
-- Logging via HTTPCORE_LOG_LEVEL and HTTPX_LOG_LEVEL environment variables
+* Logging via HTTPCORE_LOG_LEVEL and HTTPX_LOG_LEVEL environment variables
 and TRACE level logging. (HTTPCore Pull #79)
 
 ### Fixed
 
-- Reuse of connections on HTTP/2 in close concurrency situations. (HTTPCore Pull #81)
-- When using an `app=<ASGI app>` observe neater disconnect behaviour instead of sending empty body messages. (Pull #919)
+* Reuse of connections on HTTP/2 in close concurrency situations. (HTTPCore Pull #81)
+* When using an `app=<ASGI app>` observe neater disconnect behaviour instead of sending empty body messages. (Pull #919)
 
 ## 0.13.0.dev1 (May 6th, 2020)
 
@@ -24,8 +63,8 @@ The 0.13.0.dev1 is a *pre-release* version. To install it, use `pip install http
 
 ### Fixed
 
-- Passing `http2` flag to proxy dispatchers. (Pull #934)
-- Use [`httpcore` v0.8.3](https://github.com/encode/httpcore/releases/tag/0.8.3)
+* Passing `http2` flag to proxy dispatchers. (Pull #934)
+* Use [`httpcore` v0.8.3](https://github.com/encode/httpcore/releases/tag/0.8.3)
 which addresses problems in handling of headers when using proxies.
 
 ## 0.13.0.dev0 (April 30th, 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,7 @@ This release switches to `httpcore` for all the internal networking, which means
 
 It also means we've had to remove our UDS support, since maintaining that would have meant having to push back our work towards a 1.0 release, which isn't a trade-off we wanted to make.
 
-We also now have [a public "Transport API"](https://www.python-httpx.org/advanced/#custom-transports),
-which you can use to implement custom transport implementations against. This formalises
-and replaces our previously private "Dispatch API".
+We also now have [a public "Transport API"](https://www.python-httpx.org/advanced/#custom-transports), which you can use to implement custom transport implementations against. This formalises and replaces our previously private "Dispatch API".
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ We also now have [a public "Transport API"](https://www.python-httpx.org/advance
 
 * Use `httpcore` for underlying HTTP transport. Drop `urllib3` requirement. (Pull #804, #967)
 * Rename pool limit options from `soft_limit`/`hard_limit` to `max_keepalive`/`max_connections`. (Pull #968)
-* The privious private "Dispatch API" has now been promoted to a public "Transport API". (Pull #963)
+* The previous private "Dispatch API" has now been promoted to a public "Transport API". When customizing the transport use `transport=...`. The `ASGIDispatch` and `WSGIDispatch` class naming is deprecated in favour of `ASGITransport` and `WSGITransport`. (Pull #963)
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 HTTPX is a fully featured HTTP client for Python 3, which provides sync and async APIs, and support for both HTTP/1.1 and HTTP/2.
 
 **Note**: _HTTPX should be considered in beta. We believe we've got the public API to
-a stable point now, but would strongly recommend pinning your dependencies to the `0.12.*`
+a stable point now, but would strongly recommend pinning your dependencies to the `0.13.*`
 release, so that you're able to properly review [API changes between package updates](https://github.com/encode/httpx/blob/master/CHANGELOG.md). A 1.0 release is expected to be issued sometime around mid-2020._
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ HTTPX is a fully featured HTTP client for Python 3, which provides sync and asyn
 !!! note
     HTTPX should currently be considered in beta.
 
-    We believe we've got the public API to a stable point now, but would strongly recommend pinning your dependencies to the `0.12.*` release, so that you're able to properly review [API changes between package updates](https://github.com/encode/httpx/blob/master/CHANGELOG.md).
+    We believe we've got the public API to a stable point now, but would strongly recommend pinning your dependencies to the `0.13.*` release, so that you're able to properly review [API changes between package updates](https://github.com/encode/httpx/blob/master/CHANGELOG.md).
 
     A 1.0 release is expected to be issued sometime around mid-2020.
 

--- a/httpx/__version__.py
+++ b/httpx/__version__.py
@@ -1,3 +1,3 @@
 __title__ = "httpx"
 __description__ = "A next generation HTTP client, for Python 3."
-__version__ = "0.13.0.dev2"
+__version__ = "0.13.0"


### PR DESCRIPTION
Preliminary CHANGELOG and `__version__` update for 0.13.

Still required...

- Review if we want #970. (Use urllib3 native config for `URLLib3Transport` pooling options)
- Review if we want the second half of #966. (Use seperated `URLLib3Transport` and `URLLib3ProxyTransport` classes as the public API)

Up for reviews onto this in the meantime tho...

---

## 0.13.0 (May 22nd, 2020)

This release switches to `httpcore` for all the internal networking, which means:

* We're using the same codebase for both our sync and async clients.
* HTTP/2 support is now available with the sync client.
* We no longer have a `urllib3` dependency for our sync client, although there is still an *optional* `URLLib3Transport` class.

It also means we've had to remove our UDS support, since maintaining that would have meant having to push back our work towards a 1.0 release, which isn't a trade-off we wanted to make.

We also now have [a public "Transport API"](https://www.python-httpx.org/advanced/#custom-transports), which you can use to implement custom transport implementations against. This formalises and replaces our previously private "Dispatch API".

### Changed

* Use `httpcore` for underlying HTTP transport. Drop `urllib3` requirement. (Pull #804, #967)
* Rename pool limit options from `soft_limit`/`hard_limit` to `max_keepalive`/`max_connections`. (Pull #968)
* The previous private "Dispatch API" has now been promoted to a public "Transport API". When customizing the transport use `transport=...`. The `ASGIDispatch` and `WSGIDispatch` class naming is deprecated in favour of `ASGITransport` and `WSGITransport`. (Pull #963)

### Added

* Added `URLLib3Transport` class for optional `urllib3` transport support. (Pull #804, #963)
* Streaming multipart uploads. (Pull #857)
* Logging via HTTPCORE_LOG_LEVEL and HTTPX_LOG_LEVEL environment variables
and TRACE level logging. (Pull encode/httpcore#79)

### Fixed

* Performance improvement in brotli decoder. (Pull #906)
* Proper warning level of deprecation notice in `Response.stream` and `Response.raw`. (Pull #908)
* Fix support for generator based WSGI apps. (Pull #887)
* Reuse of connections on HTTP/2 in close concurrency situations. (Pull encode/httpcore#81)
* Honor HTTP/2 max concurrent streams settings (Pull encode/httpcore#89, encode/httpcore#90)
* Fix bytes support in multipart uploads. (Pull #974)
* Improve typing support for `files=...`. (Pull #976)

### Removed

* Dropped support for `Client(uds=...)` (Pull #804)