### PR TITLE
Include 'request' on TooManyRedirect and RequestBodyUnavailable

### DIFF
--- a/httpx/_auth.py
+++ b/httpx/_auth.py
@@ -100,7 +100,12 @@ class DigestAuth(Auth):
 
     def auth_flow(self, request: Request) -> typing.Generator[Request, Response, None]:
         if not request.stream.can_replay():
-            raise RequestBodyUnavailable("Request body is no longer available.")
+            raise RequestBodyUnavailable(
+                "Cannot use digest auth with streaming requests that are unable "
+                "to replay the request body if a second request is required.",
+                request=request,
+            )
+
         response = yield request
 
         if response.status_code != 401 or "www-authenticate" not in response.headers:

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -376,7 +376,8 @@ class BaseClient:
         if not request.stream.can_replay():
             raise RequestBodyUnavailable(
                 "Got a redirect response, but the request body was streaming "
-                "and is no longer available."
+                "and is no longer available.",
+                request=request,
             )
 
         return request.stream
@@ -628,7 +629,9 @@ class Client(BaseClient):
 
         while True:
             if len(history) > self.max_redirects:
-                raise TooManyRedirects()
+                raise TooManyRedirects(
+                    "Exceeded maximum allowed redirects.", request=request
+                )
 
             response = self._send_handling_auth(
                 request, auth=auth, timeout=timeout, history=history
@@ -1167,7 +1170,9 @@ class AsyncClient(BaseClient):
 
         while True:
             if len(history) > self.max_redirects:
-                raise TooManyRedirects()
+                raise TooManyRedirects(
+                    "Exceeded maximum allowed redirects.", request=request
+                )
 
             response = await self._send_handling_auth(
                 request, auth=auth, timeout=timeout, history=history


### PR DESCRIPTION
Minor enhancement.
Include the `request` instance where possible on exceptions, and use helpful error messaging.