### PR TITLE
Pin isort version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ cryptography
 flake8
 flake8-bugbear
 flake8-pie
-isort
+isort==5.*
 mypy
 pytest
 pytest-asyncio


### PR DESCRIPTION
While reviewing https://github.com/encode/httpx/pull/1050 I noticed that `isort` is not pinned to the major version like it was done in httpcore's PR https://github.com/encode/httpcore/pull/111. I think it's a good idea to have it in both.

Related to this, should we pin all the development dependencies to strict versions and let someting like dependabot keep them updated? That way we would avoid breakages like what happened here: https://github.com/encode/httpx/pull/1048#issuecomment-653781722