### PR TITLE
Use public API only from transports

### DIFF
--- a/httpx/_transports/wsgi.py
+++ b/httpx/_transports/wsgi.py
@@ -4,8 +4,6 @@ import typing
 
 import httpcore
 
-from .._content_streams import ByteStream, IteratorStream
-
 
 def _skip_leading_empty_chunks(body: typing.Iterable) -> typing.Iterable:
     body = iter(body)
@@ -75,7 +73,11 @@ class WSGITransport(httpcore.SyncHTTPTransport):
         httpcore.SyncByteStream,
     ]:
         headers = [] if headers is None else headers
-        stream = ByteStream(b"") if stream is None else stream
+        stream = (
+            httpcore.SyncByteStream(chunk for chunk in [b""])
+            if stream is None
+            else stream
+        )
 
         scheme, host, port, full_path = url
         path, _, query = full_path.partition(b"?")
@@ -128,6 +130,6 @@ class WSGITransport(httpcore.SyncHTTPTransport):
             (key.encode("ascii"), value.encode("ascii"))
             for key, value in seen_response_headers
         ]
-        stream = IteratorStream(chunk for chunk in result)
+        stream = httpcore.SyncByteStream(chunk for chunk in result)
 
         return (b"HTTP/1.1", status_code, b"", headers, stream)


### PR DESCRIPTION
Prompted by https://github.com/encode/httpx/pull/998#issuecomment-664703591

Our `WSGITransport` and `ASGITransport` implementations now only use public API, which is beneficial for other folks implementing transports, and basing their work on these.

One thing that we *could* choose to further tweak here would be... `httpcore.SyncByteStream` and `httpcore.AsyncByteStream` provide a simple base implementation that allows users to pass `iterator`/`close` or `aiterator`/`aclose` parameters. That's actually a bit fiddly if you've just got a non-iterating bytestring that you want to pass. We might choose to also support passing plain bytes to the base implementation. So...

```python
    """
    The base interface for request and response bodies.
    Concrete implementations should subclass this class, and implement
    the `\\__aiter__` method, and optionally the `close` method.
    """

    def __init__(
        self, content: Union[bytes, AsyncIterator[bytes]] = b"", aclose_func: Callable = None,
    ) -> None:
        self.content = content
        self.aclose_func = aclose_func

    async def __aiter__(self) -> AsyncIterator[bytes]:
        """
        Yield bytes representing the request or response body.
        """
        if isinstance(self.content, bytes):
            yield self.content
        else:
            async for chunk in self.content:
                yield chunk

    async def aclose(self) -> None:
        """
        Must be called by the client to indicate that the stream has been closed.
        """
        if self.aclose_func is not None:
            await self.aclose_func()
```

That'd allow us to then just use eg. `httpcore.AsyncByteStream(b"")` rather than the little `async_byte_iterator` dance we've got at the moment.
