### PR TITLE
Add urllib3proxy transport to init

### DIFF
--- a/docs/http2.md
+++ b/docs/http2.md
@@ -18,12 +18,10 @@ For a comprehensive guide to HTTP/2 you may want to check out "[HTTP2 Explained]
 
 ## Enabling HTTP/2
 
-The HTTPX client provides HTTP/2 support, **which is currently only available with the async client**.
-
-HTTP/2 support is not enabled by default, because HTTP/1.1 is a mature,
-battle-hardened transport layer, and our HTTP/1.1 may be considered the more robust
-option at this point in time. It is possible that a future version of `httpx` may
-enable HTTP/2 support by default.
+When using the `httpx` client, HTTP/2 support is not enabled by default, because
+HTTP/1.1 is a mature, battle-hardened transport layer, and our HTTP/1.1
+implementation may be considered the more robust option at this point in time.
+It is possible that a future version of `httpx` may enable HTTP/2 support by default.
 
 If you're issuing highly concurrent requests you might want to consider
 trying out our HTTP/2 support. You can do so by instantiating a client with
@@ -42,6 +40,10 @@ is exited.
 async with httpx.AsyncClient(http2=True) as client:
     ...
 ```
+
+HTTP/2 support is available on both `Client`, and `AsyncClient`, although it's
+typically more useful in async contexts if you're issuing lots of concurrent
+requests.
 
 ## Inspecting the HTTP version
 

--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -26,7 +26,7 @@ from ._exceptions import (
 from ._models import URL, Cookies, Headers, QueryParams, Request, Response
 from ._status_codes import StatusCode, codes
 from ._transports.asgi import ASGIDispatch, ASGITransport
-from ._transports.urllib3 import URLLib3Transport, URLLib3ProxyTransport
+from ._transports.urllib3 import URLLib3ProxyTransport, URLLib3Transport
 from ._transports.wsgi import WSGIDispatch, WSGITransport
 
 __all__ = [

--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -26,7 +26,7 @@ from ._exceptions import (
 from ._models import URL, Cookies, Headers, QueryParams, Request, Response
 from ._status_codes import StatusCode, codes
 from ._transports.asgi import ASGIDispatch, ASGITransport
-from ._transports.urllib3 import URLLib3Transport
+from ._transports.urllib3 import URLLib3Transport, URLLib3ProxyTransport
 from ._transports.wsgi import WSGIDispatch, WSGITransport
 
 __all__ = [
@@ -74,6 +74,7 @@ __all__ = [
     "WriteTimeout",
     "URL",
     "URLLib3Transport",
+    "URLLib3ProxyTransport",
     "StatusCode",
     "Cookies",
     "Headers",


### PR DESCRIPTION
* Add `URLLib3ProxyTransport` to `__init__`.

Which should be a helpful reminder to myself not to bypass the PR workflow, even if ya think you've got one extra tiny thing that oughta go in for the release. 😇