### PR TITLE
Non relative dir tests

### DIFF
--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -1,6 +1,7 @@
 import hashlib
 import os
 import typing
+from pathlib import Path
 
 import httpcore
 import pytest
@@ -231,7 +232,7 @@ async def test_custom_auth() -> None:
 
 @pytest.mark.asyncio
 async def test_netrc_auth() -> None:
-    os.environ["NETRC"] = "tests/.netrc"
+    os.environ["NETRC"] = (Path(__file__).parent.parent / ".netrc").as_posix()
     url = "http://netrcexample.org"
 
     client = AsyncClient(transport=AsyncMockTransport())
@@ -257,7 +258,7 @@ async def test_auth_header_has_priority_over_netrc() -> None:
 
 @pytest.mark.asyncio
 async def test_trust_env_auth() -> None:
-    os.environ["NETRC"] = "tests/.netrc"
+    os.environ["NETRC"] = (Path(__file__).parent.parent / ".netrc").as_posix()
     url = "http://netrcexample.org"
 
     client = AsyncClient(transport=AsyncMockTransport(), trust_env=False)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+from pathlib import Path
 
 import pytest
 
@@ -59,7 +60,7 @@ def test_bad_get_netrc_login():
 
 
 def test_get_netrc_login():
-    netrc_info = NetRCInfo(["tests/.netrc"])
+    netrc_info = NetRCInfo([(Path(__file__).parent / ".netrc").as_posix()])
     expected_credentials = (
         "example-username",
         "example-password",
@@ -137,14 +138,14 @@ def test_get_ssl_cert_file():
     # Two environments is not set.
     assert get_ca_bundle_from_env() is None
 
-    os.environ["SSL_CERT_DIR"] = "tests/"
+    os.environ["SSL_CERT_DIR"] = (Path(__file__).parent).as_posix()
     # SSL_CERT_DIR is correctly set, SSL_CERT_FILE is not set.
-    assert get_ca_bundle_from_env() == "tests"
+    assert get_ca_bundle_from_env() == (Path(__file__).parent).as_posix()
 
     del os.environ["SSL_CERT_DIR"]
-    os.environ["SSL_CERT_FILE"] = "tests/test_utils.py"
+    os.environ["SSL_CERT_FILE"] = (Path(__file__).parent /"test_utils.py" ).as_posix()
     # SSL_CERT_FILE is correctly set, SSL_CERT_DIR is not set.
-    assert get_ca_bundle_from_env() == "tests/test_utils.py"
+    assert get_ca_bundle_from_env() == (Path(__file__).parent /"test_utils.py" ).as_posix()
 
     os.environ["SSL_CERT_FILE"] = "wrongfile"
     # SSL_CERT_FILE is set with wrong file,  SSL_CERT_DIR is not set.
@@ -155,14 +156,14 @@ def test_get_ssl_cert_file():
     # SSL_CERT_DIR is set with wrong path,  SSL_CERT_FILE is not set.
     assert get_ca_bundle_from_env() is None
 
-    os.environ["SSL_CERT_DIR"] = "tests/"
-    os.environ["SSL_CERT_FILE"] = "tests/test_utils.py"
+    os.environ["SSL_CERT_DIR"] = (Path(__file__).parent).as_posix()
+    os.environ["SSL_CERT_FILE"] = (Path(__file__).parent/ "test_utils.py").as_posix()
     # Two environments is correctly set.
-    assert get_ca_bundle_from_env() == "tests/test_utils.py"
+    assert get_ca_bundle_from_env() == (Path(__file__).parent / "test_utils.py").as_posix()
 
     os.environ["SSL_CERT_FILE"] = "wrongfile"
     # Two environments is set but SSL_CERT_FILE is not a file.
-    assert get_ca_bundle_from_env() == "tests"
+    assert get_ca_bundle_from_env() == (Path(__file__).parent).as_posix()
 
     os.environ["SSL_CERT_DIR"] = "wrongpath"
     # Two environments is set but both are not correct.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -143,9 +143,11 @@ def test_get_ssl_cert_file():
     assert get_ca_bundle_from_env() == (Path(__file__).parent).as_posix()
 
     del os.environ["SSL_CERT_DIR"]
-    os.environ["SSL_CERT_FILE"] = (Path(__file__).parent /"test_utils.py" ).as_posix()
+    os.environ["SSL_CERT_FILE"] = (Path(__file__).parent / "test_utils.py").as_posix()
     # SSL_CERT_FILE is correctly set, SSL_CERT_DIR is not set.
-    assert get_ca_bundle_from_env() == (Path(__file__).parent /"test_utils.py" ).as_posix()
+    assert (
+        get_ca_bundle_from_env() == (Path(__file__).parent / "test_utils.py").as_posix()
+    )
 
     os.environ["SSL_CERT_FILE"] = "wrongfile"
     # SSL_CERT_FILE is set with wrong file,  SSL_CERT_DIR is not set.
@@ -157,9 +159,11 @@ def test_get_ssl_cert_file():
     assert get_ca_bundle_from_env() is None
 
     os.environ["SSL_CERT_DIR"] = (Path(__file__).parent).as_posix()
-    os.environ["SSL_CERT_FILE"] = (Path(__file__).parent/ "test_utils.py").as_posix()
+    os.environ["SSL_CERT_FILE"] = (Path(__file__).parent / "test_utils.py").as_posix()
     # Two environments is correctly set.
-    assert get_ca_bundle_from_env() == (Path(__file__).parent / "test_utils.py").as_posix()
+    assert (
+        get_ca_bundle_from_env() == (Path(__file__).parent / "test_utils.py").as_posix()
+    )
 
     os.environ["SSL_CERT_FILE"] = "wrongfile"
     # Two environments is set but SSL_CERT_FILE is not a file.


### PR DESCRIPTION
Current tests works fine and all pass running the script.

However it assumes the working directory under which pytest runs is `httpx`

When using various IDE, in my case PyCharm you run tests by default using `httpx/tests` as the working directory, which is why the 4 tests "fixed" will fail because of the files/directories discovery. You can modify this of course, but the reason why the tests are failing is not immediately obvious.

So long story short it's a non-essential PR but I scratched my head on this long enough and this would avoid someone willing to contribute losing time on tests failing because of his configuration
