### PR TITLE
Full coverage, with exception of URLLib3Transport

### DIFF
--- a/scripts/coverage
+++ b/scripts/coverage
@@ -8,4 +8,4 @@ export SOURCE_FILES="httpx tests"
 
 set -x
 
-${PREFIX}coverage report --show-missing --skip-covered --fail-under=99
+${PREFIX}coverage report --omit=httpx/_transports/urllib3.py --show-missing --skip-covered --fail-under=100

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -17,6 +17,9 @@ async def test_get(server):
     assert repr(response) == "<Response [200 OK]>"
     assert response.elapsed > timedelta(seconds=0)
 
+    with pytest.raises(httpx.NotRedirectResponse):
+        await response.anext()
+
 
 @pytest.mark.parametrize(
     "url",

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -21,6 +21,9 @@ def test_get(server):
     assert repr(response) == "<Response [200 OK]>"
     assert response.elapsed > timedelta(0)
 
+    with pytest.raises(httpx.NotRedirectResponse):
+        response.next()
+
 
 @pytest.mark.parametrize(
     "url",


### PR DESCRIPTION
* Add coverage onto missing line in `Response.next()`
* Exclude `URLLib3Transport` from coverage.
* Enforce 100% coverage elsewhere.