### PR TITLE
Version 0.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.13.3 (May 29th, 2020)
+
+### Fixed
+
+* Include missing keepalive expiry configuration. (Pull #1005)
+* Improved error message when URL redirect has a custom scheme. (Pull #1002)
+
 ## 0.13.2 (May 27th, 2020)
 
 ### Fixed

--- a/httpx/__version__.py
+++ b/httpx/__version__.py
@@ -1,3 +1,3 @@
 __title__ = "httpx"
 __description__ = "A next generation HTTP client, for Python 3."
-__version__ = "0.13.2"
+__version__ = "0.13.3"


### PR DESCRIPTION
## 0.13.3 (May 29th, 2020)

### Fixed

* Include missing keepalive expiry configuration. (Pull #1005)
* Improved error message when URL redirect has a custom scheme. (Pull #1002)