### PR TITLE
Improve typing support for the `files` parameter

### DIFF
--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -65,4 +65,4 @@ FileTypes = Union[
     # (filename, file (or text), content_type)
     Tuple[Optional[str], FileContent, Optional[str]],
 ]
-RequestFiles = Dict[str, FileTypes]
+RequestFiles = Mapping[str, FileTypes]


### PR DESCRIPTION
When `files` is passed from a variable, mypy raises an error due to us using a `Dict` with union values:

```python
files = {"example": ("file name", "file content")}
_ = httpx.post("...", files=files)
```

```console
error: Argument "files" to "post" has incompatible type "Dict[str, Tuple[str, str]]"; expected "Optional[Dict[str, Union[Union[IO[str], IO[bytes], str, bytes], Tuple[Optional[str], Union[IO[str], IO[bytes], str, bytes]], Tuple[Optional[str], Union[IO[str], IO[bytes], str, bytes], Optional[str]]]]]"
note: "Dict" is invariant -- see http://mypy.readthedocs.io/en/latest/common_issues.html#variance
note: Consider using "Mapping" instead, which is covariant in the value type
```

This PR fixes this small UX bug. :-)

(Progressing on #650 would allow us to catch more of these earlier.)