### PR TITLE
Refactor map_exceptions

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -20,7 +20,6 @@ from ._config import (
 from ._content_streams import ContentStream
 from ._exceptions import (
     HTTPCORE_EXC_MAP,
-    HTTPError,
     InvalidURL,
     RequestBodyUnavailable,
     TooManyRedirects,
@@ -690,28 +689,20 @@ class Client(BaseClient):
 
         transport = self._transport_for_url(request.url)
 
-        try:
-            with map_exceptions(HTTPCORE_EXC_MAP):
-                (
-                    http_version,
-                    status_code,
-                    reason_phrase,
-                    headers,
-                    stream,
-                ) = transport.request(
-                    request.method.encode(),
-                    request.url.raw,
-                    headers=request.headers.raw,
-                    stream=request.stream,
-                    timeout=timeout.as_dict(),
-                )
-        except HTTPError as exc:
-            # Add the original request to any HTTPError unless
-            # there'a already a request attached in the case of
-            # a ProxyError.
-            if exc._request is None:
-                exc._request = request
-            raise
+        with map_exceptions(HTTPCORE_EXC_MAP, request=request):
+            (
+                http_version,
+                status_code,
+                reason_phrase,
+                headers,
+                stream,
+            ) = transport.request(
+                request.method.encode(),
+                request.url.raw,
+                headers=request.headers.raw,
+                stream=request.stream,
+                timeout=timeout.as_dict(),
+            )
         response = Response(
             status_code,
             http_version=http_version.decode("ascii"),
@@ -1231,28 +1222,20 @@ class AsyncClient(BaseClient):
 
         transport = self._transport_for_url(request.url)
 
-        try:
-            with map_exceptions(HTTPCORE_EXC_MAP):
-                (
-                    http_version,
-                    status_code,
-                    reason_phrase,
-                    headers,
-                    stream,
-                ) = await transport.request(
-                    request.method.encode(),
-                    request.url.raw,
-                    headers=request.headers.raw,
-                    stream=request.stream,
-                    timeout=timeout.as_dict(),
-                )
-        except HTTPError as exc:
-            # Add the original request to any HTTPError unless
-            # there'a already a request attached in the case of
-            # a ProxyError.
-            if exc._request is None:
-                exc._request = request
-            raise
+        with map_exceptions(HTTPCORE_EXC_MAP, request=request):
+            (
+                http_version,
+                status_code,
+                reason_phrase,
+                headers,
+                stream,
+            ) = await transport.request(
+                request.method.encode(),
+                request.url.raw,
+                headers=request.headers.raw,
+                stream=request.stream,
+                timeout=timeout.as_dict(),
+            )
         response = Response(
             status_code,
             http_version=http_version.decode("ascii"),

--- a/httpx/_exceptions.py
+++ b/httpx/_exceptions.py
@@ -216,7 +216,8 @@ class CookieConflict(HTTPError):
 
 @contextlib.contextmanager
 def map_exceptions(
-    mapping: typing.Mapping[typing.Type[Exception], typing.Type[Exception]]
+    mapping: typing.Mapping[typing.Type[Exception], typing.Type[Exception]],
+    **kwargs: typing.Any,
 ) -> typing.Iterator[None]:
     try:
         yield
@@ -235,7 +236,8 @@ def map_exceptions(
         if mapped_exc is None:
             raise
 
-        raise mapped_exc(exc) from None
+        message = str(exc)
+        raise mapped_exc(message, **kwargs) from None  # type: ignore
 
 
 HTTPCORE_EXC_MAP = {


### PR DESCRIPTION
Refactors `map_exceptions` to also allow optional `**kwargs` which are passed to the new exception.

This is useful for us because the `httpcore` exception classes don't have an associated `request` because the model doesn't exist at that layer, but the equivelent `httpx` exception classes all do have an associated `request`.

As a result we can now do...

```python
with map_exceptions(HTTPCORE_EXC_MAP, request=request):
    http_version, status_code, reason_phrase, headers, stream = transport.request(...)
```

Without having to do any extra dancing around re-catching the raised exception and setting the request.
