### PR TITLE
Make isort configuration compatible with isort v5

### DIFF
--- a/httpx/_transports/asgi.py
+++ b/httpx/_transports/asgi.py
@@ -8,6 +8,7 @@ from .._utils import warn_deprecated
 
 if TYPE_CHECKING:  # pragma: no cover
     import asyncio
+
     import trio
 
     Event = Union[asyncio.Event, trio.Event]

--- a/scripts/check
+++ b/scripts/check
@@ -11,4 +11,4 @@ set -x
 ${PREFIX}black --check --diff --target-version=py36 $SOURCE_FILES
 ${PREFIX}flake8 $SOURCE_FILES
 ${PREFIX}mypy httpx
-${PREFIX}isort --check --diff --project=httpx --recursive $SOURCE_FILES
+${PREFIX}isort --check --diff --project=httpx $SOURCE_FILES

--- a/scripts/lint
+++ b/scripts/lint
@@ -10,5 +10,5 @@ set -x
 
 ${PREFIX}autoflake --in-place --recursive $SOURCE_FILES
 ${PREFIX}seed-isort-config --application-directories=httpx
-${PREFIX}isort --project=httpx --recursive --apply $SOURCE_FILES
+${PREFIX}isort --project=httpx $SOURCE_FILES
 ${PREFIX}black --target-version=py36 $SOURCE_FILES

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,13 +11,10 @@ disallow_untyped_defs = False
 check_untyped_defs = True
 
 [tool:isort]
+profile = black
 combine_as_imports = True
-force_grid_wrap = 0
-include_trailing_comma = True
 known_first_party = httpx,tests
 known_third_party = brotli,certifi,chardet,cryptography,hstspreload,httpcore,pytest,rfc3986,setuptools,sniffio,trio,trustme,uvicorn
-line_length = 88
-multi_line_output = 3
 
 [tool:pytest]
 addopts = --cov=httpx --cov=tests -rxXs


### PR DESCRIPTION
See https://timothycrosley.github.io/isort/CHANGELOG/

isort removed the flags `--recursive` and `--apply`. They are the default behavior in isort v5.