### PR TITLE
Use AnyStr where appropriate

### DIFF
--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -7,6 +7,7 @@ from http.cookiejar import CookieJar
 from typing import (
     IO,
     TYPE_CHECKING,
+    AnyStr,
     AsyncIterator,
     Callable,
     Dict,
@@ -24,7 +25,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from ._config import Proxy, Timeout  # noqa: F401
     from ._models import URL, Cookies, Headers, QueryParams, Request  # noqa: F401
 
-StrOrBytes = Union[str, bytes]
 
 PrimitiveData = Optional[Union[str, int, float, bool]]
 
@@ -38,7 +38,7 @@ QueryParamTypes = Union[
 ]
 
 HeaderTypes = Union[
-    "Headers", Dict[StrOrBytes, StrOrBytes], Sequence[Tuple[StrOrBytes, StrOrBytes]],
+    "Headers", Dict[AnyStr, AnyStr], Sequence[Tuple[AnyStr, AnyStr]],
 ]
 
 CookieTypes = Union["Cookies", CookieJar, Dict[str, str]]

--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -7,7 +7,6 @@ from http.cookiejar import CookieJar
 from typing import (
     IO,
     TYPE_CHECKING,
-    AnyStr,
     AsyncIterator,
     Callable,
     Dict,

--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -38,7 +38,11 @@ QueryParamTypes = Union[
 ]
 
 HeaderTypes = Union[
-    "Headers", Dict[AnyStr, AnyStr], Sequence[Tuple[AnyStr, AnyStr]],
+    "Headers",
+    Dict[str, str],
+    Dict[bytes, bytes],
+    Sequence[Tuple[str, str]],
+    Sequence[Tuple[bytes, bytes]],
 ]
 
 CookieTypes = Union["Cookies", CookieJar, Dict[str, str]]

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -16,7 +16,7 @@ from types import TracebackType
 from urllib.request import getproxies
 
 from ._exceptions import NetworkError
-from ._types import PrimitiveData, StrOrBytes
+from ._types import PrimitiveData
 
 if typing.TYPE_CHECKING:  # pragma: no cover
     from ._models import URL
@@ -31,7 +31,9 @@ _HTML5_FORM_ENCODING_RE = re.compile(
 )
 
 
-def normalize_header_key(value: StrOrBytes, encoding: str = None) -> bytes:
+def normalize_header_key(
+    value: typing.Union[str, bytes], encoding: str = None
+) -> bytes:
     """
     Coerce str/bytes into a strictly byte-wise HTTP header key.
     """
@@ -40,7 +42,9 @@ def normalize_header_key(value: StrOrBytes, encoding: str = None) -> bytes:
     return value.encode(encoding or "ascii").lower()
 
 
-def normalize_header_value(value: StrOrBytes, encoding: str = None) -> bytes:
+def normalize_header_value(
+    value: typing.Union[str, bytes], encoding: str = None
+) -> bytes:
     """
     Coerce str/bytes into a strictly byte-wise HTTP header value.
     """
@@ -206,8 +210,8 @@ SENSITIVE_HEADERS = {"authorization", "proxy-authorization"}
 
 
 def obfuscate_sensitive_headers(
-    items: typing.Iterable[typing.Tuple[StrOrBytes, StrOrBytes]]
-) -> typing.Iterator[typing.Tuple[StrOrBytes, StrOrBytes]]:
+    items: typing.Iterable[typing.Tuple[typing.AnyStr, typing.AnyStr]]
+) -> typing.Iterator[typing.Tuple[typing.AnyStr, typing.AnyStr]]:
     for k, v in items:
         if to_str(k.lower()) in SENSITIVE_HEADERS:
             v = to_bytes_or_str("[secure]", match_type_of=v)
@@ -303,7 +307,7 @@ def to_str(value: typing.Union[str, bytes], encoding: str = "utf-8") -> str:
     return value if isinstance(value, str) else value.decode(encoding)
 
 
-def to_bytes_or_str(value: str, match_type_of: StrOrBytes) -> StrOrBytes:
+def to_bytes_or_str(value: str, match_type_of: typing.AnyStr) -> typing.AnyStr:
     return value if isinstance(match_type_of, str) else value.encode()
 
 


### PR DESCRIPTION
Refs #993, #985 

Makes more careful use of `typing.Union[str, bytes]` vs. `typing.AnyStr`.

Use `AnyStr` where we'd expect the types to be the same across everything in the signature. Eg. `typing.Mapping[AnyStr, AnyStr]` means "choose either str or bytes here, but be consistent.".

Resolves an issues where mypy errors with a really simple bit of `httpx` usage...

**example.py**

```python
import httpx

headers = {"content-type": "example"}
httpx.Headers(headers)
```

**MyPy**

```shell
$ venv/bin/mypy example.py 
example.py:5: error: Argument 1 to "Headers" has incompatible type "Dict[str, str]"; expected "Union[Headers, Dict[Union[str, bytes], Union[str, bytes]], Sequence[Tuple[Union[str, bytes], Union[str, bytes]]], None]"
Found 1 error in 1 file (checked 1 source file)
```

