### PR TITLE
Version 0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.13.2 (May 27th, 2020)
+
+### Fixed
+
+* Include explicit "Content-Length: 0" on POST, PUT, PATCH if no request body is used. (Pull #995)
+* Add `http2` option to `httpx.Client`. (Pull #982)
+* Tighten up API typing in places. (Pull #992, #999)
+
 ## 0.13.1 (May 22nd, 2020)
 
 ### Fixed

--- a/httpx/__version__.py
+++ b/httpx/__version__.py
@@ -1,3 +1,3 @@
 __title__ = "httpx"
 __description__ = "A next generation HTTP client, for Python 3."
-__version__ = "0.13.1"
+__version__ = "0.13.2"


### PR DESCRIPTION
Related: https://github.com/encode/httpcore/pull/99

## 0.13.2 (May 27th, 2020)

### Fixed

* Include explicit "Content-Length: 0" on POST, PUT, PATCH if no request body is used. (Pull #995)
* Add `http2` option to `httpx.Client`. (Pull #982)
* Tighten up API typing in places. (Pull #992, #999)