### PR TITLE
Improve error when redirecting with custom schemes

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -322,6 +322,10 @@ class BaseClient:
 
         url = URL(location, allow_relative=True)
 
+        # Check that we can handle the scheme
+        if url.scheme and url.scheme not in ("http", "https"):
+            raise InvalidURL(f'Scheme "{url.scheme}" not supported.')
+
         # Handle malformed 'Location' headers that are "absolute" form, have no host.
         # See: https://github.com/encode/httpx/issues/771
         if url.scheme and not url.host:

--- a/tests/client/test_redirects.py
+++ b/tests/client/test_redirects.py
@@ -8,6 +8,7 @@ import pytest
 from httpx import (
     URL,
     AsyncClient,
+    InvalidURL,
     NotRedirectResponse,
     RequestBodyUnavailable,
     TooManyRedirects,
@@ -139,6 +140,17 @@ class MockDispatch(httpcore.AsyncHTTPTransport):
                 )
             else:
                 return b"HTTP/1.1", 200, b"OK", [], ByteStream(b"Hello, world!")
+
+        elif path == b"/redirect_custom_scheme":
+            status_code = codes.MOVED_PERMANENTLY
+            headers = [(b"location", b"market://details?id=42")]
+            return (
+                b"HTTP/1.1",
+                status_code,
+                b"Moved Permanently",
+                headers,
+                ByteStream(b""),
+            )
 
         return b"HTTP/1.1", 200, b"OK", [], ByteStream(b"Hello, world!")
 
@@ -431,3 +443,11 @@ async def test_redirect_cookie_behavior():
     response = await client.get("https://example.com/")
     assert response.url == "https://example.com/"
     assert response.text == "Not logged in"
+
+
+@pytest.mark.usefixtures("async_environment")
+async def test_redirect_custom_scheme():
+    client = AsyncClient(dispatch=MockDispatch())
+    with pytest.raises(InvalidURL) as e:
+        await client.post("https://example.org/redirect_custom_scheme")
+    assert str(e.value) == 'Scheme "market" not supported.'


### PR DESCRIPTION
Fixes #822

I used `Scheme "blah" not supported` as the error message instead of `URL scheme must be "http" or "https".` used in other parts of the code. It makes more sense to show the actual invalid scheme since it's coming from the server and not something that the user specified.

I also tried the same test with `allow_redirects=False` but unfortunately when the response object is built, it needs a port which we can't derive from the custom scheme. Not sure how to solve this without changing the port definition of `Url` to allow a `None` port, ideas?