### PR TITLE
Support QueryParams(None)

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -73,9 +73,6 @@ class BaseClient:
         else:
             self.base_url = URL(base_url)
 
-        if params is None:
-            params = {}
-
         self.auth = auth
         self._params = QueryParams(params)
         self._headers = Headers(headers)

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -287,7 +287,7 @@ class QueryParams(typing.Mapping[str, str]):
         value = args[0] if args else kwargs
 
         items: typing.Sequence[typing.Tuple[str, PrimitiveData]]
-        if isinstance(value, str):
+        if value is None or isinstance(value, str):
             items = parse_qsl(value)
         elif isinstance(value, QueryParams):
             items = value.multi_items()

--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -34,6 +34,7 @@ QueryParamTypes = Union[
     Mapping[str, Union[PrimitiveData, Sequence[PrimitiveData]]],
     List[Tuple[str, PrimitiveData]],
     str,
+    None,
 ]
 
 HeaderTypes = Union[

--- a/tests/models/test_queryparams.py
+++ b/tests/models/test_queryparams.py
@@ -44,6 +44,9 @@ def test_queryparams(source):
 
 
 def test_queryparam_types():
+    q = QueryParams(None)
+    assert str(q) == ""
+
     q = QueryParams({"a": True})
     assert str(q) == "a=true"
 


### PR DESCRIPTION
Ensures marginally more consistent behaviour, eg...

```python
# This will behave as expected.
client.params = None
```