### PR TITLE
URL matching

### DIFF
--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -426,6 +426,47 @@ class ElapsedTimer:
 
 
 class URLMatcher:
+    """
+    A utility class currently used for making lookups against proxy keys...
+
+    # Wildcard matching...
+    >>> pattern = URLMatcher("all")
+    >>> pattern.matches(httpx.URL("http://example.com"))
+    True
+
+    # Witch scheme matching...
+    >>> pattern = URLMatcher("https")
+    >>> pattern.matches(httpx.URL("https://example.com"))
+    True
+    >>> pattern.matches(httpx.URL("http://example.com"))
+    False
+
+    # With domain matching...
+    >>> pattern = URLMatcher("https://example.com")
+    >>> pattern.matches(httpx.URL("https://example.com"))
+    True
+    >>> pattern.matches(httpx.URL("http://example.com"))
+    False
+    >>> pattern.matches(httpx.URL("https://other.com"))
+    False
+
+    # Wildcard scheme, with domain matching...
+    >>> pattern = URLMatcher("all://example.com")
+    >>> pattern.matches(httpx.URL("https://example.com"))
+    True
+    >>> pattern.matches(httpx.URL("http://example.com"))
+    True
+    >>> pattern.matches(httpx.URL("https://other.com"))
+    False
+
+    # With port matching...
+    >>> pattern = URLMatcher("https://example.com:1234")
+    >>> pattern.matches(httpx.URL("https://example.com:1234"))
+    True
+    >>> pattern.matches(httpx.URL("https://example.com"))
+    False
+    """
+
     def __init__(self, pattern: str) -> None:
         from ._models import URL
 

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -458,6 +458,9 @@ class URLMatcher:
         scheme_priority = -len(self.scheme)
         return (port_priority, host_priority, scheme_priority)
 
+    def __hash__(self) -> int:
+        return hash(self.pattern)
+
     def __lt__(self, other: "URLMatcher") -> bool:
         return self.priority < other.priority
 

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -496,7 +496,7 @@ class URLMatcher:
     def priority(self) -> tuple:
         """
         The priority allows URLMatcher instances to be sortable, so that
-        if we can match from most specific to least specific.
+        we can match from most specific to least specific.
         """
         port_priority = -1 if self.port is not None else 0
         host_priority = -len(self.host)

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ flake8-bugbear
 flake8-pie
 isort==5.*
 mypy
-pytest
+pytest==5.*
 pytest-asyncio
 pytest-trio
 pytest-cov

--- a/tests/client/test_proxies.py
+++ b/tests/client/test_proxies.py
@@ -2,6 +2,7 @@ import httpcore
 import pytest
 
 import httpx
+from httpx._utils import URLMatcher
 
 
 def url_to_origin(url: str):
@@ -36,8 +37,9 @@ def test_proxies_parameter(proxies, expected_proxies):
     client = httpx.AsyncClient(proxies=proxies)
 
     for proxy_key, url in expected_proxies:
-        assert proxy_key in client._proxies
-        proxy = client._proxies[proxy_key]
+        matcher = URLMatcher(proxy_key)
+        assert matcher in client._proxies
+        proxy = client._proxies[matcher]
         assert isinstance(proxy, httpcore.AsyncHTTPProxy)
         assert proxy.proxy_origin == url_to_origin(url)
 
@@ -54,15 +56,15 @@ PROXY_URL = "http://[::1]"
         ("http://example.com", {}, None),
         ("http://example.com", {"https": PROXY_URL}, None),
         ("http://example.com", {"http://example.net": PROXY_URL}, None),
-        ("http://example.com:443", {"http://example.com": PROXY_URL}, None),
+        ("http://example.com:443", {"http://example.com": PROXY_URL}, PROXY_URL),
         ("http://example.com", {"all": PROXY_URL}, PROXY_URL),
         ("http://example.com", {"http": PROXY_URL}, PROXY_URL),
         ("http://example.com", {"all://example.com": PROXY_URL}, PROXY_URL),
-        ("http://example.com", {"all://example.com:80": PROXY_URL}, PROXY_URL),
+        ("http://example.com", {"all://example.com:80": PROXY_URL}, None),
         ("http://example.com", {"http://example.com": PROXY_URL}, PROXY_URL),
-        ("http://example.com", {"http://example.com:80": PROXY_URL}, PROXY_URL),
+        ("http://example.com", {"http://example.com:80": PROXY_URL}, None),
         ("http://example.com:8080", {"http://example.com:8080": PROXY_URL}, PROXY_URL),
-        ("http://example.com:8080", {"http://example.com": PROXY_URL}, None),
+        ("http://example.com:8080", {"http://example.com": PROXY_URL}, PROXY_URL),
         (
             "http://example.com",
             {


### PR DESCRIPTION
This pull request refactors our URL matching for proxy lookups.

It adds a utility class `URLMatcher` that handles matching against the [proxy keys that we currently support](https://www.python-httpx.org/advanced/#http-proxying).

It's best explained through some examples...

```python
>>> from httpx._utils import URLMatcher  # Private API, intended for internal usage only.
>>> import httpx

>>> pattern = URLMatcher("all")
>>> pattern.matches(httpx.URL("http://example.com"))
True

# Witch scheme matching...
>>> pattern = URLMatcher("https")
>>> pattern.matches(httpx.URL("https://example.com"))
True
>>> pattern.matches(httpx.URL("http://example.com"))
False

# With domain matching...
>>> pattern = URLMatcher("https://example.com")
>>> pattern.matches(httpx.URL("https://example.com"))
True
>>> pattern.matches(httpx.URL("http://example.com"))
False
>>> pattern.matches(httpx.URL("https://other.com"))
False

# Wildcard scheme, with domain matching...
>>> pattern = URLMatcher("all://example.com")
>>> pattern.matches(httpx.URL("https://example.com"))
True
>>> pattern.matches(httpx.URL("http://example.com"))
True
>>> pattern.matches(httpx.URL("https://other.com"))
False

# With port matching...
>>> pattern = URLMatcher("https://example.com:1234")
>>> pattern.matches(httpx.URL("https://example.com:1234"))
True
>>> pattern.matches(httpx.URL("https://example.com"))
False
```

Here's why we care about it...

* The implementation in `transport_for_url` is much more clear now.
* This initial pass doesn't also hook in the no_proxies support, but we'll be able to extend this slightly to deal with matching against `NO_PROXY`, and allow us to resolve #1062 neatly.
* We'll be able to use this as the basis for our Mount API. #977

Note that some of the cases in `test_proxies_parameter` *have* changed, but they're all odd cases, where the desired behaviour is ambiguous, and I don't think we're actually regressing in any of those case.

* If a user explicitly uses `proxies={"http://example.com:80": httpx.Proxy(...)}`, then we now only match if the requested URL includes an explicit port 80. That seems pretty reasonable. It's an odd key to use in any case.
* If a user uses `proxies={"http://example.com": httpx.Proxy(...)}`, then we now match both `example.com` and `example.com:<some port>` to the proxy. That seems like an improvement in expected behaviour.
* A malformed request URL of "http://example.com:443" *will* now match against "http". Pretty ambiguous what you'd expect there, but if anything it seems reasonable. Likely you'll end up with a transport error later down the line, but that's to be expected. (Or not, depending on what the heck you're actually doing there with the kludgy scheme/port mismatch there.)