### PR TITLE
Drop the auto-prompting 'do you want to run scripts/lint now'

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -5,21 +5,11 @@ if [ -d 'venv' ] ; then
     export PREFIX="venv/bin/"
 fi
 
-if [ -z $GITHUB_ACTIONS ]; then
-    set +e
-    scripts/check
-    while [ $? -ne 0 ]; do
-        read -p "Running 'scripts/check' failed. Do you want to run 'scripts/lint' now? [y/N]  " yn
-        case $yn in
-           [Yy]* ) :;;
-           * ) exit;;
-        esac
-        scripts/lint
-        scripts/check
-    done
-fi
-
 set -ex
+
+if [ -z $GITHUB_ACTIONS ]; then
+    scripts/check
+fi
 
 ${PREFIX}pytest $@
 


### PR DESCRIPTION
In practice I've actually found this far more annoying that useful.

I think our scripts are in pretty great shape at the moment.

Closes #950.