### PR TITLE
Drop deprecated API

### DIFF
--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -32,9 +32,9 @@ from ._exceptions import (
 )
 from ._models import URL, Cookies, Headers, QueryParams, Request, Response
 from ._status_codes import StatusCode, codes
-from ._transports.asgi import ASGIDispatch, ASGITransport
+from ._transports.asgi import ASGITransport
 from ._transports.urllib3 import URLLib3ProxyTransport, URLLib3Transport
-from ._transports.wsgi import WSGIDispatch, WSGITransport
+from ._transports.wsgi import WSGITransport
 
 __all__ = [
     "__description__",
@@ -51,7 +51,6 @@ __all__ = [
     "request",
     "stream",
     "codes",
-    "ASGIDispatch",
     "ASGITransport",
     "AsyncClient",
     "Auth",
@@ -96,6 +95,5 @@ __all__ = [
     "Request",
     "Response",
     "DigestAuth",
-    "WSGIDispatch",
     "WSGITransport",
 ]

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -48,7 +48,6 @@ from ._utils import (
     get_environment_proxies,
     get_logger,
     should_not_be_proxied,
-    warn_deprecated,
 )
 
 logger = get_logger(__name__)
@@ -472,14 +471,6 @@ class Client(BaseClient):
         )
 
         proxy_map = self.get_proxy_map(proxies, trust_env)
-
-        if dispatch is not None:
-            warn_deprecated(
-                "The dispatch argument is deprecated since v0.13 and will be "
-                "removed in a future release, please use 'transport'"
-            )
-            if transport is None:
-                transport = dispatch
 
         self.transport = self.init_transport(
             verify=verify,
@@ -1004,7 +995,6 @@ class AsyncClient(BaseClient):
         max_redirects: int = DEFAULT_MAX_REDIRECTS,
         base_url: URLTypes = None,
         transport: httpcore.AsyncHTTPTransport = None,
-        dispatch: httpcore.AsyncHTTPTransport = None,
         app: typing.Callable = None,
         trust_env: bool = True,
     ):
@@ -1018,14 +1008,6 @@ class AsyncClient(BaseClient):
             base_url=base_url,
             trust_env=trust_env,
         )
-
-        if dispatch is not None:
-            warn_deprecated(
-                "The dispatch argument is deprecated since v0.13 and will be "
-                "removed in a future release, please use 'transport'",
-            )
-            if transport is None:
-                transport = dispatch
 
         proxy_map = self.get_proxy_map(proxies, trust_env)
 

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -432,7 +432,6 @@ class Client(BaseClient):
     request URLs.
     * **transport** - *(optional)* A transport class to use for sending requests
     over the network.
-    * **dispatch** - *(optional)* A deprecated alias for transport.
     * **app** - *(optional)* An WSGI application to send requests to,
     rather than sending actual network requests.
     * **trust_env** - *(optional)* Enables or disables usage of environment
@@ -455,7 +454,6 @@ class Client(BaseClient):
         max_redirects: int = DEFAULT_MAX_REDIRECTS,
         base_url: URLTypes = None,
         transport: httpcore.SyncHTTPTransport = None,
-        dispatch: httpcore.SyncHTTPTransport = None,
         app: typing.Callable = None,
         trust_env: bool = True,
     ):
@@ -972,7 +970,6 @@ class AsyncClient(BaseClient):
     request URLs.
     * **transport** - *(optional)* A transport class to use for sending requests
     over the network.
-    * **dispatch** - *(optional)* A deprecated alias for transport.
     * **app** - *(optional)* An ASGI application to send requests to,
     rather than sending actual network requests.
     * **trust_env** - *(optional)* Enables or disables usage of environment

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -8,7 +8,7 @@ import certifi
 
 from ._models import URL, Headers
 from ._types import CertTypes, HeaderTypes, TimeoutTypes, URLTypes, VerifyTypes
