### PR TITLE
Replace remaining occurrences of dispatch with transport

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -54,9 +54,6 @@ from ._utils import (
     warn_deprecated,
 )
 
-if typing.TYPE_CHECKING:  # pragma: no cover
-    from ._dispatch.base import AsyncDispatcher  # noqa: F401
-
 
 class URL:
     def __init__(

--- a/httpx/_transports/asgi.py
+++ b/httpx/_transports/asgi.py
@@ -34,17 +34,17 @@ class ASGITransport(httpcore.AsyncHTTPTransport):
     client = httpx.AsyncClient(app=app)
     ```
 
-    Alternatively, you can setup the dispatch instance explicitly.
+    Alternatively, you can setup the transport instance explicitly.
     This allows you to include any additional configuration arguments specific
     to the ASGITransport class:
 
     ```
-    dispatch = httpx.ASGITransport(
+    transport = httpx.ASGITransport(
         app=app,
         root_path="/submount",
         client=("1.2.3.4", 123)
     )
-    client = httpx.AsyncClient(dispatch=dispatch)
+    client = httpx.AsyncClient(transport=transport)
     ```
 
     Arguments:

--- a/httpx/_transports/wsgi.py
+++ b/httpx/_transports/wsgi.py
@@ -25,17 +25,17 @@ class WSGITransport(httpcore.SyncHTTPTransport):
     client = httpx.Client(app=app)
     ```
 
-    Alternatively, you can setup the dispatch instance explicitly.
+    Alternatively, you can setup the transport instance explicitly.
     This allows you to include any additional configuration arguments specific
     to the WSGITransport class:
 
     ```
-    dispatch = httpx.WSGITransport(
+    transport = httpx.WSGITransport(
         app=app,
         script_name="/submount",
         remote_addr="1.2.3.4"
     )
-    client = httpx.Client(dispatch=dispatch)
+    client = httpx.Client(transport=transport)
     ```
 
     Arguments:

--- a/tests/client/test_cookies.py
+++ b/tests/client/test_cookies.py
@@ -16,7 +16,7 @@ def get_header_value(headers, key, default=None):
     return default
 
 
-class MockDispatch(httpcore.AsyncHTTPTransport):
+class MockTransport(httpcore.AsyncHTTPTransport):
     async def request(
         self,
         method: bytes,
@@ -48,7 +48,7 @@ async def test_set_cookie() -> None:
     url = "http://example.org/echo_cookies"
     cookies = {"example-name": "example-value"}
 
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
     response = await client.get(url, cookies=cookies)
 
     assert response.status_code == 200
@@ -84,7 +84,7 @@ async def test_set_cookie_with_cookiejar() -> None:
     )
     cookies.set_cookie(cookie)
 
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
     response = await client.get(url, cookies=cookies)
 
     assert response.status_code == 200
@@ -120,7 +120,7 @@ async def test_setting_client_cookies_to_cookiejar() -> None:
     )
     cookies.set_cookie(cookie)
 
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
     client.cookies = cookies  # type: ignore
     response = await client.get(url)
 
@@ -138,7 +138,7 @@ async def test_set_cookie_with_cookies_model() -> None:
     cookies = Cookies()
     cookies["example-name"] = "example-value"
 
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
     response = await client.get(url, cookies=cookies)
 
     assert response.status_code == 200
@@ -149,7 +149,7 @@ async def test_set_cookie_with_cookies_model() -> None:
 async def test_get_cookie() -> None:
     url = "http://example.org/set_cookie"
 
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
     response = await client.get(url)
 
     assert response.status_code == 200
@@ -162,7 +162,7 @@ async def test_cookie_persistence() -> None:
     """
     Ensure that Client instances persist cookies between requests.
     """
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
 
     response = await client.get("http://example.org/echo_cookies")
     assert response.status_code == 200

--- a/tests/client/test_headers.py
+++ b/tests/client/test_headers.py
@@ -9,7 +9,7 @@ from httpx import AsyncClient, Headers, __version__
 from httpx._content_streams import ContentStream, JSONStream
 
 
-class MockDispatch(httpcore.AsyncHTTPTransport):
+class MockTransport(httpcore.AsyncHTTPTransport):
     async def request(
         self,
         method: bytes,
@@ -35,7 +35,7 @@ async def test_client_header():
     url = "http://example.org/echo_headers"
     headers = {"Example-Header": "example-value"}
 
-    client = AsyncClient(dispatch=MockDispatch(), headers=headers)
+    client = AsyncClient(transport=MockTransport(), headers=headers)
     response = await client.get(url)
 
     assert response.status_code == 200
@@ -56,7 +56,7 @@ async def test_header_merge():
     url = "http://example.org/echo_headers"
     client_headers = {"User-Agent": "python-myclient/0.2.1"}
     request_headers = {"X-Auth-Token": "FooBarBazToken"}
-    client = AsyncClient(dispatch=MockDispatch(), headers=client_headers)
+    client = AsyncClient(transport=MockTransport(), headers=client_headers)
     response = await client.get(url, headers=request_headers)
 
     assert response.status_code == 200
@@ -77,7 +77,7 @@ async def test_header_merge_conflicting_headers():
     url = "http://example.org/echo_headers"
     client_headers = {"X-Auth-Token": "FooBar"}
     request_headers = {"X-Auth-Token": "BazToken"}
-    client = AsyncClient(dispatch=MockDispatch(), headers=client_headers)
+    client = AsyncClient(transport=MockTransport(), headers=client_headers)
     response = await client.get(url, headers=request_headers)
 
     assert response.status_code == 200
@@ -96,7 +96,7 @@ async def test_header_merge_conflicting_headers():
 @pytest.mark.asyncio
 async def test_header_update():
     url = "http://example.org/echo_headers"
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
     first_response = await client.get(url)
     client.headers.update(
         {"User-Agent": "python-myclient/0.2.1", "Another-Header": "AThing"}
@@ -142,7 +142,7 @@ async def test_host_with_auth_and_port_in_url():
     """
     url = "http://username:password@example.org:80/echo_headers"
 
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
     response = await client.get(url)
 
     assert response.status_code == 200
@@ -166,7 +166,7 @@ async def test_host_with_non_default_port_in_url():
     """
     url = "http://username:password@example.org:123/echo_headers"
 
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
     response = await client.get(url)
 
     assert response.status_code == 200

--- a/tests/client/test_queryparams.py
+++ b/tests/client/test_queryparams.py
@@ -7,7 +7,7 @@ from httpx import URL, AsyncClient, Headers, QueryParams
 from httpx._content_streams import ContentStream, JSONStream
 
 
-class MockDispatch(httpcore.AsyncHTTPTransport):
+class MockTransport(httpcore.AsyncHTTPTransport):
     async def request(
         self,
         method: bytes,
@@ -45,7 +45,7 @@ async def test_client_queryparams_echo():
     url = "http://example.org/echo_queryparams"
     client_queryparams = "first=str"
     request_queryparams = {"second": "dict"}
-    client = AsyncClient(dispatch=MockDispatch(), params=client_queryparams)
+    client = AsyncClient(transport=MockTransport(), params=client_queryparams)
     response = await client.get(url, params=request_queryparams)
 
     assert response.status_code == 200

--- a/tests/client/test_redirects.py
+++ b/tests/client/test_redirects.py
@@ -25,7 +25,7 @@ def get_header_value(headers, key, default=None):
     return default
 
 
-class MockDispatch(httpcore.AsyncHTTPTransport):
+class MockTransport(httpcore.AsyncHTTPTransport):
     async def request(
         self,
         method: bytes,
@@ -157,7 +157,7 @@ class MockDispatch(httpcore.AsyncHTTPTransport):
 
 @pytest.mark.usefixtures("async_environment")
 async def test_no_redirect():
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
     url = "https://example.com/no_redirect"
     response = await client.get(url)
     assert response.status_code == 200
@@ -167,7 +167,7 @@ async def test_no_redirect():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_redirect_301():
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
     response = await client.post("https://example.org/redirect_301")
     assert response.status_code == codes.OK
     assert response.url == URL("https://example.org/")
@@ -176,7 +176,7 @@ async def test_redirect_301():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_redirect_302():
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
     response = await client.post("https://example.org/redirect_302")
     assert response.status_code == codes.OK
     assert response.url == URL("https://example.org/")
@@ -185,7 +185,7 @@ async def test_redirect_302():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_redirect_303():
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
     response = await client.get("https://example.org/redirect_303")
     assert response.status_code == codes.OK
     assert response.url == URL("https://example.org/")
@@ -194,7 +194,7 @@ async def test_redirect_303():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_disallow_redirects():
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
     response = await client.post(
         "https://example.org/redirect_303", allow_redirects=False
     )
@@ -212,7 +212,7 @@ async def test_disallow_redirects():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_relative_redirect():
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
     response = await client.get("https://example.org/relative_redirect")
     assert response.status_code == codes.OK
     assert response.url == URL("https://example.org/")
@@ -222,7 +222,7 @@ async def test_relative_redirect():
 @pytest.mark.usefixtures("async_environment")
 async def test_malformed_redirect():
     # https://github.com/encode/httpx/issues/771
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
     response = await client.get("http://example.org/malformed_redirect")
     assert response.status_code == codes.OK
     assert response.url == URL("https://example.org/")
@@ -231,7 +231,7 @@ async def test_malformed_redirect():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_no_scheme_redirect():
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
     response = await client.get("https://example.org/no_scheme_redirect")
     assert response.status_code == codes.OK
     assert response.url == URL("https://example.org/")
@@ -240,7 +240,7 @@ async def test_no_scheme_redirect():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_fragment_redirect():
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
     response = await client.get("https://example.org/relative_redirect#fragment")
     assert response.status_code == codes.OK
     assert response.url == URL("https://example.org/#fragment")
@@ -249,7 +249,7 @@ async def test_fragment_redirect():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_multiple_redirects():
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
     response = await client.get("https://example.org/multiple_redirects?count=20")
     assert response.status_code == codes.OK
     assert response.url == URL("https://example.org/multiple_redirects")
@@ -266,14 +266,14 @@ async def test_multiple_redirects():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_too_many_redirects():
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
     with pytest.raises(TooManyRedirects):
         await client.get("https://example.org/multiple_redirects?count=21")
 
 
 @pytest.mark.usefixtures("async_environment")
 async def test_too_many_redirects_calling_next():
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
     url = "https://example.org/multiple_redirects?count=21"
     response = await client.get(url, allow_redirects=False)
     with pytest.raises(TooManyRedirects):
@@ -283,14 +283,14 @@ async def test_too_many_redirects_calling_next():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_redirect_loop():
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
     with pytest.raises(TooManyRedirects):
         await client.get("https://example.org/redirect_loop")
 
 
 @pytest.mark.usefixtures("async_environment")
 async def test_cross_domain_redirect():
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
     url = "https://example.com/cross_domain"
     headers = {"Authorization": "abc"}
     response = await client.get(url, headers=headers)
@@ -300,7 +300,7 @@ async def test_cross_domain_redirect():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_same_domain_redirect():
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
     url = "https://example.org/cross_domain"
     headers = {"Authorization": "abc"}
     response = await client.get(url, headers=headers)
@@ -313,7 +313,7 @@ async def test_body_redirect():
     """
     A 308 redirect should preserve the request body.
     """
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
     url = "https://example.org/redirect_body"
     data = b"Example request body"
     response = await client.post(url, data=data)
@@ -327,7 +327,7 @@ async def test_no_body_redirect():
     """
     A 303 redirect should remove the request body.
     """
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
     url = "https://example.org/redirect_no_body"
     data = b"Example request body"
     response = await client.post(url, data=data)
@@ -338,7 +338,7 @@ async def test_no_body_redirect():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_can_stream_if_no_redirect():
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
     url = "https://example.org/redirect_301"
     async with client.stream("GET", url, allow_redirects=False) as response:
         assert not response.is_closed
@@ -348,7 +348,7 @@ async def test_can_stream_if_no_redirect():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_cannot_redirect_streaming_body():
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
     url = "https://example.org/redirect_body"
 
     async def streaming_body():
@@ -360,13 +360,13 @@ async def test_cannot_redirect_streaming_body():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_cross_subdomain_redirect():
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
     url = "https://example.com/cross_subdomain"
     response = await client.get(url)
     assert response.url == URL("https://www.example.org/cross_subdomain")
 
 
-class MockCookieDispatch(httpcore.AsyncHTTPTransport):
+class MockCookieTransport(httpcore.AsyncHTTPTransport):
     async def request(
         self,
         method: bytes,
@@ -417,7 +417,7 @@ class MockCookieDispatch(httpcore.AsyncHTTPTransport):
 
 @pytest.mark.usefixtures("async_environment")
 async def test_redirect_cookie_behavior():
-    client = AsyncClient(dispatch=MockCookieDispatch())
+    client = AsyncClient(transport=MockCookieTransport())
 
     # The client is not logged in.
     response = await client.get("https://example.com/")
@@ -447,7 +447,7 @@ async def test_redirect_cookie_behavior():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_redirect_custom_scheme():
-    client = AsyncClient(dispatch=MockDispatch())
+    client = AsyncClient(transport=MockTransport())
     with pytest.raises(InvalidURL) as e:
         await client.post("https://example.org/redirect_custom_scheme")
     assert str(e.value) == 'Scheme "market" not supported.'

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -13,7 +13,7 @@ from httpx._content_streams import AsyncIteratorStream, encode
 from httpx._utils import format_form_param
 
 
-class MockDispatch(httpcore.AsyncHTTPTransport):
+class MockTransport(httpcore.AsyncHTTPTransport):
     async def request(
         self,
         method: bytes,
@@ -35,7 +35,7 @@ class MockDispatch(httpcore.AsyncHTTPTransport):
 @pytest.mark.parametrize(("value,output"), (("abc", b"abc"), (b"abc", b"abc")))
 @pytest.mark.asyncio
 async def test_multipart(value, output):
-    client = httpx.AsyncClient(dispatch=MockDispatch())
+    client = httpx.AsyncClient(transport=MockTransport())
 
     # Test with a single-value 'data' argument, and a plain file 'files' argument.
     data = {"text": value}
@@ -59,7 +59,7 @@ async def test_multipart(value, output):
 @pytest.mark.parametrize(("key"), (b"abc", 1, 2.3, None))
 @pytest.mark.asyncio
 async def test_multipart_invalid_key(key):
-    client = httpx.AsyncClient(dispatch=MockDispatch())
+    client = httpx.AsyncClient(transport=MockTransport())
     data = {key: "abc"}
     files = {"file": io.BytesIO(b"<file content>")}
     with pytest.raises(TypeError) as e:
@@ -70,7 +70,7 @@ async def test_multipart_invalid_key(key):
 @pytest.mark.parametrize(("value"), (1, 2.3, None, [None, "abc"], {None: "abc"}))
 @pytest.mark.asyncio
 async def test_multipart_invalid_value(value):
-    client = httpx.AsyncClient(dispatch=MockDispatch())
+    client = httpx.AsyncClient(transport=MockTransport())
     data = {"text": value}
     files = {"file": io.BytesIO(b"<file content>")}
     with pytest.raises(TypeError) as e:
@@ -80,7 +80,7 @@ async def test_multipart_invalid_value(value):
 
 @pytest.mark.asyncio
 async def test_multipart_file_tuple():
-    client = httpx.AsyncClient(dispatch=MockDispatch())
+    client = httpx.AsyncClient(transport=MockTransport())
 
     # Test with a list of values 'data' argument, and a tuple style 'files' argument.
     data = {"text": ["abc"]}

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -34,7 +34,7 @@ async def test_connect_timeout(server):
 
 @pytest.mark.usefixtures("async_environment")
 async def test_pool_timeout(server):
-    pool_limits = httpx.PoolLimits(hard_limit=1)
+    pool_limits = httpx.PoolLimits(max_connections=1)
     timeout = httpx.Timeout(pool_timeout=1e-4)
 
     async with httpx.AsyncClient(pool_limits=pool_limits, timeout=timeout) as client:


### PR DESCRIPTION
Since there were still a few uses of `dispatch` instead of `transport` in tests, pytest complained about deprecation warnings.

Same thing happened with `hard_limit` and `max_connections` from `httpx.PoolLimits`.