### PR TITLE
Tweak headers type hints

### DIFF
--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -7,6 +7,7 @@ from http.cookiejar import CookieJar
 from typing import (
     IO,
     TYPE_CHECKING,
+    AnyStr,
     AsyncIterator,
     Callable,
     Dict,
@@ -38,7 +39,14 @@ QueryParamTypes = Union[
 ]
 
 HeaderTypes = Union[
-    "Headers", Dict[StrOrBytes, StrOrBytes], Sequence[Tuple[StrOrBytes, StrOrBytes]],
+    "Headers",
+    # NOTE: Mapping is invariant in key (https://github.com/python/mypy/issues/1114).
+    # So using `StrOrBytes` as the mapping key type would result in
+    # users come across https://github.com/python/mypy/issues/8477.
+    # The suggested solution is to use a generic key type (defined as a `TypeVar`),
+    # hence `AnyStr` here.
+    Mapping[AnyStr, StrOrBytes],
+    Sequence[Tuple[StrOrBytes, StrOrBytes]],
 ]
 
 CookieTypes = Union["Cookies", CookieJar, Dict[str, str]]


### PR DESCRIPTION
Prompted by https://github.com/encode/httpx/pull/985#discussion_r429615097

Fixes a type hints itch that our users can come across currently, similarly to https://github.com/python/mypy/issues/8477. This happens when providing headers from a separate variable, like we do in some of our tests:

https://github.com/encode/httpx/blob/82dc6f32f864d26677df8fc61249a7fc74c687e8/tests/models/test_responses.py#L40-L48

```python
# example.py
headers = {"content-type": "example"}
httpx.Headers(headers)
```

```console
$ mypy example.py
example.py:5: error: Argument 1 to "Headers" has incompatible type "Dict[str, str]"; expected "Union[Headers, Dict[Union[str, bytes], Union[str, bytes]], Sequence[Tuple[Union[str, bytes], Union[str, bytes]]], None]"
Found 1 error in 1 file (checked 1 source file)
```

This error is super confusing, so we should fix it. (It's due to a limitation in mypy: `Mapping` is invariant in key (see https://github.com/python/mypy/issues/1114) — so `Union`'s don't typically work very well.)

This PR fixes it in the form of a surgical tweak to our `HeaderTypes` type alias, based on @hramezani's fix here: https://github.com/encode/httpx/pull/985#discussion_r429615097.
