### PR TITLE
Increase test coverage, document Headers.copy(), misc cleanup

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -151,7 +151,8 @@ True
 'application/json'
 ```
 
-* `def __init__(self, headers)`
+* `def __init__(self, headers, encoding=None)`
+* `def copy()` - **Headers**
 
 ## `Cookies`
 

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -481,9 +481,6 @@ class Headers(typing.MutableMapping[str, str]):
         for header in headers:
             self[header] = headers[header]
 
-    def copy(self) -> "Headers":
-        return Headers(self.items(), encoding=self.encoding)
-
     def __getitem__(self, key: str) -> str:
         """
         Return a single header value.

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -481,6 +481,9 @@ class Headers(typing.MutableMapping[str, str]):
         for header in headers:
             self[header] = headers[header]
 
+    def copy(self) -> "Headers":
+        return Headers(self.items(), encoding=self.encoding)
+
     def __getitem__(self, key: str) -> str:
         """
         Return a single header value.

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -1,8 +1,10 @@
 from datetime import timedelta
 
+import httpcore
 import pytest
 
 import httpx
+from httpx import ASGIDispatch
 
 
 @pytest.mark.usefixtures("async_environment")
@@ -16,6 +18,13 @@ async def test_get(server):
     assert response.headers
     assert repr(response) == "<Response [200 OK]>"
     assert response.elapsed > timedelta(seconds=0)
+
+
+@pytest.mark.usefixtures("async_environment")
+async def test_get_invalid_url(server):
+    async with httpx.AsyncClient() as client:
+        with pytest.raises(httpx.InvalidURL):
+            await client.get("invalid://example.org")
 
 
 @pytest.mark.usefixtures("async_environment")
@@ -148,3 +157,28 @@ async def test_100_continue(server):
 
     assert response.status_code == 200
     assert response.content == data
+
+
+def test_dispatch_deprecated():
+    dispatch = httpcore.AsyncHTTPTransport()
+
+    with pytest.warns(DeprecationWarning) as record:
+        client = httpx.AsyncClient(dispatch=dispatch)
+
+    assert client.transport is dispatch
+    assert len(record) == 1
+    assert record[0].message.args[0] == (
+        "The dispatch argument is deprecated since v0.13 and will be "
+        "removed in a future release, please use 'transport'"
+    )
+
+
+def test_asgi_dispatch_deprecated():
+    with pytest.warns(DeprecationWarning) as record:
+        ASGIDispatch(None)
+
+    assert len(record) == 1
+    assert (
+        record[0].message.args[0]
+        == "ASGIDispatch is deprecated, please use ASGITransport"
+    )

--- a/tests/client/test_proxies.py
+++ b/tests/client/test_proxies.py
@@ -105,11 +105,12 @@ def test_unsupported_proxy_scheme():
         ),
     ],
 )
-def test_proxies_environ(monkeypatch, url, env, expected):
+@pytest.mark.parametrize("client_class", [httpx.Client, httpx.AsyncClient])
+def test_proxies_environ(monkeypatch, client_class, url, env, expected):
     for name, value in env.items():
         monkeypatch.setenv(name, value)
 
-    client = httpx.AsyncClient()
+    client = client_class()
     transport = client.transport_for_url(httpx.URL(url))
 
     if expected is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,8 +76,6 @@ async def app(scope, receive, send):
     assert scope["type"] == "http"
     if scope["path"].startswith("/slow_response"):
         await slow_response(scope, receive, send)
-    elif scope["path"].startswith("/premature_close"):
-        await premature_close(scope, receive, send)
     elif scope["path"].startswith("/status"):
         await status_code(scope, receive, send)
     elif scope["path"].startswith("/echo_body"):
@@ -111,16 +109,6 @@ async def slow_response(scope, receive, send):
         }
     )
     await send({"type": "http.response.body", "body": b"Hello, world!"})
-
-
-async def premature_close(scope, receive, send):
-    await send(
-        {
-            "type": "http.response.start",
-            "status": 200,
-            "headers": [[b"content-type", b"text/plain"]],
-        }
-    )
 
 
 async def status_code(scope, receive, send):

--- a/tests/models/test_headers.py
+++ b/tests/models/test_headers.py
@@ -46,7 +46,14 @@ def test_header_mutations():
     assert h.raw == [(b"b", b"4")]
 
 
-def test_copy_headers():
+def test_copy_headers_method():
+    headers = httpx.Headers({"custom": "example"})
+    headers_copy = headers.copy()
+    assert headers == headers_copy
+    assert headers is not headers_copy
+
+
+def test_copy_headers_init():
     headers = httpx.Headers({"custom": "example"})
     headers_copy = httpx.Headers(headers)
     assert headers == headers_copy

--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -192,6 +192,11 @@ def test_origin_from_url_string():
     assert origin.port == 443
 
 
+def test_origin_repr():
+    origin = Origin("https://example.com:8080")
+    assert str(origin) == "Origin(scheme='https' host='example.com' port=8080)"
+
+
 def test_url_copywith_for_authority():
     copy_with_kwargs = {
         "username": "username",


### PR DESCRIPTION
Small work towards https://github.com/encode/httpx/issues/316, added a few tests to increase the coverage.

Also removed a couple of bits that were not used anymore.