### PR TITLE
Remove needless whitespace strips

### DIFF
--- a/httpx/_auth.py
+++ b/httpx/_auth.py
@@ -76,7 +76,7 @@ class BasicAuth(Auth):
         self, username: typing.Union[str, bytes], password: typing.Union[str, bytes]
     ) -> str:
         userpass = b":".join((to_bytes(username), to_bytes(password)))
-        token = b64encode(userpass).decode().strip()
+        token = b64encode(userpass).decode()
         return f"Basic {token}"
 
 

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -355,7 +355,7 @@ class Proxy:
 
     def build_auth_header(self, username: str, password: str) -> str:
         userpass = (username.encode("utf-8"), password.encode("utf-8"))
-        token = b64encode(b":".join(userpass)).decode().strip()
+        token = b64encode(b":".join(userpass)).decode()
         return f"Basic {token}"
 
     def __repr__(self) -> str:


### PR DESCRIPTION
Dont strip whitespace from base64 strings. Whitespace characters are not included in base64 character set, so AFAIK it should be impossible for `b64encode` output to contain them.