### PR TITLE
Skip HSTS preloading on single-label domains

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -204,7 +204,11 @@ class BaseClient:
         to create the URL used for the outgoing request.
         """
         url = self.base_url.join(relative_url=url)
-        if url.scheme == "http" and hstspreload.in_hsts_preload(url.host):
+        if (
+            url.scheme == "http"
+            and hstspreload.in_hsts_preload(url.host)
+            and len(url.host.split(".")) > 1
+        ):
             port = None if url.port == 80 else url.port
             url = url.copy_with(scheme="https", port=port)
         return url

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -162,3 +162,18 @@ def test_merge_url():
     request = client.build_request("GET", "http://www.paypal.com")
     assert request.url.scheme == "https"
     assert request.url.is_ssl
+
+
+@pytest.mark.parametrize(
+    "url,scheme,is_ssl",
+    [
+        ("http://www.paypal.com", "https", True),
+        ("http://app", "http", False),
+        ("http://192.168.1.42", "http", False),
+    ],
+)
+def test_merge_url_hsts(url: str, scheme: str, is_ssl: bool):
+    client = httpx.Client()
+    request = client.build_request("GET", url)
+    assert request.url.scheme == scheme
+    assert request.url.is_ssl == is_ssl


### PR DESCRIPTION
As discussed in #1025, this is a simple fix to prevent HSTS on single-label domains like Docker hostnames, while a decision is made about if HSTS should be part of httpx or not.

I've added a separated unit test for this, that'll be easy to drop if it's not needed.

Cheers 👋