### PR TITLE
Fix handling of None values in timeout tuple type hint

### DIFF
--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -45,7 +45,11 @@ CookieTypes = Union["Cookies", CookieJar, Dict[str, str]]
 
 CertTypes = Union[str, Tuple[str, str], Tuple[str, str, str]]
 VerifyTypes = Union[str, bool, ssl.SSLContext]
-TimeoutTypes = Union[None, float, Tuple[float, float, float, float], "Timeout"]
+TimeoutTypes = Union[
+    Optional[float],
+    Tuple[Optional[float], Optional[float], Optional[float], Optional[float]],
+    "Timeout",
+]
 ProxiesTypes = Union[URLTypes, "Proxy", Dict[URLTypes, Union[URLTypes, "Proxy"]]]
 
 AuthTypes = Union[


### PR DESCRIPTION
Fixes an issue with our `TimeoutTypes` that makes mypy complain if users pass `None`'s as part of a timeout tuple (although `None` are accepted, meaning "no timeout"):

```python
# example.py
import httpx

_ = httpx.Timeout((1.0, None, None, None))
```

```console
$ mypy example.py
example.py:3: error: Argument 1 to "Timeout" has incompatible type "Tuple[float, None, None, None]"; expected "Union[float, Tuple[float, float, float, float], Timeout, None]"
Found 1 error in 1 file (checked 1 source file)
```