### PR TITLE
Type check tests

### DIFF
--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -72,4 +72,4 @@ FileTypes = Union[
     # (filename, file (or text), content_type)
     Tuple[Optional[str], FileContent, Optional[str]],
 ]
-RequestFiles = Union[Mapping[str, FileTypes], List[Tuple[str, FileTypes]]]
+RequestFiles = Union[Mapping[str, FileTypes], Sequence[Tuple[str, FileTypes]]]

--- a/scripts/check
+++ b/scripts/check
@@ -10,5 +10,5 @@ set -x
 
 ${PREFIX}black --check --diff --target-version=py36 $SOURCE_FILES
 ${PREFIX}flake8 $SOURCE_FILES
-${PREFIX}mypy httpx
+${PREFIX}mypy $SOURCE_FILES
 ${PREFIX}isort --check --diff --project=httpx $SOURCE_FILES

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -174,8 +174,11 @@ def test_dispatch_deprecated():
 
 
 def test_asgi_dispatch_deprecated():
+    async def app(scope, receive, send):
+        pass
+
     with pytest.warns(DeprecationWarning) as record:
-        ASGIDispatch(None)
+        ASGIDispatch(app)
 
     assert len(record) == 1
     assert (

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -11,7 +11,6 @@ from httpx import (
     Auth,
     Client,
     DigestAuth,
-    Headers,
     ProtocolError,
     Request,
     RequestBodyUnavailable,
@@ -86,23 +85,26 @@ class MockDigestAuthTransport(httpcore.AsyncHTTPTransport):
     async def request(
         self,
         method: bytes,
-        url: typing.Tuple[bytes, bytes, int, bytes],
-        headers: typing.List[typing.Tuple[bytes, bytes]],
-        stream: ContentStream,
+        url: typing.Tuple[bytes, bytes, typing.Optional[int], bytes],
+        headers: typing.List[typing.Tuple[bytes, bytes]] = None,
+        stream: httpcore.AsyncByteStream = None,
         timeout: typing.Dict[str, typing.Optional[float]] = None,
     ) -> typing.Tuple[
         bytes, int, bytes, typing.List[typing.Tuple[bytes, bytes]], ContentStream
     ]:
         if self._response_count < self.send_response_after_attempt:
-            return self.challenge_send(method, url, headers, stream)
+            assert headers is not None
+            return self.challenge_send(method, headers)
 
         authorization = get_header_value(headers, "Authorization")
         body = JSONStream({"auth": authorization})
         return b"HTTP/1.1", 200, b"", [], body
 
     def challenge_send(
-        self, method: bytes, url: URL, headers: Headers, stream: ContentStream,
-    ) -> typing.Tuple[int, bytes, Headers, ContentStream]:
+        self, method: bytes, headers: typing.List[typing.Tuple[bytes, bytes]],
+    ) -> typing.Tuple[
+        bytes, int, bytes, typing.List[typing.Tuple[bytes, bytes]], ContentStream
+    ]:
         self._response_count += 1
         nonce = (
             hashlib.sha256(os.urandom(8)).hexdigest()
@@ -297,7 +299,8 @@ async def test_auth_hidden_header() -> None:
 async def test_auth_invalid_type() -> None:
     url = "https://example.org/"
     client = AsyncClient(
-        transport=AsyncMockTransport(), auth="not a tuple, not a callable",
+        transport=AsyncMockTransport(),
+        auth="not a tuple, not a callable",  # type: ignore
     )
     with pytest.raises(TypeError):
         await client.get(url)

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -182,8 +182,11 @@ def test_dispatch_deprecated():
 
 
 def test_wsgi_dispatch_deprecated():
+    def app(start_response, environ):
+        pass
+
     with pytest.warns(DeprecationWarning) as record:
-        WSGIDispatch(None)
+        WSGIDispatch(app)
 
     assert len(record) == 1
     assert (

--- a/tests/client/test_cookies.py
+++ b/tests/client/test_cookies.py
@@ -20,14 +20,15 @@ class MockTransport(httpcore.AsyncHTTPTransport):
     async def request(
         self,
         method: bytes,
-        url: typing.Tuple[bytes, bytes, int, bytes],
-        headers: typing.List[typing.Tuple[bytes, bytes]],
-        stream: ContentStream,
+        url: typing.Tuple[bytes, bytes, typing.Optional[int], bytes],
+        headers: typing.List[typing.Tuple[bytes, bytes]] = None,
+        stream: httpcore.AsyncByteStream = None,
         timeout: typing.Dict[str, typing.Optional[float]] = None,
     ) -> typing.Tuple[
         bytes, int, bytes, typing.List[typing.Tuple[bytes, bytes]], ContentStream
     ]:
         host, scheme, port, path = url
+        body: ContentStream
         if path.startswith(b"/echo_cookies"):
             cookie = get_header_value(headers, "cookie")
             body = JSONStream({"cookies": cookie})

--- a/tests/client/test_headers.py
+++ b/tests/client/test_headers.py
@@ -13,13 +13,14 @@ class MockTransport(httpcore.AsyncHTTPTransport):
     async def request(
         self,
         method: bytes,
-        url: typing.Tuple[bytes, bytes, int, bytes],
-        headers: typing.List[typing.Tuple[bytes, bytes]],
-        stream: ContentStream,
+        url: typing.Tuple[bytes, bytes, typing.Optional[int], bytes],
+        headers: typing.List[typing.Tuple[bytes, bytes]] = None,
+        stream: httpcore.AsyncByteStream = None,
         timeout: typing.Dict[str, typing.Optional[float]] = None,
     ) -> typing.Tuple[
         bytes, int, bytes, typing.List[typing.Tuple[bytes, bytes]], ContentStream
     ]:
+        assert headers is not None
         headers_dict = {
             key.decode("ascii"): value.decode("ascii") for key, value in headers
         }

--- a/tests/client/test_properties.py
+++ b/tests/client/test_properties.py
@@ -3,14 +3,14 @@ from httpx import AsyncClient, Cookies, Headers
 
 def test_client_headers():
     client = AsyncClient()
-    client.headers = {"a": "b"}
+    client.headers = {"a": "b"}  # type: ignore
     assert isinstance(client.headers, Headers)
     assert client.headers["A"] == "b"
 
 
 def test_client_cookies():
     client = AsyncClient()
-    client.cookies = {"a": "b"}
+    client.cookies = {"a": "b"}  # type: ignore
     assert isinstance(client.cookies, Cookies)
     mycookies = list(client.cookies.jar)
     assert len(mycookies) == 1

--- a/tests/client/test_proxies.py
+++ b/tests/client/test_proxies.py
@@ -1,3 +1,4 @@
+import httpcore
 import pytest
 
 import httpx
@@ -24,7 +25,9 @@ def test_proxies_parameter(proxies, expected_proxies):
 
     for proxy_key, url in expected_proxies:
         assert proxy_key in client.proxies
-        assert client.proxies[proxy_key].proxy_origin == httpx.URL(url).raw[:3]
+        proxy = client.proxies[proxy_key]
+        assert isinstance(proxy, httpcore.AsyncHTTPProxy)
+        assert proxy.proxy_origin == httpx.URL(url).raw[:3]
 
     assert len(expected_proxies) == len(client.proxies)
 
@@ -81,6 +84,7 @@ def test_transport_for_request(url, proxies, expected):
     if expected is None:
         assert transport is client.transport
     else:
+        assert isinstance(transport, httpcore.AsyncHTTPProxy)
         assert transport.proxy_origin == httpx.URL(expected).raw[:3]
 
 

--- a/tests/client/test_queryparams.py
+++ b/tests/client/test_queryparams.py
@@ -3,7 +3,7 @@ import typing
 import httpcore
 import pytest
 
-from httpx import URL, AsyncClient, Headers, QueryParams
+from httpx import URL, AsyncClient, QueryParams
 from httpx._content_streams import ContentStream, JSONStream
 
 
@@ -11,16 +11,15 @@ class MockTransport(httpcore.AsyncHTTPTransport):
     async def request(
         self,
         method: bytes,
-        url: typing.Tuple[bytes, bytes, int, bytes],
-        headers: typing.List[typing.Tuple[bytes, bytes]],
-        stream: ContentStream,
+        url: typing.Tuple[bytes, bytes, typing.Optional[int], bytes],
+        headers: typing.List[typing.Tuple[bytes, bytes]] = None,
+        stream: httpcore.AsyncByteStream = None,
         timeout: typing.Dict[str, typing.Optional[float]] = None,
     ) -> typing.Tuple[
         bytes, int, bytes, typing.List[typing.Tuple[bytes, bytes]], ContentStream
     ]:
-        headers = Headers()
         body = JSONStream({"ok": "ok"})
-        return b"HTTP/1.1", 200, b"OK", headers, body
+        return b"HTTP/1.1", 200, b"OK", [], body
 
 
 def test_client_queryparams():
@@ -35,7 +34,7 @@ def test_client_queryparams_string():
     assert client.params["a"] == "b"
 
     client = AsyncClient()
-    client.params = "a=b"
+    client.params = "a=b"  # type: ignore
     assert isinstance(client.params, QueryParams)
     assert client.params["a"] == "b"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,7 +56,7 @@ def async_environment(request: typing.Any) -> str:
 
 
 @pytest.fixture(scope="function", autouse=True)
-def clean_environ() -> typing.Dict[str, typing.Any]:
+def clean_environ():
     """Keeps os.environ clean for every test without having to mock os.environ"""
     original_environ = os.environ.copy()
     os.environ.clear()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -68,7 +68,6 @@ def test_stream(server):
     assert response.http_version == "HTTP/1.1"
 
 
-@pytest.mark.asyncio
-async def test_get_invalid_url(server):
+def test_get_invalid_url():
     with pytest.raises(httpx.InvalidURL):
-        await httpx.get("invalid://example.org")
+        httpx.get("invalid://example.org")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -56,7 +56,7 @@ def test_load_ssl_config_verify_env_file(https_server, ca_cert_pem_file, config)
 
 def test_load_ssl_config_verify_directory():
     path = Path(certifi.where()).parent
-    ssl_config = SSLConfig(verify=path)
+    ssl_config = SSLConfig(verify=str(path))
     context = ssl_config.ssl_context
     assert context.verify_mode == ssl.VerifyMode.CERT_REQUIRED
     assert context.check_hostname is True
@@ -192,7 +192,7 @@ def test_ssl_config_support_for_keylog_file(tmpdir, monkeypatch):  # pragma: noc
 
         ssl_config = SSLConfig(trust_env=True)
 
-        assert ssl_config.ssl_context.keylog_filename is None
+        assert ssl_config.ssl_context.keylog_filename is None  # type: ignore
 
     filename = str(tmpdir.join("test.log"))
 
@@ -201,11 +201,11 @@ def test_ssl_config_support_for_keylog_file(tmpdir, monkeypatch):  # pragma: noc
 
         ssl_config = SSLConfig(trust_env=True)
 
-        assert ssl_config.ssl_context.keylog_filename == filename
+        assert ssl_config.ssl_context.keylog_filename == filename  # type: ignore
 
         ssl_config = SSLConfig(trust_env=False)
 
-        assert ssl_config.ssl_context.keylog_filename is None
+        assert ssl_config.ssl_context.keylog_filename is None  # type: ignore
 
 
 @pytest.mark.parametrize(

--- a/tests/test_content_streams.py
+++ b/tests/test_content_streams.py
@@ -203,7 +203,7 @@ async def test_empty_request():
 
 def test_invalid_argument():
     with pytest.raises(TypeError):
-        encode(123)
+        encode(123)  # type: ignore
 
 
 @pytest.mark.asyncio

--- a/tests/test_status_codes.py
+++ b/tests/test_status_codes.py
@@ -7,7 +7,7 @@ def test_status_code_as_int():
 
 
 def test_lowercase_status_code():
-    assert httpx.codes.not_found == 404
+    assert httpx.codes.not_found == 404  # type: ignore
 
 
 def test_reason_phrase_for_status_code():


### PR DESCRIPTION
Closes #650

Finally get us to enable `mypy` on `tests/` :-)

This PR consists in:

- Updating `scripts/check` so that mypy is also run on the `tests/` directory.
- Fixing or silencing any type errors in tests to make mypy pass.