### PR TITLE
Prefer defaulting to utf-8, rather than using chardet autodetect

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ The HTTPX project relies on these excellent libraries:
   * `h11` - HTTP/1.1 support.
   * `h2` - HTTP/2 support.
 * `certifi` - SSL certificates.
-* `chardet` - Fallback auto-detection for response encoding.
 * `hstspreload` - determines whether IDNA-encoded host should be only accessed via HTTPS.
 * `idna` - Internationalized domain name support.
 * `rfc3986` - URL parsing & normalization.

--- a/docs/index.md
+++ b/docs/index.md
@@ -110,7 +110,6 @@ The HTTPX project relies on these excellent libraries:
   * `h11` - HTTP/1.1 support.
   * `h2` - HTTP/2 support.
 * `certifi` - SSL certificates.
-* `chardet` - Fallback auto-detection for response encoding.
 * `hstspreload` - determines whether IDNA-encoded host should be only accessed via HTTPS.
 * `idna` - Internationalized domain name support.
 * `rfc3986` - URL parsing & normalization.

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -8,7 +8,6 @@ from collections.abc import MutableMapping
 from http.cookiejar import Cookie, CookieJar
 from urllib.parse import parse_qsl, urlencode
 
-import chardet
 import rfc3986
 
 from .__version__ import __version__
@@ -750,9 +749,7 @@ class Response:
         if not hasattr(self, "_encoding"):
             encoding = self.charset_encoding
             if encoding is None or not is_known_encoding(encoding):
-                encoding = self.apparent_encoding
-                if encoding is None or not is_known_encoding(encoding):
-                    encoding = "utf-8"
+                encoding = "utf-8"
             self._encoding = encoding
         return self._encoding
 
@@ -781,13 +778,6 @@ class Response:
             return "iso-8859-1"
 
         return None
-
-    @property
-    def apparent_encoding(self) -> typing.Optional[str]:
-        """
-        Return the encoding, as it appears to autodetection.
-        """
-        return chardet.detect(self.content)["encoding"]
 
     @property
     def decoder(self) -> Decoder:

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ check_untyped_defs = True
 profile = black
 combine_as_imports = True
 known_first_party = httpx,tests
-known_third_party = brotli,certifi,chardet,cryptography,hstspreload,httpcore,pytest,rfc3986,setuptools,sniffio,trio,trustme,uvicorn
+known_third_party = brotli,certifi,cryptography,hstspreload,httpcore,pytest,rfc3986,setuptools,sniffio,trio,trustme,uvicorn
 
 [tool:pytest]
 addopts = --cov=httpx --cov=tests -rxXs

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ setup(
         "certifi",
         "hstspreload",
         "sniffio",
-        "chardet==3.*",
         "idna==2.*",
         "rfc3986>=1.3,<2",
         "httpcore==0.9.*",

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -48,25 +48,15 @@ def test_response_content_type_encoding():
     assert response.encoding == "latin-1"
 
 
-def test_response_autodetect_encoding():
+def test_response_fallback_to_utf8():
     """
-    Autodetect encoding if there is no charset info in a Content-Type header.
-    """
-    content = "おはようございます。".encode("EUC-JP")
-    response = httpx.Response(200, content=content, request=REQUEST)
-    assert response.text == "おはようございます。"
-    assert response.encoding == "EUC-JP"
-
-
-def test_response_fallback_to_autodetect():
-    """
-    Fallback to autodetection if we get an invalid charset in the Content-Type header.
+    Fallback to utf-8 if we get an invalid charset in the Content-Type header.
     """
     headers = {"Content-Type": "text-plain; charset=invalid-codec-name"}
-    content = "おはようございます。".encode("EUC-JP")
+    content = "おはようございます。".encode("utf-8")
     response = httpx.Response(200, content=content, headers=headers, request=REQUEST)
     assert response.text == "おはようございます。"
-    assert response.encoding == "EUC-JP"
+    assert response.encoding == "utf-8"
 
 
 def test_response_default_text_encoding():
@@ -84,10 +74,11 @@ def test_response_default_text_encoding():
 
 def test_response_default_encoding():
     """
-    Default to utf-8 if all else fails.
+    Default to utf-8 for decoding.
     """
-    response = httpx.Response(200, content=b"", request=REQUEST)
-    assert response.text == ""
+    content = "おはようございます。".encode("utf-8")
+    response = httpx.Response(200, content=content, request=REQUEST)
+    assert response.text == "おはようございます。"
     assert response.encoding == "utf-8"
 
 
@@ -98,7 +89,7 @@ def test_response_non_text_encoding():
     headers = {"Content-Type": "image/png"}
     response = httpx.Response(200, content=b"xyz", headers=headers, request=REQUEST)
     assert response.text == "xyz"
-    assert response.encoding == "ascii"
+    assert response.encoding == "utf-8"
 
 
 def test_response_set_explicit_encoding():
@@ -129,7 +120,7 @@ def test_read():
 
     assert response.status_code == 200
     assert response.text == "Hello, world!"
-    assert response.encoding == "ascii"
+    assert response.encoding == "utf-8"
     assert response.is_closed
 
     content = response.read()
@@ -145,7 +136,7 @@ async def test_aread():
 
     assert response.status_code == 200
     assert response.text == "Hello, world!"
-    assert response.encoding == "ascii"
+    assert response.encoding == "utf-8"
     assert response.is_closed
 
     content = await response.aread()

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -154,16 +154,6 @@ def test_decoding_errors(header_value):
     [
         ((b"Hello,", b" world!"), "ascii"),
         ((b"\xe3\x83", b"\x88\xe3\x83\xa9", b"\xe3", b"\x83\x99\xe3\x83\xab"), "utf-8"),
-        ((b"\x83g\x83\x89\x83x\x83\x8b",) * 64, "shift-jis"),
-        ((b"\x83g\x83\x89\x83x\x83\x8b",) * 600, "shift-jis"),
-        (
-            (b"\xcb\xee\xf0\xe5\xec \xe8\xef\xf1\xf3\xec \xe4\xee\xeb\xee\xf0",) * 64,
-            "MacCyrillic",
-        ),
-        (
-            (b"\xa5\xa6\xa5\xa7\xa5\xd6\xa4\xce\xb9\xf1\xba\xdd\xb2\xbd",) * 512,
-            "euc-jp",
-        ),
     ],
 )
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #1018

Not marking this as a "draft" since it *is* ready for review, but we shouldn't merge it without prior discussion.
Drops `chardet` autodetection in favour of `utf-8` as the default.

This changes our behaviour from:

* Use any explicitly set `.encoding`.
* Then use any `charset` included on the Content-Type.
* Then use use iso-8859-1 for any `text/*` Content-Type without a charset.
* Then use chardet autodetection.

To...

* Use any explicitly set `.encoding`.
* Then use any `charset` included on the Content-Type.
* Then use use iso-8859-1 for any `text/*` Content-Type without a charset.
* Then use utf-8.

We would probably want to document how to use chardet for autodetection, at least for the simpler non-streaming case.
Users can replicate the previous behaviour with...

```python
response = client.get(...)
if response.charset_encoding is None:
    response.encoding = chardet.detect(self.content)["encoding"]
response.text
```

We *might* also consider a TextDecoder API at some point in order to allow users to customize text decoding, including the streaming case, which would allow us to support eg. chardet or HTML meta tag detection options.

What are our thoughts on switching to utf-8 as the fallback case, rather than using chardet-autodetection?