-from ._utils import get_ca_bundle_from_env, get_logger, warn_deprecated
+from ._utils import get_ca_bundle_from_env, get_logger
 
 DEFAULT_CIPHERS = ":".join(
     [
@@ -295,23 +295,10 @@ class PoolLimits:
     """
 
     def __init__(
-        self,
-        *,
-        max_keepalive: int = None,
-        max_connections: int = None,
-        soft_limit: int = None,
-        hard_limit: int = None,
+        self, *, max_keepalive: int = None, max_connections: int = None,
     ):
         self.max_keepalive = max_keepalive
         self.max_connections = max_connections
-        if soft_limit is not None:  # pragma: nocover
-            self.max_keepalive = soft_limit
-            warn_deprecated("'soft_limit' is deprecated. Use 'max_keepalive' instead.",)
-        if hard_limit is not None:  # pragma: nocover
-            self.max_connections = hard_limit
-            warn_deprecated(
-                "'hard_limit' is deprecated. Use 'max_connections' instead.",
-            )
 
     def __eq__(self, other: typing.Any) -> bool:
         return (

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -51,7 +51,6 @@ from ._utils import (
     obfuscate_sensitive_headers,
     parse_header_links,
     str_query_param,
-    warn_deprecated,
 )
 
 
@@ -873,22 +872,6 @@ class Response:
 
     def __repr__(self) -> str:
         return f"<Response [{self.status_code} {self.reason_phrase}]>"
-
-    @property
-    def stream(self):  # type: ignore
-        warn_deprecated(  # pragma: nocover
-            "Response.stream() is due to be deprecated. "
-            "Use Response.aiter_bytes() instead.",
-        )
-        return self.aiter_bytes  # pragma: nocover
-
-    @property
-    def raw(self):  # type: ignore
-        warn_deprecated(  # pragma: nocover
-            "Response.raw() is due to be deprecated. "
-            "Use Response.aiter_raw() instead.",
-        )
-        return self.aiter_raw  # pragma: nocover
 
     def read(self) -> bytes:
         """

--- a/httpx/_transports/asgi.py
+++ b/httpx/_transports/asgi.py
@@ -4,7 +4,6 @@ import httpcore
 import sniffio
 
 from .._content_streams import ByteStream
-from .._utils import warn_deprecated
 
 if TYPE_CHECKING:  # pragma: no cover
     import asyncio
@@ -159,20 +158,3 @@ class ASGITransport(httpcore.AsyncHTTPTransport):
         stream = ByteStream(b"".join(body_parts))
 
         return (b"HTTP/1.1", status_code, b"", response_headers, stream)
-
-
-class ASGIDispatch(ASGITransport):
-    def __init__(
-        self,
-        app: Callable,
-        raise_app_exceptions: bool = True,
-        root_path: str = "",
-        client: Tuple[str, int] = ("127.0.0.1", 123),
-    ) -> None:
-        warn_deprecated("ASGIDispatch is deprecated, please use ASGITransport")
-        super().__init__(
-            app=app,
-            raise_app_exceptions=raise_app_exceptions,
-            root_path=root_path,
-            client=client,
-        )

--- a/httpx/_transports/wsgi.py
+++ b/httpx/_transports/wsgi.py
@@ -5,7 +5,6 @@ import typing
 import httpcore
 
 from .._content_streams import ByteStream, IteratorStream
-from .._utils import warn_deprecated
 
 
 def _skip_leading_empty_chunks(body: typing.Iterable) -> typing.Iterable:
@@ -132,20 +131,3 @@ class WSGITransport(httpcore.SyncHTTPTransport):
         stream = IteratorStream(chunk for chunk in result)
 
         return (b"HTTP/1.1", status_code, b"", headers, stream)
-
-
-class WSGIDispatch(WSGITransport):
-    def __init__(
-        self,
-        app: typing.Callable,
-        raise_app_exceptions: bool = True,
-        script_name: str = "",
-        remote_addr: str = "127.0.0.1",
-    ) -> None:
-        warn_deprecated("WSGIDispatch is deprecated, please use WSGITransport")
-        super().__init__(
-            app=app,
-            raise_app_exceptions=raise_app_exceptions,
-            script_name=script_name,
-            remote_addr=remote_addr,
-        )

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -1,6 +1,5 @@
 import codecs
 import collections
-import contextlib
 import logging
 import mimetypes
 import netrc
@@ -15,7 +14,6 @@ from time import perf_counter
 from types import TracebackType
 from urllib.request import getproxies
 
-from ._exceptions import NetworkError
 from ._types import PrimitiveData
 
 if typing.TYPE_CHECKING:  # pragma: no cover
@@ -396,16 +394,5 @@ class ElapsedTimer:
         return timedelta(seconds=self.end - self.start)
 
 
-@contextlib.contextmanager
-def as_network_error(*exception_classes: type) -> typing.Iterator[None]:
-    try:
-        yield
-    except BaseException as exc:
-        for cls in exception_classes:
-            if isinstance(exc, cls):
-                raise NetworkError(exc) from exc
-        raise
-
-
-def warn_deprecated(message: str) -> None:
+def warn_deprecated(message: str) -> None:  # pragma: nocover
     warnings.warn(message, DeprecationWarning, stacklevel=2)

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -159,20 +159,6 @@ async def test_100_continue(server):
     assert response.content == data
 
 
-def test_dispatch_deprecated():
-    dispatch = httpcore.AsyncHTTPTransport()
-
-    with pytest.warns(DeprecationWarning) as record:
-        client = httpx.AsyncClient(dispatch=dispatch)
-
-    assert client.transport is dispatch
-    assert len(record) == 1
-    assert record[0].message.args[0] == (
-        "The dispatch argument is deprecated since v0.13 and will be "
-        "removed in a future release, please use 'transport'"
-    )
-
-
 def test_asgi_dispatch_deprecated():
     async def app(scope, receive, send):
         pass

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -1,10 +1,8 @@
 from datetime import timedelta
 
-import httpcore
 import pytest
 
 import httpx
-from httpx import ASGIDispatch
 
 
 @pytest.mark.usefixtures("async_environment")
@@ -157,17 +155,3 @@ async def test_100_continue(server):
 
     assert response.status_code == 200
     assert response.content == data
-
-
-def test_asgi_dispatch_deprecated():
-    async def app(scope, receive, send):
-        pass
-
-    with pytest.warns(DeprecationWarning) as record:
-        ASGIDispatch(app)
-
-    assert len(record) == 1
-    assert (
-        record[0].message.args[0]
-        == "ASGIDispatch is deprecated, please use ASGITransport"
-    )

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1,10 +1,8 @@
 from datetime import timedelta
 
-import httpcore
 import pytest
 
 import httpx
-from httpx import WSGIDispatch
 
 
 def test_get(server):
@@ -165,17 +163,3 @@ def test_merge_url():
 
     assert url.scheme == "https"
     assert url.is_ssl
-
-
-def test_wsgi_dispatch_deprecated():
-    def app(start_response, environ):
-        pass
-
-    with pytest.warns(DeprecationWarning) as record:
-        WSGIDispatch(app)
-
-    assert len(record) == 1
-    assert (
-        record[0].message.args[0]
-        == "WSGIDispatch is deprecated, please use WSGITransport"
-    )

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -167,20 +167,6 @@ def test_merge_url():
     assert url.is_ssl
 
 
-def test_dispatch_deprecated():
-    dispatch = httpcore.SyncHTTPTransport()
-
-    with pytest.warns(DeprecationWarning) as record:
-        client = httpx.Client(dispatch=dispatch)
-
-    assert client.transport is dispatch
-    assert len(record) == 1
-    assert record[0].message.args[0] == (
-        "The dispatch argument is deprecated since v0.13 and will be "
-        "removed in a future release, please use 'transport'"
-    )
-
-
 def test_wsgi_dispatch_deprecated():
     def app(start_response, environ):
         pass

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -20,7 +20,7 @@ def test_httpcore_all_exceptions_mapped() -> None:
         and value not in HTTPCORE_EXC_MAP
     ]
 
-    if not_mapped:
+    if not_mapped:  # pragma: nocover
         pytest.fail(f"Unmapped httpcore exceptions: {not_mapped}")
 
 
@@ -57,5 +57,5 @@ def test_httpx_exceptions_exposed() -> None:
         and not hasattr(httpx, name)
     ]
 
-    if not_exposed:
+    if not_exposed:  # pragma: nocover
         pytest.fail(f"Unexposed HTTPX exceptions: {not_exposed}")


### PR DESCRIPTION
* Drop `ASGIDispatch`, `WSGIDispatch`, which has been replaced by `ASGITransport`, `WSGITransport`.
* Drop `dispatch=...` on client, which has been replaced by `transport=...`
* Drop `soft_limit`, `hard_limit`, which have been replaced by `max_keepalive` and `max_connections`.
* Drop `Response.stream` and `Response.raw`, which have been replaced by `aiter_bytes` and `aiter_raw`.
* Drop internal usage of `as_network_error` in favour of `map_exceptions`.