### PR TITLE
Fix pool option warnings for default connection pool

### DIFF
--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -367,5 +367,5 @@ class Proxy:
 
 
 DEFAULT_TIMEOUT_CONFIG = Timeout(timeout=5.0)
-DEFAULT_POOL_LIMITS = PoolLimits(soft_limit=10, hard_limit=100)
+DEFAULT_POOL_LIMITS = PoolLimits(max_keepalive=10, max_connections=100)
 DEFAULT_MAX_REDIRECTS = 20

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -404,4 +404,4 @@ def as_network_error(*exception_classes: type) -> typing.Iterator[None]:
 
 
 def warn_deprecated(message: str) -> None:
-    warnings.warn(message, DeprecationWarning)
+    warnings.warn(message, DeprecationWarning, stacklevel=2)


### PR DESCRIPTION
Currently creating a client with default options on httpx 0.13.0 produces these warnings:

```
.../lib/python3.8/site-packages/httpx/_utils.py:407
  .../lib/python3.8/site-packages/httpx/_utils.py:407: DeprecationWarning: 'soft_limit' is deprecated. Use 'max_keepalive' instead.
    warnings.warn(message, DeprecationWarning)

.../lib/python3.8/site-packages/httpx/_utils.py:407
  .../lib/python3.8/site-packages/httpx/_utils.py:407: DeprecationWarning: 'hard_limit' is deprecated. Use 'max_connections' instead.
    warnings.warn(message, DeprecationWarning)
```