### PR TITLE
Drop `URL(allow_relative=bool)`

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -24,7 +24,6 @@ from ._decoders import (
 from ._exceptions import (
     CookieConflict,
     HTTPStatusError,
-    InvalidURL,
     NotRedirectResponse,
     RequestNotRead,
     ResponseClosed,
@@ -55,12 +54,7 @@ from ._utils import (
 
 
 class URL:
-    def __init__(
-        self,
-        url: URLTypes,
-        allow_relative: bool = False,
-        params: QueryParamTypes = None,
-    ) -> None:
+    def __init__(self, url: URLTypes, params: QueryParamTypes = None,) -> None:
         if isinstance(url, str):
             self._uri_reference = rfc3986.api.iri_reference(url).encode()
         else:
@@ -79,13 +73,6 @@ class URL:
             else:
                 query_string = str(QueryParams(params))
             self._uri_reference = self._uri_reference.copy_with(query=query_string)
-
-        # Enforce absolute URLs by default.
-        if not allow_relative:
-            if not self.scheme:
-                raise InvalidURL("No scheme included in URL.")
-            if not self.host:
-                raise InvalidURL("No host included in URL.")
 
         # Allow setting full_path to custom attributes requests
         # like OPTIONS, CONNECT, and forwarding proxy requests.
@@ -205,10 +192,7 @@ class URL:
 
             kwargs["authority"] = authority
 
-        return URL(
-            self._uri_reference.copy_with(**kwargs).unsplit(),
-            allow_relative=self.is_relative_url,
-        )
+        return URL(self._uri_reference.copy_with(**kwargs).unsplit(),)
 
     def join(self, relative_url: URLTypes) -> "URL":
         """
@@ -220,7 +204,7 @@ class URL:
         # We drop any fragment portion, because RFC 3986 strictly
         # treats URLs with a fragment portion as not being absolute URLs.
         base_uri = self._uri_reference.copy_with(fragment=None)
-        relative_url = URL(relative_url, allow_relative=True)
+        relative_url = URL(relative_url)
         return URL(relative_url._uri_reference.resolve_with(base_uri).unsplit())
 
     def __hash__(self) -> int:

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -54,7 +54,7 @@ from ._utils import (
 
 
 class URL:
-    def __init__(self, url: URLTypes, params: QueryParamTypes = None,) -> None:
+    def __init__(self, url: URLTypes, params: QueryParamTypes = None) -> None:
         if isinstance(url, str):
             self._uri_reference = rfc3986.api.iri_reference(url).encode()
         else:

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -272,7 +272,7 @@ def enforce_http_url(url: "URL") -> None:
     if url.scheme not in ("http", "https"):
         raise InvalidURL('URL scheme must be "http" or "https".')
 
-        
+
 def same_origin(url: "URL", other: "URL") -> bool:
     """
     Return 'True' if the given URLs share the same origin.

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -14,6 +14,7 @@ from time import perf_counter
 from types import TracebackType
 from urllib.request import getproxies
 
+from ._exceptions import InvalidURL
 from ._types import PrimitiveData
 
 if typing.TYPE_CHECKING:  # pragma: no cover
@@ -258,6 +259,18 @@ def get_logger(name: str) -> Logger:
     logger.trace = trace  # type: ignore
 
     return typing.cast(Logger, logger)
+
+
+def enforce_http_url(url: "URL") -> None:
+    """
+    Raise an appropriate InvalidURL for any non-HTTP URLs.
+    """
+    if not url.scheme:
+        raise InvalidURL("No scheme included in URL.")
+    if not url.host:
+        raise InvalidURL("No host included in URL.")
+    if url.scheme not in ("http", "https"):
+        raise InvalidURL('URL scheme must be "http" or "https".')
 
 
 def should_not_be_proxied(url: "URL") -> bool:

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -23,6 +23,10 @@ async def test_get_invalid_url(server):
     async with httpx.AsyncClient() as client:
         with pytest.raises(httpx.InvalidURL):
             await client.get("invalid://example.org")
+        with pytest.raises(httpx.InvalidURL):
+            await client.get("://example.org")
+        with pytest.raises(httpx.InvalidURL):
+            await client.get("http://")
 
 
 @pytest.mark.usefixtures("async_environment")

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -22,6 +22,16 @@ def test_get(server):
     assert response.elapsed > timedelta(0)
 
 
+def test_get_invalid_url(server):
+    with httpx.Client() as client:
+        with pytest.raises(httpx.InvalidURL):
+            client.get("invalid://example.org")
+        with pytest.raises(httpx.InvalidURL):
+            client.get("://example.org")
+        with pytest.raises(httpx.InvalidURL):
+            client.get("http://")
+
+
 def test_build_request(server):
     url = server.url.copy_with(path="/echo_headers")
     headers = {"Custom-header": "value"}

--- a/tests/models/test_requests.py
+++ b/tests/models/test_requests.py
@@ -110,11 +110,3 @@ def test_url():
     assert request.url.scheme == "https"
     assert request.url.port == 443
     assert request.url.full_path == "/abc?foo=bar"
-
-
-def test_invalid_urls():
-    with pytest.raises(httpx.InvalidURL):
-        httpx.Request("GET", "example.org")
-
-    with pytest.raises(httpx.InvalidURL):
-        httpx.Request("GET", "http:///foo")

--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -1,6 +1,6 @@
 import pytest
 
-from httpx import URL, InvalidURL
+from httpx import URL
 from httpx._models import Origin
 
 
@@ -116,9 +116,6 @@ def test_url_join_rfc3986():
     """
 
     url = URL("http://example.com/b/c/d;p?q")
-
-    with pytest.raises(InvalidURL):
-        assert url.join("g:h") == "g:h"
 
     assert url.join("g") == "http://example.com/b/c/g"
     assert url.join("./g") == "http://example.com/b/c/g"


### PR DESCRIPTION
This PR pushes all `url.scheme` and `url.host` checking down into the `._transport_for_url` method.

This allows us to drop the `allow_relative` flag on the `URL` class, and instead just always allow relative URLs, up until the point that we're looking up a transport instance, at which point we enforce HTTP/HTTPS.

There are two benefits here...

* `allow_relative=...` wasn't really ever intended as a bit of public API, we just happened to be relying on it ourselves. It's cleaner for our API for allow eg `httpx.URL("")` as a valid relative URL, without having to explicitly enable it. But we *do* still want to raise an error if you attempt to issue a request with it.
* This change is a necessary pre-requisite for #954, since we don't necessarily want to hard-code enforce `http`/`https` schemes only, once we support mounting other scheme types too. Dropping the enforcement logic into the transport lookup means we'll be able to instead error if there's no appropriately mounted transport.
