### PR TITLE
Drop extraneous `proxy` argument on `URLLib3Transport`.

### DIFF
--- a/httpx/_transports/urllib3.py
+++ b/httpx/_transports/urllib3.py
@@ -3,7 +3,7 @@ from typing import Dict, Iterator, List, Optional, Tuple
 
 import httpcore
 
-from .._config import Proxy, SSLConfig
+from .._config import SSLConfig
 from .._content_streams import ByteStream, IteratorStream
 from .._exceptions import NetworkError, map_exceptions
 from .._types import CertTypes, VerifyTypes

--- a/httpx/_transports/urllib3.py
+++ b/httpx/_transports/urllib3.py
@@ -19,7 +19,6 @@ class URLLib3Transport(httpcore.SyncHTTPTransport):
     def __init__(
         self,
         *,
-        proxy: Proxy = None,
         verify: VerifyTypes = True,
         cert: CertTypes = None,
         trust_env: bool = None,


### PR DESCRIPTION
Drop `proxy` argument that has been accidentally left over on `URLLib3Transport`.
It's not used anywhere, and it's not relevant since we seperate `URLLib3Transport` and `URLLib3ProxyTransport` classes.