### PR TITLE
Increase test coverage - take 2

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -249,8 +249,8 @@ We can raise an exception for any Client or Server error responses (4xx or 5xx s
 >>> not_found.raise_for_status()
 Traceback (most recent call last):
   File "/Users/tomchristie/GitHub/encode/httpcore/httpx/models.py", line 776, in raise_for_status
-    raise HttpError(message)
-httpx.exceptions.HttpError: 404 Not Found
+    raise HTTPError(message)
+httpx.HTTPError: 404 Not Found
 ```
 
 Any successful response codes will simply return `None` rather than raising an exception.

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -1539,5 +1539,3 @@ class StreamContextManager:
     ) -> None:
         assert isinstance(self.client, AsyncClient)
         await self.response.aclose()
-        if self.close_client:
-            await self.client.aclose()

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -826,7 +826,7 @@ class Response:
 
     def raise_for_status(self) -> None:
         """
-        Raise the `HttpError` if one occurred.
+        Raise the `HTTPError` if one occurred.
         """
         message = (
             "{0.status_code} {error_type}: {0.reason_phrase} for url: {0.url}\n"

--- a/scripts/coverage
+++ b/scripts/coverage
@@ -8,4 +8,4 @@ export SOURCE_FILES="httpx tests"
 
 set -x
 
-${PREFIX}coverage report --show-missing --skip-covered --fail-under=97
+${PREFIX}coverage report --show-missing --skip-covered --fail-under=99

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -9,6 +9,7 @@ from httpx import (
     URL,
     AsyncClient,
     Auth,
+    Client,
     DigestAuth,
     Headers,
     ProtocolError,
@@ -27,12 +28,35 @@ def get_header_value(headers, key, default=None):
     return default
 
 
-class MockTransport(httpcore.AsyncHTTPTransport):
+class AsyncMockTransport(httpcore.AsyncHTTPTransport):
     def __init__(self, auth_header: bytes = b"", status_code: int = 200) -> None:
         self.auth_header = auth_header
         self.status_code = status_code
 
     async def request(
+        self,
+        method: bytes,
+        url: typing.Tuple[bytes, bytes, int, bytes],
+        headers: typing.List[typing.Tuple[bytes, bytes]],
+        stream: ContentStream,
+        timeout: typing.Dict[str, typing.Optional[float]] = None,
+    ) -> typing.Tuple[
+        bytes, int, bytes, typing.List[typing.Tuple[bytes, bytes]], ContentStream
+    ]:
+        authorization = get_header_value(headers, "Authorization")
+        response_headers = (
+            [(b"www-authenticate", self.auth_header)] if self.auth_header else []
+        )
+        response_stream = JSONStream({"auth": authorization})
+        return b"HTTP/1.1", self.status_code, b"", response_headers, response_stream
+
+
+class SyncMockTransport(httpcore.SyncHTTPTransport):
+    def __init__(self, auth_header: bytes = b"", status_code: int = 200) -> None:
+        self.auth_header = auth_header
+        self.status_code = status_code
+
+    def request(
         self,
         method: bytes,
         url: typing.Tuple[bytes, bytes, int, bytes],
@@ -114,12 +138,58 @@ class MockDigestAuthTransport(httpcore.AsyncHTTPTransport):
         return b"HTTP/1.1", 401, b"", headers, ContentStream()
 
 
+class RepeatAuth(Auth):
+    """
+    A mock authentication scheme that requires clients to send
+    the request a fixed number of times, and then send a last request containing
+    an aggregation of nonces that the server sent in 'WWW-Authenticate' headers
+    of intermediate responses.
+    """
+
+    requires_request_body = True
+
+    def __init__(self, repeat: int):
+        self.repeat = repeat
+
+    def auth_flow(self, request: Request) -> typing.Generator[Request, Response, None]:
+        nonces = []
+
+        for index in range(self.repeat):
+            request.headers["Authorization"] = f"Repeat {index}"
+            response = yield request
+            nonces.append(response.headers["www-authenticate"])
+
+        key = ".".join(nonces)
+        request.headers["Authorization"] = f"Repeat {key}"
+        yield request
+
+
+class ResponseBodyAuth(Auth):
+    """
+    A mock authentication scheme that requires clients to send an 'Authorization'
+    header, then send back the contents of the response in the 'Authorization'
+    header.
+    """
+
+    requires_response_body = True
+
+    def __init__(self, token):
+        self.token = token
+
+    def auth_flow(self, request: Request) -> typing.Generator[Request, Response, None]:
+        request.headers["Authorization"] = self.token
+        response = yield request
+        data = response.text
+        request.headers["Authorization"] = data
+        yield request
+
+
 @pytest.mark.asyncio
 async def test_basic_auth() -> None:
     url = "https://example.org/"
     auth = ("tomchristie", "password123")
 
-    client = AsyncClient(transport=MockTransport())
+    client = AsyncClient(transport=AsyncMockTransport())
     response = await client.get(url, auth=auth)
 
     assert response.status_code == 200
@@ -130,7 +200,7 @@ async def test_basic_auth() -> None:
 async def test_basic_auth_in_url() -> None:
     url = "https://tomchristie:password123@example.org/"
 
-    client = AsyncClient(transport=MockTransport())
+    client = AsyncClient(transport=AsyncMockTransport())
     response = await client.get(url)
 
     assert response.status_code == 200
@@ -142,7 +212,7 @@ async def test_basic_auth_on_session() -> None:
     url = "https://example.org/"
     auth = ("tomchristie", "password123")
 
-    client = AsyncClient(transport=MockTransport(), auth=auth)
+    client = AsyncClient(transport=AsyncMockTransport(), auth=auth)
     response = await client.get(url)
 
     assert response.status_code == 200
@@ -157,7 +227,7 @@ async def test_custom_auth() -> None:
         request.headers["Authorization"] = "Token 123"
         return request
 
-    client = AsyncClient(transport=MockTransport())
+    client = AsyncClient(transport=AsyncMockTransport())
     response = await client.get(url, auth=auth)
 
     assert response.status_code == 200
@@ -169,7 +239,7 @@ async def test_netrc_auth() -> None:
     os.environ["NETRC"] = "tests/.netrc"
     url = "http://netrcexample.org"
 
-    client = AsyncClient(transport=MockTransport())
+    client = AsyncClient(transport=AsyncMockTransport())
     response = await client.get(url)
 
     assert response.status_code == 200
@@ -183,7 +253,7 @@ async def test_auth_header_has_priority_over_netrc() -> None:
     os.environ["NETRC"] = "tests/.netrc"
     url = "http://netrcexample.org"
 
-    client = AsyncClient(transport=MockTransport())
+    client = AsyncClient(transport=AsyncMockTransport())
     response = await client.get(url, headers={"Authorization": "Override"})
 
     assert response.status_code == 200
@@ -195,13 +265,13 @@ async def test_trust_env_auth() -> None:
     os.environ["NETRC"] = "tests/.netrc"
     url = "http://netrcexample.org"
 
-    client = AsyncClient(transport=MockTransport(), trust_env=False)
+    client = AsyncClient(transport=AsyncMockTransport(), trust_env=False)
     response = await client.get(url)
 
     assert response.status_code == 200
     assert response.json() == {"auth": None}
 
-    client = AsyncClient(transport=MockTransport(), trust_env=True)
+    client = AsyncClient(transport=AsyncMockTransport(), trust_env=True)
     response = await client.get(url)
 
     assert response.status_code == 200
@@ -222,7 +292,7 @@ async def test_auth_hidden_header() -> None:
     url = "https://example.org/"
     auth = ("example-username", "example-password")
 
-    client = AsyncClient(transport=MockTransport())
+    client = AsyncClient(transport=AsyncMockTransport())
     response = await client.get(url, auth=auth)
 
     assert "'authorization': '[secure]'" in str(response.request.headers)
@@ -232,7 +302,7 @@ async def test_auth_hidden_header() -> None:
 async def test_auth_invalid_type() -> None:
     url = "https://example.org/"
     client = AsyncClient(
-        transport=MockTransport(), auth="not a tuple, not a callable",  # type: ignore
+        transport=AsyncMockTransport(), auth="not a tuple, not a callable",
     )
     with pytest.raises(TypeError):
         await client.get(url)
@@ -243,7 +313,7 @@ async def test_digest_auth_returns_no_auth_if_no_digest_header_in_response() -> 
     url = "https://example.org/"
     auth = DigestAuth(username="tomchristie", password="password123")
 
-    client = AsyncClient(transport=MockTransport())
+    client = AsyncClient(transport=AsyncMockTransport())
     response = await client.get(url, auth=auth)
 
     assert response.status_code == 200
@@ -258,7 +328,7 @@ async def test_digest_auth_200_response_including_digest_auth_header() -> None:
     auth_header = b'Digest realm="realm@host.com",qop="auth",nonce="abc",opaque="xyz"'
 
     client = AsyncClient(
-        transport=MockTransport(auth_header=auth_header, status_code=200)
+        transport=AsyncMockTransport(auth_header=auth_header, status_code=200)
     )
     response = await client.get(url, auth=auth)
 
@@ -272,7 +342,7 @@ async def test_digest_auth_401_response_without_digest_auth_header() -> None:
     url = "https://example.org/"
     auth = DigestAuth(username="tomchristie", password="password123")
 
-    client = AsyncClient(transport=MockTransport(auth_header=b"", status_code=401))
+    client = AsyncClient(transport=AsyncMockTransport(auth_header=b"", status_code=401))
     response = await client.get(url, auth=auth)
 
     assert response.status_code == 401
@@ -413,58 +483,77 @@ async def test_digest_auth_incorrect_credentials() -> None:
     ],
 )
 @pytest.mark.asyncio
-async def test_digest_auth_raises_protocol_error_on_malformed_header(
+async def test_async_digest_auth_raises_protocol_error_on_malformed_header(
     auth_header: bytes,
 ) -> None:
     url = "https://example.org/"
     auth = DigestAuth(username="tomchristie", password="password123")
     client = AsyncClient(
-        transport=MockTransport(auth_header=auth_header, status_code=401)
+        transport=AsyncMockTransport(auth_header=auth_header, status_code=401)
     )
 
     with pytest.raises(ProtocolError):
         await client.get(url, auth=auth)
 
 
+@pytest.mark.parametrize(
+    "auth_header",
+    [
+        b'Digest realm="httpx@example.org", qop="auth"',  # missing fields
+        b'realm="httpx@example.org", qop="auth"',  # not starting with Digest
+        b'DigestZ realm="httpx@example.org", qop="auth"'
+        b'qop="auth,auth-int",nonce="abc",opaque="xyz"',
+        b'Digest realm="httpx@example.org", qop="auth,au',  # malformed fields list
+    ],
+)
+def test_sync_digest_auth_raises_protocol_error_on_malformed_header(
+    auth_header: bytes,
+) -> None:
+    url = "https://example.org/"
+    auth = DigestAuth(username="tomchristie", password="password123")
+    client = Client(
+        transport=SyncMockTransport(auth_header=auth_header, status_code=401)
+    )
+
+    with pytest.raises(ProtocolError):
+        client.get(url, auth=auth)
+
+
 @pytest.mark.asyncio
-async def test_auth_history() -> None:
+async def test_async_auth_history() -> None:
     """
     Test that intermediate requests sent as part of an authentication flow
     are recorded in the response history.
     """
-
-    class RepeatAuth(Auth):
-        """
-        A mock authentication scheme that requires clients to send
-        the request a fixed number of times, and then send a last request containing
-        an aggregation of nonces that the server sent in 'WWW-Authenticate' headers
-        of intermediate responses.
-        """
-
-        requires_request_body = True
-
-        def __init__(self, repeat: int):
-            self.repeat = repeat
-
-        def auth_flow(
-            self, request: Request
-        ) -> typing.Generator[Request, Response, None]:
-            nonces = []
-
-            for index in range(self.repeat):
-                request.headers["Authorization"] = f"Repeat {index}"
-                response = yield request
-                nonces.append(response.headers["www-authenticate"])
-
-            key = ".".join(nonces)
-            request.headers["Authorization"] = f"Repeat {key}"
-            yield request
-
     url = "https://example.org/"
     auth = RepeatAuth(repeat=2)
-    client = AsyncClient(transport=MockTransport(auth_header=b"abc"))
+    client = AsyncClient(transport=AsyncMockTransport(auth_header=b"abc"))
 
     response = await client.get(url, auth=auth)
+    assert response.status_code == 200
+    assert response.json() == {"auth": "Repeat abc.abc"}
+
+    assert len(response.history) == 2
+    resp1, resp2 = response.history
+    assert resp1.json() == {"auth": "Repeat 0"}
+    assert resp2.json() == {"auth": "Repeat 1"}
+
+    assert len(resp2.history) == 1
+    assert resp2.history == [resp1]
+
+    assert len(resp1.history) == 0
+
+
+def test_sync_auth_history() -> None:
+    """
+    Test that intermediate requests sent as part of an authentication flow
+    are recorded in the response history.
+    """
+    url = "https://example.org/"
+    auth = RepeatAuth(repeat=2)
+    client = Client(transport=SyncMockTransport(auth_header=b"abc"))
+
+    response = client.get(url, auth=auth)
     assert response.status_code == 200
     assert response.json() == {"auth": "Repeat abc.abc"}
 
@@ -483,7 +572,7 @@ async def test_auth_history() -> None:
 async def test_digest_auth_unavailable_streaming_body():
     url = "https://example.org/"
     auth = DigestAuth(username="tomchristie", password="password123")
-    client = AsyncClient(transport=MockTransport())
+    client = AsyncClient(transport=AsyncMockTransport())
 
     async def streaming_body():
         yield b"Example request body"  # pragma: nocover
@@ -493,37 +582,29 @@ async def test_digest_auth_unavailable_streaming_body():
 
 
 @pytest.mark.asyncio
-async def test_auth_reads_response_body() -> None:
+async def test_async_auth_reads_response_body() -> None:
     """
     Test that we can read the response body in an auth flow if `requires_response_body`
     is set.
     """
-
-    class ResponseBodyAuth(Auth):
-        """
-        A mock authentication scheme that requires clients to send an 'Authorization'
-        header, then send back the contents of the response in the 'Authorization'
-        header.
-        """
-
-        requires_response_body = True
-
-        def __init__(self, token):
-            self.token = token
-
-        def auth_flow(
-            self, request: Request
-        ) -> typing.Generator[Request, Response, None]:
-            request.headers["Authorization"] = self.token
-            response = yield request
-            data = response.text
-            request.headers["Authorization"] = data
-            yield request
-
     url = "https://example.org/"
     auth = ResponseBodyAuth("xyz")
-    client = AsyncClient(transport=MockTransport())
+    client = AsyncClient(transport=AsyncMockTransport())
 
     response = await client.get(url, auth=auth)
+    assert response.status_code == 200
+    assert response.json() == {"auth": '{"auth": "xyz"}'}
+
+
+def test_sync_auth_reads_response_body() -> None:
+    """
+    Test that we can read the response body in an auth flow if `requires_response_body`
+    is set.
+    """
+    url = "https://example.org/"
+    auth = ResponseBodyAuth("xyz")
+    client = Client(transport=SyncMockTransport())
+
+    response = client.get(url, auth=auth)
     assert response.status_code == 200
     assert response.json() == {"auth": '{"auth": "xyz"}'}

--- a/tests/client/test_proxies.py
+++ b/tests/client/test_proxies.py
@@ -84,6 +84,17 @@ def test_transport_for_request(url, proxies, expected):
         assert transport.proxy_origin == httpx.URL(expected).raw[:3]
 
 
+@pytest.mark.asyncio
+async def test_async_proxy_close():
+    client = httpx.AsyncClient(proxies={"all": PROXY_URL})
+    await client.aclose()
+
+
+def test_sync_proxy_close():
+    client = httpx.Client(proxies={"all": PROXY_URL})
+    client.close()
+
+
 def test_unsupported_proxy_scheme():
     with pytest.raises(ValueError):
         httpx.AsyncClient(proxies="ftp://127.0.0.1")

--- a/tests/concurrency.py
+++ b/tests/concurrency.py
@@ -10,6 +10,6 @@ import trio
 
 async def sleep(seconds: float) -> None:
     if sniffio.current_async_library() == "trio":
-        await trio.sleep(seconds)
+        await trio.sleep(seconds)  # pragma: nocover
     else:
         await asyncio.sleep(seconds)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -233,7 +233,7 @@ class TestServer(Server):
         }
         await asyncio.wait(tasks)
 
-    async def restart(self) -> None:
+    async def restart(self) -> None:  # pragma: nocover
         # This coroutine may be called from a different thread than the one the
         # server is running on, and from an async environment that's not asyncio.
         # For this reason, we use an event to coordinate with the server
@@ -244,7 +244,7 @@ class TestServer(Server):
         while not self.started:
             await sleep(0.2)
 
-    async def watch_restarts(self):
+    async def watch_restarts(self):  # pragma: nocover
         while True:
             if self.should_exit:
                 return

--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -197,6 +197,14 @@ def test_origin_repr():
     assert str(origin) == "Origin(scheme='https' host='example.com' port=8080)"
 
 
+def test_origin_equal():
+    origin1 = Origin("https://example.com")
+    origin2 = Origin("https://example.com")
+    assert origin1 is not origin2
+    assert origin1 == origin2
+    assert len({origin1, origin2}) == 1
+
+
 def test_url_copywith_for_authority():
     copy_with_kwargs = {
         "username": "username",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -67,6 +67,11 @@ def test_get_netrc_login():
     assert netrc_info.get_credentials("netrcexample.org") == expected_credentials
 
 
+def test_get_netrc_unknown():
+    netrc_info = NetRCInfo(["tests/.netrc"])
+    assert netrc_info.get_credentials("nonexistant.org") is None
+
+
 @pytest.mark.parametrize(
     "value, expected",
     (


### PR DESCRIPTION
More work towards #316, continuation of #1003

After this is merged, the only remaining untested part will be `URLLib3Transport`.

Small note about `StreamContextManager`. [The only line not tested](https://github.com/encode/httpx/blob/8c84210555294ce10c681edae2df71627095a4e9/httpx/_client.py#L1543) is because the only usage of the context manager in an async environment is from [BaseClient.stream](https://github.com/jcugat/httpx/blob/e4048964d40fb1aec627c77d1c0adcd509fc1975/httpx/_client.py#L171) where it doesn't use the `close_client` parameter (and by default is `false`). The only other usage is from the [api.stream](https://github.com/jcugat/httpx/blob/e4048964d40fb1aec627c77d1c0adcd509fc1975/httpx/_api.py#L100) method but that is always called from a sync context, so the `__aexit__` will never have `close_client=True`. Should it be removed?