### PR TITLE
Tweak .stream() API

### DIFF
--- a/httpx/_api.py
+++ b/httpx/_api.py
@@ -130,8 +130,8 @@ def stream(
     response = client.send(
         request=request,
         auth=auth,
-        allow_redirects=allow_redirects,
         timeout=timeout,
+        allow_redirects=allow_redirects,
         stream=True,
     )
     try:

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -6,6 +6,7 @@ import typing
 import urllib.request
 from collections.abc import MutableMapping
 from http.cookiejar import Cookie, CookieJar
+from types import TracebackType
 from urllib.parse import parse_qsl, urlencode
 
 import chardet
@@ -954,6 +955,17 @@ class Response:
             if hasattr(self, "_raw_stream"):
                 self._raw_stream.close()
 
+    def __enter__(self) -> "Response":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: typing.Type[BaseException] = None,
+        exc_value: BaseException = None,
+        traceback: TracebackType = None,
+    ) -> None:
+        self.close()
+
     async def aread(self) -> bytes:
         """
         Read and return the response content.
@@ -1026,6 +1038,17 @@ class Response:
             self._elapsed = self.request.timer.elapsed
             if hasattr(self, "_raw_stream"):
                 await self._raw_stream.aclose()
+
+    async def __aenter__(self) -> "Response":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: typing.Type[BaseException] = None,
+        exc_value: BaseException = None,
+        traceback: TracebackType = None,
+    ) -> None:
+        await self.aclose()
 
 
 class Cookies(MutableMapping):

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -61,7 +61,7 @@ async def test_post_json(server):
 @pytest.mark.usefixtures("async_environment")
 async def test_stream_response(server):
     async with httpx.AsyncClient() as client:
-        async with client.stream("GET", server.url) as response:
+        async with await client.stream("GET", server.url) as response:
             body = await response.aread()
 
     assert response.status_code == 200
@@ -72,7 +72,7 @@ async def test_stream_response(server):
 @pytest.mark.usefixtures("async_environment")
 async def test_access_content_stream_response(server):
     async with httpx.AsyncClient() as client:
-        async with client.stream("GET", server.url) as response:
+        async with await client.stream("GET", server.url) as response:
             pass
 
     assert response.status_code == 200

--- a/tests/client/test_redirects.py
+++ b/tests/client/test_redirects.py
@@ -372,7 +372,7 @@ async def test_no_body_redirect():
 async def test_can_stream_if_no_redirect():
     client = AsyncClient(transport=AsyncMockTransport())
     url = "https://example.org/redirect_301"
-    async with client.stream("GET", url, allow_redirects=False) as response:
+    async with await client.stream("GET", url, allow_redirects=False) as response:
         assert not response.is_closed
     assert response.status_code == codes.MOVED_PERMANENTLY
     assert response.headers["location"] == "https://example.org/"

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -38,6 +38,6 @@ async def test_pool_timeout(server):
     timeout = httpx.Timeout(pool_timeout=1e-4)
 
     async with httpx.AsyncClient(pool_limits=pool_limits, timeout=timeout) as client:
-        async with client.stream("GET", server.url):
+        async with await client.stream("GET", server.url):
             with pytest.raises(httpx.PoolTimeout):
                 await client.get("http://localhost:8000/")


### PR DESCRIPTION
Refs #830 

A proof-of-concept (but working) PR to illustrate https://github.com/encode/httpx/issues/830#issuecomment-644974594

- Add context manager capabilities to `Response`. (This brings us closer to what Requests does.)
- Make `.stream()` return a `Response`, allowing both context-managed and non-context-managed usage with an equivalent level of user experience.

The high-level `httpx.stream()` is kept to context-managed only because we also need to close the client on exit (and it would be awkward to eg implement a close callback API on the `Response` class just for this internal use case).

The breaking change here is that users would need to use `async with await client.stream()` in the async context-managed use case (extra `await`). This usage might be surprising but in line with other things such as [trio's `open_file()` API](https://trio.readthedocs.io/en/stable/reference-io.html#trio.open_file).