### PR TITLE
Mount API

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -470,7 +470,7 @@ class Client(BaseClient):
 
         proxy_map = self.get_proxy_map(proxies, trust_env)
 
-        self.transport = self.init_transport(
+        self._transport = self.init_transport(
             verify=verify,
             cert=cert,
             http2=http2,
@@ -479,7 +479,7 @@ class Client(BaseClient):
             app=app,
             trust_env=trust_env,
         )
-        self.proxies: typing.Dict[str, httpcore.SyncHTTPTransport] = {
+        self._proxies: typing.Dict[str, httpcore.SyncHTTPTransport] = {
             key: self.init_proxy_transport(
                 proxy,
                 verify=verify,
@@ -548,7 +548,7 @@ class Client(BaseClient):
         Returns the transport instance that should be used for a given URL.
         This will either be the standard connection pool, or a proxy.
         """
-        if self.proxies and not should_not_be_proxied(url):
+        if self._proxies and not should_not_be_proxied(url):
             is_default_port = (url.scheme == "http" and url.port == 80) or (
                 url.scheme == "https" and url.port == 443
             )
@@ -562,11 +562,11 @@ class Client(BaseClient):
                 "all",
             )
             for proxy_key in proxy_keys:
-                if proxy_key and proxy_key in self.proxies:
-                    transport = self.proxies[proxy_key]
+                if proxy_key and proxy_key in self._proxies:
+                    transport = self._proxies[proxy_key]
                     return transport
 
-        return self.transport
+        return self._transport
 
     def request(
         self,
@@ -911,8 +911,8 @@ class Client(BaseClient):
         )
 
     def close(self) -> None:
-        self.transport.close()
-        for proxy in self.proxies.values():
+        self._transport.close()
+        for proxy in self._proxies.values():
             proxy.close()
 
     def __enter__(self) -> "Client":
@@ -1008,7 +1008,7 @@ class AsyncClient(BaseClient):
 
         proxy_map = self.get_proxy_map(proxies, trust_env)
 
-        self.transport = self.init_transport(
+        self._transport = self.init_transport(
             verify=verify,
             cert=cert,
             http2=http2,
@@ -1017,7 +1017,7 @@ class AsyncClient(BaseClient):
             app=app,
             trust_env=trust_env,
         )
-        self.proxies: typing.Dict[str, httpcore.AsyncHTTPTransport] = {
+        self._proxies: typing.Dict[str, httpcore.AsyncHTTPTransport] = {
             key: self.init_proxy_transport(
                 proxy,
                 verify=verify,
@@ -1086,7 +1086,7 @@ class AsyncClient(BaseClient):
         Returns the transport instance that should be used for a given URL.
         This will either be the standard connection pool, or a proxy.
         """
-        if self.proxies and not should_not_be_proxied(url):
+        if self._proxies and not should_not_be_proxied(url):
             is_default_port = (url.scheme == "http" and url.port == 80) or (
                 url.scheme == "https" and url.port == 443
             )
@@ -1100,11 +1100,11 @@ class AsyncClient(BaseClient):
                 "all",
             )
             for proxy_key in proxy_keys:
-                if proxy_key and proxy_key in self.proxies:
-                    transport = self.proxies[proxy_key]
+                if proxy_key and proxy_key in self._proxies:
+                    transport = self._proxies[proxy_key]
                     return transport
 
-        return self.transport
+        return self._transport
 
     async def request(
         self,
@@ -1452,8 +1452,8 @@ class AsyncClient(BaseClient):
         )
 
     async def aclose(self) -> None:
-        await self.transport.aclose()
-        for proxy in self.proxies.values():
+        await self._transport.aclose()
+        for proxy in self._proxies.values():
             await proxy.aclose()
 
     async def __aenter__(self) -> "AsyncClient":

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -549,15 +549,11 @@ class Client(BaseClient):
         This will either be the standard connection pool, or a proxy.
         """
         if self._proxies and not should_not_be_proxied(url):
-            is_default_port = (url.scheme == "http" and url.port == 80) or (
-                url.scheme == "https" and url.port == 443
-            )
-            hostname = f"{url.host}:{url.port}"
             proxy_keys = (
-                f"{url.scheme}://{hostname}",
-                f"{url.scheme}://{url.host}" if is_default_port else None,
-                f"all://{hostname}",
-                f"all://{url.host}" if is_default_port else None,
+                f"{url.scheme}://{url.authority}",
+                f"{url.scheme}://{url.host}",
+                f"all://{url.authority}",
+                f"all://{url.host}",
                 url.scheme,
                 "all",
             )
@@ -1087,15 +1083,11 @@ class AsyncClient(BaseClient):
         This will either be the standard connection pool, or a proxy.
         """
         if self._proxies and not should_not_be_proxied(url):
-            is_default_port = (url.scheme == "http" and url.port == 80) or (
-                url.scheme == "https" and url.port == 443
-            )
-            hostname = f"{url.host}:{url.port}"
             proxy_keys = (
-                f"{url.scheme}://{hostname}",
-                f"{url.scheme}://{url.host}" if is_default_port else None,
-                f"all://{hostname}",
-                f"all://{url.host}" if is_default_port else None,
+                f"{url.scheme}://{url.authority}",
+                f"{url.scheme}://{url.host}",
+                f"all://{url.authority}",
+                f"all://{url.host}",
                 url.scheme,
                 "all",
             )

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -48,6 +48,7 @@ from ._utils import (
     get_environment_proxies,
     get_logger,
     should_not_be_proxied,
+    url_keys,
 )
 
 logger = get_logger(__name__)
@@ -538,15 +539,7 @@ class Client(BaseClient):
         This will either be the standard connection pool, or a proxy.
         """
         if self._proxies and not should_not_be_proxied(url):
-            proxy_keys = (
-                f"{url.scheme}://{url.authority}",
-                f"{url.scheme}://{url.host}",
-                f"all://{url.authority}",
-                f"all://{url.host}",
-                url.scheme,
-                "all",
-            )
-            for proxy_key in proxy_keys:
+            for proxy_key in url_keys(url):
                 if proxy_key and proxy_key in self._proxies:
                     transport = self._proxies[proxy_key]
                     return transport
@@ -1072,15 +1065,7 @@ class AsyncClient(BaseClient):
         This will either be the standard connection pool, or a proxy.
         """
         if self._proxies and not should_not_be_proxied(url):
-            proxy_keys = (
-                f"{url.scheme}://{url.authority}",
-                f"{url.scheme}://{url.host}",
-                f"all://{url.authority}",
-                f"all://{url.host}",
-                url.scheme,
-                "all",
-            )
-            for proxy_key in proxy_keys:
+            for proxy_key in url_keys(url):
                 if proxy_key and proxy_key in self._proxies:
                     transport = self._proxies[proxy_key]
                     return transport

--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -53,7 +53,7 @@ TimeoutTypes = Union[
     Tuple[Optional[float], Optional[float], Optional[float], Optional[float]],
     "Timeout",
 ]
-ProxiesTypes = Union[URLTypes, "Proxy", Dict[URLTypes, Union[URLTypes, "Proxy"]]]
+ProxiesTypes = Union[URLTypes, "Proxy", Dict[URLTypes, Union[URLTypes, "Proxy", None]]]
 
 AuthTypes = Union[
     Tuple[Union[str, bytes], Union[str, bytes]],

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -293,7 +293,7 @@ def get_environment_proxies() -> typing.Dict[str, str]:
     return {
         key: val
         for key, val in getproxies().items()
-        if ("://" in key or key in supported_proxy_schemes)
+        if (key in supported_proxy_schemes)
     }
 
 

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -297,6 +297,58 @@ def get_environment_proxies() -> typing.Dict[str, str]:
     }
 
 
+def url_keys(url: "URL") -> typing.List[str]:
+    """
+    Given a URL return a list of keys to use for looking up mounted transports.
+    For example...
+
+    url_keys(URL("https://www.google.com:1234")) == [
+        "https://www.google.com:1234",
+        "all://www.google.com:1234",
+        "https://www.google.com",
+        "all://www.google.com",
+        "https://*.google.com",
+        "all://*.google.com",
+        "https://*.com",
+        "all://*.com",
+        "https",
+        "all"
+    ]
+    """
+
+    keys = []
+
+    # Match the hostname and an explicit port.
+    if url.authority != url.host:
+        keys += [
+            f"{url.scheme}://{url.authority}",
+            f"all://{url.authority}",
+        ]
+
+    # Match just the hostname.
+    keys += [
+        f"{url.scheme}://{url.host}",
+        f"all://{url.host}",
+    ]
+
+    # Match against wildcard domains.
+    split_host = url.host.split(".")
+    for idx in range(1, len(split_host)):
+        wildcard_host = ".".join(["*"] + split_host[idx:])
+        keys += [
+            f"{url.scheme}://{wildcard_host}",
+            f"all://{wildcard_host}",
+        ]
+
+    # Match against 'https', 'all'.
+    keys += [
+        url.scheme,
+        "all",
+    ]
+
+    return keys
+
+
 def to_bytes(value: typing.Union[str, bytes], encoding: str = "utf-8") -> bytes:
     return value.encode(encoding) if isinstance(value, str) else value
 

--- a/tests/client/test_proxies.py
+++ b/tests/client/test_proxies.py
@@ -17,9 +17,7 @@ PROXY_URL = "http://[::1]"
         ("http://example.com", {"all": PROXY_URL}, PROXY_URL),
         ("http://example.com", {"http": PROXY_URL}, PROXY_URL),
         ("http://example.com", {"all://example.com": PROXY_URL}, PROXY_URL),
-        ("http://example.com", {"all://example.com:80": PROXY_URL}, PROXY_URL),
-        ("http://example.com", {"http://example.com": PROXY_URL}, PROXY_URL),
-        ("http://example.com", {"http://example.com:80": PROXY_URL}, PROXY_URL),
+        ("http://example.com:80", {"http://example.com": PROXY_URL}, PROXY_URL),
         ("http://example.com:8080", {"http://example.com:8080": PROXY_URL}, PROXY_URL),
         ("http://example.com:8080", {"http://example.com": PROXY_URL}, None),
         (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,6 +13,7 @@ from httpx._utils import (
     obfuscate_sensitive_headers,
     parse_header_links,
     should_not_be_proxied,
+    url_keys,
 )
 from tests.utils import override_log_level
 
@@ -288,3 +289,19 @@ def test_should_not_be_proxied(url, no_proxy, expected):
     os.environ.update(no_proxy)
     parsed_url = httpx.URL(url)
     assert should_not_be_proxied(parsed_url) == expected
+
+
+def test_url_keys():
+    url = httpx.URL("https://www.google.com:1234")
+    assert url_keys(url) == [
+        "https://www.google.com:1234",
+        "all://www.google.com:1234",
+        "https://www.google.com",
+        "all://www.google.com",
+        "https://*.google.com",
+        "all://*.google.com",
+        "https://*.com",
+        "all://*.com",
+        "https",
+        "all",
+    ]


### PR DESCRIPTION
Working towards having the proxy and transport configuration as part of a more generic URL mounting system.

Here's what I've done so far...

* Make `.transport` and `.proxies` private. We don't really want those as public API.
* A bit of cleanup in the `getproxies` code, for simplicity.
* A bit of refactoring in `transport_for_url` for simplicity.
