### PR TITLE
httpx.Timeout must include a default

### DIFF
--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -195,9 +195,8 @@ class Timeout:
 
     **Usage**:
 
-    Timeout()                           # No timeout.
     Timeout(5.0)                        # 5s timeout on all operations.
-    Timeout(connect_timeout=5.0)        # 5s timeout on connect, no other timeouts.
+    Timeout(None, connect_timeout=5.0)  # 5s timeout on connect, no other timeouts.
     Timeout(5.0, connect_timeout=10.0)  # 10s timeout on connect. 5s timeout elsewhere.
     Timeout(5.0, pool_timeout=None)     # No timeout on acquiring connection from pool.
                                         # 5s timeout elsewhere.
@@ -205,7 +204,7 @@ class Timeout:
 
     def __init__(
         self,
-        timeout: TimeoutTypes = None,
+        timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
         *,
         connect_timeout: typing.Union[None, float, UnsetType] = UNSET,
         read_timeout: typing.Union[None, float, UnsetType] = UNSET,
@@ -230,6 +229,20 @@ class Timeout:
             self.read_timeout = timeout[1]
             self.write_timeout = None if len(timeout) < 3 else timeout[2]
             self.pool_timeout = None if len(timeout) < 4 else timeout[3]
+        elif isinstance(timeout, UnsetType):
+            assert not (
+                isinstance(connect_timeout, UnsetType)
+                or isinstance(read_timeout, UnsetType)
+                or isinstance(write_timeout, UnsetType)
+                or isinstance(pool_timeout, UnsetType)
+            ), (
+                "httpx.Timeout must either include a default, "
+                "or set all four parameters explicitly."
+            )
+            self.connect_timeout = connect_timeout
+            self.read_timeout = read_timeout
+            self.write_timeout = write_timeout
+            self.pool_timeout = pool_timeout
         else:
             self.connect_timeout = (
                 timeout if isinstance(connect_timeout, UnsetType) else connect_timeout

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -1,6 +1,7 @@
 import os
 import ssl
 import typing
+import warnings
 from base64 import b64encode
 from pathlib import Path
 
@@ -230,21 +231,25 @@ class Timeout:
             self.read_timeout = timeout[1]
             self.write_timeout = None if len(timeout) < 3 else timeout[2]
             self.pool_timeout = None if len(timeout) < 4 else timeout[3]
-        elif isinstance(timeout, UnsetType):
-            assert not (
-                isinstance(connect_timeout, UnsetType)
-                or isinstance(read_timeout, UnsetType)
-                or isinstance(write_timeout, UnsetType)
-                or isinstance(pool_timeout, UnsetType)
-            ), (
-                "httpx.Timeout must either include a default, "
-                "or set all four parameters explicitly."
-            )
+        elif not (
+            isinstance(connect_timeout, UnsetType)
+            or isinstance(read_timeout, UnsetType)
+            or isinstance(write_timeout, UnsetType)
+            or isinstance(pool_timeout, UnsetType)
+        ):
             self.connect_timeout = connect_timeout
             self.read_timeout = read_timeout
             self.write_timeout = write_timeout
             self.pool_timeout = pool_timeout
         else:
+            if isinstance(timeout, UnsetType):
+                warnings.warn(
+                    "httpx.Timeout must either include a default, or set all "
+                    "four parameters explicitly. Omitting the default argument "
+                    "is deprecated and will raise errors in a future version.",
+                    DeprecationWarning,
+                )
+                timeout = None
             self.connect_timeout = (
                 timeout if isinstance(connect_timeout, UnsetType) else connect_timeout
             )

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -195,6 +195,7 @@ class Timeout:
 
     **Usage**:
 
+    Timeout(None)                       # No timeouts.
     Timeout(5.0)                        # 5s timeout on all operations.
     Timeout(None, connect_timeout=5.0)  # 5s timeout on connect, no other timeouts.
     Timeout(5.0, connect_timeout=10.0)  # 10s timeout on connect. 5s timeout elsewhere.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -132,8 +132,15 @@ def test_timeout_eq():
     assert timeout == httpx.Timeout(timeout=5.0)
 
 
+def test_timeout_all_parameters_set():
+    timeout = httpx.Timeout(
+        connect_timeout=5.0, read_timeout=5.0, write_timeout=5.0, pool_timeout=5.0
+    )
+    assert timeout == httpx.Timeout(timeout=5.0)
+
+
 def test_timeout_from_nothing():
-    timeout = httpx.Timeout()
+    timeout = httpx.Timeout(None)
     assert timeout.connect_timeout is None
     assert timeout.read_timeout is None
     assert timeout.write_timeout is None
@@ -142,16 +149,16 @@ def test_timeout_from_nothing():
 
 def test_timeout_from_none():
     timeout = httpx.Timeout(timeout=None)
-    assert timeout == httpx.Timeout()
+    assert timeout == httpx.Timeout(None)
 
 
 def test_timeout_from_one_none_value():
-    timeout = httpx.Timeout(read_timeout=None)
-    assert timeout == httpx.Timeout()
+    timeout = httpx.Timeout(None, read_timeout=None)
+    assert timeout == httpx.Timeout(None)
 
 
 def test_timeout_from_one_value():
-    timeout = httpx.Timeout(read_timeout=5.0)
+    timeout = httpx.Timeout(None, read_timeout=5.0)
     assert timeout == httpx.Timeout(timeout=(None, 5.0, None, None))
 
 
@@ -174,7 +181,7 @@ def test_timeout_repr():
     timeout = httpx.Timeout(timeout=5.0)
     assert repr(timeout) == "Timeout(timeout=5.0)"
 
-    timeout = httpx.Timeout(read_timeout=5.0)
+    timeout = httpx.Timeout(None, read_timeout=5.0)
     assert repr(timeout) == (
         "Timeout(connect_timeout=None, read_timeout=5.0, "
         "write_timeout=None, pool_timeout=None)"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -167,6 +167,12 @@ def test_timeout_from_one_value_and_default():
     assert timeout == httpx.Timeout(timeout=(5.0, 5.0, 5.0, 60.0))
 
 
+def test_timeout_missing_default():
+    with pytest.warns(DeprecationWarning):
+        timeout = httpx.Timeout(pool_timeout=60.0)
+        assert timeout == httpx.Timeout(timeout=(None, None, None, 60.0))
+
+
 def test_timeout_from_tuple():
     timeout = httpx.Timeout(timeout=(5.0, 5.0, 5.0, 5.0))
     assert timeout == httpx.Timeout(timeout=5.0)

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -5,7 +5,7 @@ import httpx
 
 @pytest.mark.usefixtures("async_environment")
 async def test_read_timeout(server):
-    timeout = httpx.Timeout(read_timeout=1e-6)
+    timeout = httpx.Timeout(None, read_timeout=1e-6)
 
     async with httpx.AsyncClient(timeout=timeout) as client:
         with pytest.raises(httpx.ReadTimeout):
@@ -14,7 +14,7 @@ async def test_read_timeout(server):
 
 @pytest.mark.usefixtures("async_environment")
 async def test_write_timeout(server):
-    timeout = httpx.Timeout(write_timeout=1e-6)
+    timeout = httpx.Timeout(None, write_timeout=1e-6)
 
     async with httpx.AsyncClient(timeout=timeout) as client:
         with pytest.raises(httpx.WriteTimeout):
@@ -24,7 +24,7 @@ async def test_write_timeout(server):
 
 @pytest.mark.usefixtures("async_environment")
 async def test_connect_timeout(server):
-    timeout = httpx.Timeout(connect_timeout=1e-6)
+    timeout = httpx.Timeout(None, connect_timeout=1e-6)
 
     async with httpx.AsyncClient(timeout=timeout) as client:
         with pytest.raises(httpx.ConnectTimeout):
@@ -35,7 +35,7 @@ async def test_connect_timeout(server):
 @pytest.mark.usefixtures("async_environment")
 async def test_pool_timeout(server):
     pool_limits = httpx.PoolLimits(max_connections=1)
-    timeout = httpx.Timeout(pool_timeout=1e-4)
+    timeout = httpx.Timeout(None, pool_timeout=1e-4)
 
     async with httpx.AsyncClient(pool_limits=pool_limits, timeout=timeout) as client:
         async with client.stream("GET", server.url):


### PR DESCRIPTION
For consideration, wrt. 1.0 API tightening.

Ensures that `httpx.Timeout(...)` must strictly include an explicit default.

Usages like `httpx.Timeout()` and `httpx.Timeout(read_timeout=5.0)` are no longer valid. The default value must be explicitly included. Eg. `httpx.Timeout(None)` and `httpx.Timeout(None, read_timeout=5.0)`.

Docstring on the class is:

Timeout configuration.

 **Usage**:

`httpx.Timeout(None)` *No timeouts.*
`httpx.Timeout(5.0)` *5s timeout on all operations.*
`httpx.Timeout(None, connect_timeout=5.0)`  *5s timeout on connect, no other timeouts.*
`httpx.Timeout(5.0, connect_timeout=10.0)`  *10s timeout on connect. 5s timeout elsewhere.*
`httpx.Timeout(5.0, pool_timeout=None)` *No timeout on acquiring connection from pool. 5s timeout elsewhere.*