### PR TITLE
Include missing keepalive_expiry configuration

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -46,6 +46,8 @@ from ._utils import (
 
 logger = get_logger(__name__)
 
+KEEPALIVE_EXPIRY = 5.0
+
 
 class BaseClient:
     def __init__(
@@ -517,6 +519,7 @@ class Client(BaseClient):
             ssl_context=ssl_context,
             max_keepalive=pool_limits.max_keepalive,
             max_connections=pool_limits.max_connections,
+            keepalive_expiry=KEEPALIVE_EXPIRY,
             http2=http2,
         )
 
@@ -540,6 +543,7 @@ class Client(BaseClient):
             ssl_context=ssl_context,
             max_keepalive=pool_limits.max_keepalive,
             max_connections=pool_limits.max_connections,
+            keepalive_expiry=KEEPALIVE_EXPIRY,
             http2=http2,
         )
 
@@ -1062,6 +1066,7 @@ class AsyncClient(BaseClient):
             ssl_context=ssl_context,
             max_keepalive=pool_limits.max_keepalive,
             max_connections=pool_limits.max_connections,
+            keepalive_expiry=KEEPALIVE_EXPIRY,
             http2=http2,
         )
 
@@ -1085,6 +1090,7 @@ class AsyncClient(BaseClient):
             ssl_context=ssl_context,
             max_keepalive=pool_limits.max_keepalive,
             max_connections=pool_limits.max_connections,
+            keepalive_expiry=KEEPALIVE_EXPIRY,
             http2=http2,
         )
 


### PR DESCRIPTION
Refs https://github.com/encode/httpcore/issues/44

In 12.x we used to default the keepalive_expiry to 5.0 to mitigate asyncio's flaky behaviour for checking the aliveness of the TCP connection. https://github.com/encode/httpx/blob/0.12.1/httpx/_dispatch/connection_pool.py#L89

We failed to continue to do so in 13.x when we switched to `httpcore`. This change reverts that.