### PR TITLE
Added type annotation for tests/client/test_async_client.py

### DIFF
--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -95,7 +95,7 @@ async def test_raise_for_status(server):
                     response.raise_for_status()
                 assert exc_info.value.response == response
             else:
-                assert response.raise_for_status() is None
+                assert response.raise_for_status() is None  # type: ignore
 
 
 @pytest.mark.usefixtures("async_environment")

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -110,7 +110,7 @@ def test_raise_for_status(server):
                     response.raise_for_status()
                 assert exc_info.value.response == response
             else:
-                assert response.raise_for_status() is None
+                assert response.raise_for_status() is None  # type: ignore
 
 
 def test_options(server):


### PR DESCRIPTION
Refs https://github.com/encode/httpx/issues/650

We have still 3 issues in this file:
```
tests/client/test_async_client.py:29: error: Argument 1 to "update" of "Headers" has incompatible type "Dict[str, str]"; expected "Union[Headers, Dict[Union[str, bytes], Union[str, bytes]], Sequence[Tuple[Union[str, bytes], Union[str, bytes]]], None]"
tests/client/test_async_client.py:148: error: Argument "headers" to "post" of "AsyncClient" has incompatible type "Dict[str, str]"; expected "Union[Headers, Dict[Union[str, bytes], Union[str, bytes]], Sequence[Tuple[Union[str, bytes], Union[str, bytes]]], None]"
```
In above two test we defined headers like:
`headers = {"Custom-header": "value"}`
`headers = {"Expect": "100-continue"}`
which have type `Dict[str, str]` and I think they are valid type based on [HeaderTypes definition](https://github.com/encode/httpx/blob/a4145ce2fba4c273702aff2cc4da85b8acc6455e/httpx/_types.py#L40). we can fix them by replacing them by List of Tuples like `headers = [("Expect", "100-continue")]`. TBH, can not figure out why they are incompatible.

```
tests/client/test_async_client.py:100: error: "raise_for_status" of "Response" does not return a value
```
What should we do with this error :thinking:? Shall we ignore checking for this line?

I don't have much experience in type annotation, that's why I am asking this questions.
