### PR TITLE
Consistent multidict methods

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -248,17 +248,31 @@ class QueryParams(typing.Mapping[str, str]):
         return self._dict.values()
 
     def items(self) -> typing.ItemsView:
+        """
+        Return all items in the query params. If a key occurs more than once
+        only the first item for that key is returned.
+        """
         return self._dict.items()
 
     def multi_items(self) -> typing.List[typing.Tuple[str, str]]:
+        """
+        Return all items in the query params. Allow duplicate keys to occur.
+        """
         return list(self._list)
 
     def get(self, key: typing.Any, default: typing.Any = None) -> typing.Any:
+        """
+        Get a value from the query param for a given key. If the key occurs
+        more than once, then only the first value is returned.
+        """
         if key in self._dict:
             return self._dict[key]
         return default
 
     def get_list(self, key: typing.Any) -> typing.List[str]:
+        """
+        Get all values from the query param for a given key.
+        """
         return [item_value for item_key, item_value in self._list if item_key == key]
 
     def update(self, params: QueryParamTypes = None) -> None:

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -434,7 +434,7 @@ class Headers(typing.MutableMapping[str, str]):
 
     def get(self, key: str, default: typing.Any = None) -> typing.Any:
         """
-        Return a header value. If multiple occurances of the header occur
+        Return a header value. If multiple occurences of the header occur
         then concatenate them together with commas.
         """
         try:

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -424,7 +424,7 @@ class Headers(typing.MutableMapping[str, str]):
     def multi_items(self) -> typing.List[typing.Tuple[str, str]]:  # type: ignore
         """
         Return a list of `(key, value)` pairs of headers. Allow multiple
-        occurances of the same key without concatenating into a single
+        occurences of the same key without concatenating into a single
         comma seperated value.
         """
         return [

--- a/tests/models/test_headers.py
+++ b/tests/models/test_headers.py
@@ -13,7 +13,7 @@ def test_headers():
     assert h["a"] == "123, 456"
     assert h.get("a") == "123, 456"
     assert h.get("nope", default=None) is None
-    assert h.getlist("a") == ["123", "456"]
+    assert h.get_list("a") == ["123", "456"]
     assert h.keys() == ["a", "b"]
     assert h.values() == ["123, 456", "789"]
     assert h.items() == [("a", "123, 456"), ("b", "789")]
@@ -154,13 +154,13 @@ def test_headers_decode_explicit_encoding():
 
 def test_multiple_headers():
     """
-    Most headers should split by commas for `getlist`, except 'Set-Cookie'.
+    `Headers.get_list` should support both split_commas=False and split_commas=True.
     """
     h = httpx.Headers([("set-cookie", "a, b"), ("set-cookie", "c")])
-    h.getlist("Set-Cookie") == ["a, b", "b"]
+    assert h.get_list("Set-Cookie") == ["a, b", "c"]
 
     h = httpx.Headers([("vary", "a, b"), ("vary", "c")])
-    h.getlist("Vary") == ["a", "b", "c"]
+    assert h.get_list("Vary", split_commas=True) == ["a", "b", "c"]
 
 
 @pytest.mark.parametrize("header", ["authorization", "proxy-authorization"])

--- a/tests/models/test_headers.py
+++ b/tests/models/test_headers.py
@@ -14,10 +14,11 @@ def test_headers():
     assert h.get("a") == "123, 456"
     assert h.get("nope", default=None) is None
     assert h.getlist("a") == ["123", "456"]
-    assert h.keys() == ["a", "a", "b"]
-    assert h.values() == ["123", "456", "789"]
-    assert h.items() == [("a", "123"), ("a", "456"), ("b", "789")]
-    assert list(h) == ["a", "a", "b"]
+    assert h.keys() == ["a", "b"]
+    assert h.values() == ["123, 456", "789"]
+    assert h.items() == [("a", "123, 456"), ("b", "789")]
+    assert h.multi_items() == [("a", "123"), ("a", "456"), ("b", "789")]
+    assert list(h) == ["a", "b"]
     assert dict(h) == {"a": "123, 456", "b": "789"}
     assert repr(h) == "Headers([('a', '123'), ('a', '456'), ('b', '789')])"
     assert h == httpx.Headers([("a", "123"), ("b", "789"), ("a", "456")])

--- a/tests/models/test_queryparams.py
+++ b/tests/models/test_queryparams.py
@@ -19,7 +19,7 @@ def test_queryparams(source):
     assert q["a"] == "456"
     assert q.get("a") == "456"
     assert q.get("nope", default=None) is None
-    assert q.getlist("a") == ["123", "456"]
+    assert q.get_list("a") == ["123", "456"]
     assert list(q.keys()) == ["a", "b"]
     assert list(q.values()) == ["456", "789"]
     assert list(q.items()) == [("a", "456"), ("b", "789")]


### PR DESCRIPTION
Nice sensible symmetry and expected behaviours across each of the following...
 
* `Headers.get`
* `Headers.get_list`
* `Headers.items`
* `Headers.multi_items`
* `QueryParams.get`
* `QueryParams.get_list`
* `QueryParams.items`
* `QueryParams.multi_items`

The following have been renamed, but the synonyms remain, and are now pending deprecation...

* `Headers.getlist()` -> `Headers.get_list()`
* `QueryParams.getlist()` -> `QueryParams.get_list()`