### PR TITLE
Add support for async multipart file contents

### DIFF
--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -3,6 +3,7 @@ from ._api import delete, get, head, options, patch, post, put, request, stream
 from ._auth import Auth, BasicAuth, DigestAuth
 from ._client import AsyncClient, Client
 from ._config import PoolLimits, Proxy, Timeout
+from ._content_streams import AsyncMultipartContent
 from ._exceptions import (
     ConnectTimeout,
     CookieConflict,
@@ -47,6 +48,7 @@ __all__ = [
     "ASGIDispatch",
     "ASGITransport",
     "AsyncClient",
+    "AsyncMultipartContent",
     "Auth",
     "BasicAuth",
     "Client",

--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from ._auth import Auth  # noqa: F401
     from ._config import Proxy, Timeout  # noqa: F401
     from ._models import URL, Cookies, Headers, QueryParams, Request  # noqa: F401
+    from ._content_streams import AsyncMultipartContent
 
 
 PrimitiveData = Optional[Union[str, int, float, bool]]
@@ -63,7 +64,7 @@ AuthTypes = Union[
 
 RequestData = Union[dict, str, bytes, Iterator[bytes], AsyncIterator[bytes]]
 
-FileContent = Union[IO[str], IO[bytes], str, bytes]
+FileContent = Union[IO[str], IO[bytes], str, bytes, "AsyncMultipartContent"]
 FileTypes = Union[
     # file (or text)
     FileContent,


### PR DESCRIPTION
Fixes #1015 

Add an `AsyncMultipartContent` helper that requires passing a `length` hint, and review our multipart implementation to expect that in the `__aiter__()` code path (which we had already implemented to allow using multipart with `AsyncClient`).

Still needs a bit of refining, but submitting this for comments already…

The idea behind a dedicated wrapping helper is that there's no official "here's what async file I/O looks like" in Python (mostly because file I/O in kernels is almost always synchronous anyway, and eg `aiofiles` achieves async by deffering to threads). The only blocker to allowing any arbitrary async iterator is that we need to be able to peek the content length, otherwise we'd have to read everything, and lose the streaming behavior. (I'm actually thinking we might want this potentially-unsafe default to be opt-in, eg "raise exception unless user has set an allow flag", but that's something else.) So, hence this wrapper for "give me an aiterator + its expected total content length".