### PR TITLE
Tighten up types in multipart upload implementation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ combine_as_imports = True
 force_grid_wrap = 0
 include_trailing_comma = True
 known_first_party = httpx,tests
-known_third_party = brotli,certifi,chardet,cryptography,hstspreload,httpcore,pytest,rfc3986,setuptools,sniffio,trio,trustme,urllib3,uvicorn
+known_third_party = brotli,certifi,chardet,cryptography,hstspreload,httpcore,pytest,rfc3986,setuptools,sniffio,trio,trustme,uvicorn
 line_length = 88
 multi_line_output = 3
 


### PR DESCRIPTION
Refs #974

Use our type aliases for request files to more tightly type-check the `MultipartStream` implementation.

Helps catching any type-related issues such as the one resolved by #974.