### PR TITLE
Move test server to a separately importable module

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,5 @@
-import asyncio
 import json
 import os
-import threading
-import time
 import typing
 
 import pytest
@@ -15,10 +12,9 @@ from cryptography.hazmat.primitives.serialization import (
     load_pem_private_key,
 )
 from uvicorn.config import Config
-from uvicorn.main import Server
 
-from httpx import URL
-from tests.concurrency import sleep
+from .concurrency import sleep
+from .server import Server, serve_in_thread
 
 ENVIRONMENT_VARIABLES = {
     "SSL_CERT_FILE",
@@ -224,74 +220,18 @@ def cert_encrypted_private_key_file(localhost_cert):
         yield tmp
 
 
-class TestServer(Server):
-    @property
-    def url(self) -> URL:
-        protocol = "https" if self.config.is_ssl else "http"
-        return URL(f"{protocol}://{self.config.host}:{self.config.port}/")
-
-    def install_signal_handlers(self) -> None:
-        # Disable the default installation of handlers for signals such as SIGTERM,
-        # because it can only be done in the main thread.
-        pass
-
-    async def serve(self, sockets=None):
-        self.restart_requested = asyncio.Event()
-
-        loop = asyncio.get_event_loop()
-        tasks = {
-            loop.create_task(super().serve(sockets=sockets)),
-            loop.create_task(self.watch_restarts()),
-        }
-        await asyncio.wait(tasks)
-
-    async def restart(self) -> None:
-        # This coroutine may be called from a different thread than the one the
-        # server is running on, and from an async environment that's not asyncio.
-        # For this reason, we use an event to coordinate with the server
-        # instead of calling shutdown()/startup() directly, and should not make
-        # any asyncio-specific operations.
-        self.started = False
-        self.restart_requested.set()
-        while not self.started:
-            await sleep(0.2)
-
-    async def watch_restarts(self):
-        while True:
-            if self.should_exit:
-                return
-
-            try:
-                await asyncio.wait_for(self.restart_requested.wait(), timeout=0.1)
-            except asyncio.TimeoutError:
-                continue
-
-            self.restart_requested.clear()
-            await self.shutdown()
-            await self.startup()
-
-
-def serve_in_thread(server: Server):
-    thread = threading.Thread(target=server.run)
-    thread.start()
-    try:
-        while not server.started:
-            time.sleep(1e-3)
-        yield server
-    finally:
-        server.should_exit = True
-        thread.join()
-
-
 @pytest.fixture(scope=SERVER_SCOPE)
-def server():
+def server() -> typing.Iterator[Server]:
     config = Config(app=app, lifespan="off", loop="asyncio")
-    server = TestServer(config=config)
-    yield from serve_in_thread(server)
+    server = Server(config=config)
+    with serve_in_thread(server):
+        yield server
 
 
 @pytest.fixture(scope=SERVER_SCOPE)
-def https_server(cert_pem_file, cert_private_key_file):
+def https_server(
+    cert_pem_file: str, cert_private_key_file: str
+) -> typing.Iterator[Server]:
     config = Config(
         app=app,
         lifespan="off",
@@ -301,5 +241,6 @@ def https_server(cert_pem_file, cert_private_key_file):
         port=8001,
         loop="asyncio",
     )
-    server = TestServer(config=config)
-    yield from serve_in_thread(server)
+    server = Server(config=config)
+    with serve_in_thread(server):
+        yield server

--- a/tests/server.py
+++ b/tests/server.py
@@ -1,12 +1,13 @@
+import asyncio
+import contextlib
 import threading
 import time
-import contextlib
-import asyncio
 from typing import Iterator
 
 import uvicorn
 
 import httpx
+
 from .concurrency import sleep
 
 

--- a/tests/server.py
+++ b/tests/server.py
@@ -1,0 +1,70 @@
+import threading
+import time
+import contextlib
+import asyncio
+from typing import Iterator
+
+import uvicorn
+
+import httpx
+from .concurrency import sleep
+
+
+class Server(uvicorn.Server):
+    @property
+    def url(self) -> httpx.URL:
+        protocol = "https" if self.config.is_ssl else "http"
+        return httpx.URL(f"{protocol}://{self.config.host}:{self.config.port}/")
+
+    def install_signal_handlers(self) -> None:
+        # Disable the default installation of handlers for signals such as SIGTERM,
+        # because it can only be done in the main thread.
+        pass
+
+    async def serve(self, sockets: list = None) -> None:
+        self.restart_requested = asyncio.Event()
+
+        loop = asyncio.get_event_loop()
+        tasks = {
+            loop.create_task(super().serve(sockets=sockets)),
+            loop.create_task(self.watch_restarts()),
+        }
+        await asyncio.wait(tasks)
+
+    async def restart(self) -> None:
+        # This coroutine may be called from a different thread than the one the
+        # server is running on, and from an async environment that's not asyncio.
+        # For this reason, we use an event to coordinate with the server
+        # instead of calling shutdown()/startup() directly, and should not make
+        # any asyncio-specific operations.
+        self.started = False
+        self.restart_requested.set()
+        while not self.started:
+            await sleep(0.2)
+
+    async def watch_restarts(self) -> None:
+        while True:
+            if self.should_exit:
+                return
+
+            try:
+                await asyncio.wait_for(self.restart_requested.wait(), timeout=0.1)
+            except asyncio.TimeoutError:
+                continue
+
+            self.restart_requested.clear()
+            await self.shutdown()
+            await self.startup()
+
+
+@contextlib.contextmanager
+def serve_in_thread(server: Server) -> Iterator[None]:
+    thread = threading.Thread(target=server.run)
+    thread.start()
+    try:
+        while not server.started:
+            time.sleep(1e-3)
+        yield
+    finally:
+        server.should_exit = True
+        thread.join()


### PR DESCRIPTION
Refs #650, prompted by https://github.com/encode/httpx/pull/985#discussion_r429614983

Being able to import the test `Server` is required* for annotating tests.

*At least, it's required with our _current_ test setup. Dunno if we might want to consider tweaking our mypy configuration with `--check-untyped-defs`, so that the inside of test functions is type checked even though their signature is not annotated. In general it's really the inside of tests (calls to HTTPX) that we want to make sure provide a good typing experience — type hinting the test function signatures doesn't provide a huge gain (but on the contrary a non-negligible amount of work is required if we did want to annotate them all).

So, marking this as a draft for now…