### PR TITLE
Improve list/dict comprehensions

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -651,7 +651,7 @@ class Request:
         Read and return the request content.
         """
         if not hasattr(self, "_content"):
-            self._content = b"".join([part for part in self.stream])
+            self._content = b"".join(list(self.stream))
             # If a streaming request has been read entirely into memory, then
             # we can replace the stream with a raw bytes implementation,
             # to ensure that any non-replayable streams can still be used.
@@ -895,7 +895,7 @@ class Response:
         Read and return the response content.
         """
         if not hasattr(self, "_content"):
-            self._content = b"".join([part for part in self.iter_bytes()])
+            self._content = b"".join(list(self.iter_bytes()))
         return self._content
 
     def iter_bytes(self) -> typing.Iterator[bytes]:

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -651,7 +651,7 @@ class Request:
         Read and return the request content.
         """
         if not hasattr(self, "_content"):
-            self._content = b"".join(list(self.stream))
+            self._content = b"".join(self.stream)
             # If a streaming request has been read entirely into memory, then
             # we can replace the stream with a raw bytes implementation,
             # to ensure that any non-replayable streams can still be used.
@@ -895,7 +895,7 @@ class Response:
         Read and return the response content.
         """
         if not hasattr(self, "_content"):
-            self._content = b"".join(list(self.iter_bytes()))
+            self._content = b"".join(self.iter_bytes())
         return self._content
 
     def iter_bytes(self) -> typing.Iterator[bytes]:

--- a/httpx/_transports/urllib3.py
+++ b/httpx/_transports/urllib3.py
@@ -88,12 +88,9 @@ class URLLib3Transport(httpcore.SyncHTTPTransport):
             conn = self.pool.urlopen(
                 method=method.decode(),
                 url=url_str,
-                headers=dict(
-                    [
-                        (key.decode("ascii"), value.decode("ascii"))
-                        for key, value in headers
-                    ]
-                ),
+                headers={
+                    key.decode("ascii"): value.decode("ascii") for key, value in headers
+                },
                 body=body,
                 redirect=False,
                 assert_same_host=False,

--- a/httpx/_transports/wsgi.py
+++ b/httpx/_transports/wsgi.py
@@ -83,7 +83,7 @@ class WSGITransport(httpcore.SyncHTTPTransport):
         environ = {
             "wsgi.version": (1, 0),
             "wsgi.url_scheme": scheme.decode("ascii"),
-            "wsgi.input": io.BytesIO(b"".join([chunk for chunk in stream])),
+            "wsgi.input": io.BytesIO(b"".join(list(stream))),
             "wsgi.errors": io.BytesIO(),
             "wsgi.multithread": True,
             "wsgi.multiprocess": False,

--- a/httpx/_transports/wsgi.py
+++ b/httpx/_transports/wsgi.py
@@ -83,7 +83,7 @@ class WSGITransport(httpcore.SyncHTTPTransport):
         environ = {
             "wsgi.version": (1, 0),
             "wsgi.url_scheme": scheme.decode("ascii"),
-            "wsgi.input": io.BytesIO(b"".join(list(stream))),
+            "wsgi.input": io.BytesIO(b"".join(stream)),
             "wsgi.errors": io.BytesIO(),
             "wsgi.multithread": True,
             "wsgi.multiprocess": False,

--- a/tests/client/test_headers.py
+++ b/tests/client/test_headers.py
@@ -20,9 +20,9 @@ class MockTransport(httpcore.AsyncHTTPTransport):
     ) -> typing.Tuple[
         bytes, int, bytes, typing.List[typing.Tuple[bytes, bytes]], ContentStream
     ]:
-        headers_dict = dict(
-            [(key.decode("ascii"), value.decode("ascii")) for key, value in headers]
-        )
+        headers_dict = {
+            key.decode("ascii"): value.decode("ascii") for key, value in headers
+        }
         body = JSONStream({"headers": headers_dict})
         return b"HTTP/1.1", 200, b"OK", [], body
 

--- a/tests/client/test_redirects.py
+++ b/tests/client/test_redirects.py
@@ -100,9 +100,9 @@ class MockTransport:
             return b"HTTP/1.1", code, b"See Other", headers, ByteStream(b"")
 
         elif path == b"/cross_domain_target":
-            headers_dict = dict(
-                [(key.decode("ascii"), value.decode("ascii")) for key, value in headers]
-            )
+            headers_dict = {
+                key.decode("ascii"): value.decode("ascii") for key, value in headers
+            }
             content = ByteStream(json.dumps({"headers": headers_dict}).encode())
             return b"HTTP/1.1", 200, b"OK", [], content
 
@@ -118,9 +118,9 @@ class MockTransport:
 
         elif path == b"/redirect_body_target":
             content = b"".join(stream)
-            headers_dict = dict(
-                [(key.decode("ascii"), value.decode("ascii")) for key, value in headers]
-            )
+            headers_dict = {
+                key.decode("ascii"): value.decode("ascii") for key, value in headers
+            }
             body = ByteStream(
                 json.dumps({"body": content.decode(), "headers": headers_dict}).encode()
             )


### PR DESCRIPTION
- Use `list(iterable)` for converting to a list rather than `[item for item in iterable]`
- Use dict comprehension rather than a list comprehension wrapped in `dict()`