### PR TITLE
Add missing `Response.next()`

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -943,6 +943,15 @@ class Response:
             yield part
         self.close()
 
+    def next(self) -> "Response":
+        """
+        Get the next response from a redirect response.
+        """
+        if not self.is_redirect:
+            raise NotRedirectResponse()
+        assert self.call_next is not None
+        return self.call_next()
+
     def close(self) -> None:
         """
         Close the response and release the connection.

--- a/tests/client/test_redirects.py
+++ b/tests/client/test_redirects.py
@@ -310,7 +310,7 @@ def test_sync_too_many_redirects_calling_next():
     response = client.get(url, allow_redirects=False)
     with pytest.raises(TooManyRedirects):
         while response.is_redirect:
-            response = response.call_next()
+            response = response.next()
 
 
 @pytest.mark.usefixtures("async_environment")


### PR DESCRIPTION
**Motivation**
`Response.next()` is documented in the [developer docs](https://www.python-httpx.org/api/#response) but did not actually exist yet.