### PR TITLE
Drop HSTS Preloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ The HTTPX project relies on these excellent libraries:
   * `h2` - HTTP/2 support.
 * `certifi` - SSL certificates.
 * `chardet` - Fallback auto-detection for response encoding.
-* `hstspreload` - determines whether IDNA-encoded host should be only accessed via HTTPS.
 * `idna` - Internationalized domain name support.
 * `rfc3986` - URL parsing & normalization.
 * `sniffio` - Async library autodetection.

--- a/docs/index.md
+++ b/docs/index.md
@@ -111,7 +111,6 @@ The HTTPX project relies on these excellent libraries:
   * `h2` - HTTP/2 support.
 * `certifi` - SSL certificates.
 * `chardet` - Fallback auto-detection for response encoding.
-* `hstspreload` - determines whether IDNA-encoded host should be only accessed via HTTPS.
 * `idna` - Internationalized domain name support.
 * `rfc3986` - URL parsing & normalization.
 * `sniffio` - Async library autodetection.

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -2,7 +2,6 @@ import functools
 import typing
 from types import TracebackType
 
-import hstspreload
 import httpcore
 
 from ._auth import Auth, BasicAuth, FunctionAuth
@@ -205,15 +204,7 @@ class BaseClient:
         Merge a URL argument together with any 'base_url' on the client,
         to create the URL used for the outgoing request.
         """
-        url = self.base_url.join(relative_url=url)
-        if (
-            url.scheme == "http"
-            and hstspreload.in_hsts_preload(url.host)
-            and len(url.host.split(".")) > 1
-        ):
-            port = None if url.port == 80 else url.port
-            url = url.copy_with(scheme="https", port=port)
-        return url
+        return self.base_url.join(relative_url=url)
 
     def _merge_cookies(
         self, cookies: CookieTypes = None

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ check_untyped_defs = True
 profile = black
 combine_as_imports = True
 known_first_party = httpx,tests
-known_third_party = brotli,certifi,chardet,cryptography,hstspreload,httpcore,pytest,rfc3986,setuptools,sniffio,trio,trustme,uvicorn
+known_third_party = brotli,certifi,chardet,cryptography,httpcore,pytest,rfc3986,setuptools,sniffio,trio,trustme,uvicorn
 
 [tool:pytest]
 addopts = --cov=httpx --cov=tests -rxXs

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ setup(
     zip_safe=False,
     install_requires=[
         "certifi",
-        "hstspreload",
         "sniffio",
         "chardet==3.*",
         "idna==2.*",

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -177,20 +177,5 @@ def test_base_url(server):
 def test_merge_url():
     client = httpx.Client(base_url="https://www.paypal.com/")
     request = client.build_request("GET", "http://www.paypal.com")
-    assert request.url.scheme == "https"
-    assert request.url.is_ssl
-
-
-@pytest.mark.parametrize(
-    "url,scheme,is_ssl",
-    [
-        ("http://www.paypal.com", "https", True),
-        ("http://app", "http", False),
-        ("http://192.168.1.42", "http", False),
-    ],
-)
-def test_merge_url_hsts(url: str, scheme: str, is_ssl: bool):
-    client = httpx.Client()
-    request = client.build_request("GET", url)
-    assert request.url.scheme == scheme
-    assert request.url.is_ssl == is_ssl
+    assert request.url.scheme == "http"
+    assert not request.url.is_ssl

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -175,9 +175,10 @@ def test_base_url(server):
 
 
 def test_merge_url():
-    client = httpx.Client(base_url="https://www.paypal.com/")
-    request = client.build_request("GET", "http://www.paypal.com")
+    client = httpx.Client(base_url="https://www.example.com/")
+    request = client.build_request("GET", "http://www.example.com")
     assert request.url.scheme == "http"
+    assert not request.url.is_ssl
 
 
 def test_pool_limits_deprecated():


### PR DESCRIPTION
Maybe? See the rationale in #1102

Fixes #1102, closes #896

Essentially:

```python
>>> import httpx
>>> r = httpx.get('http://www.paypal.com')  # -> Now kept over HTTP rather than forced to HTTPS.
```

I suppose if we want to move forward with this we'd want it in 0.14, rather than 1.0, since it might be a small breaking change?

Since this was an always-on feature not controlled by any options, I can't think of a smooth deprecation path, but any ideas welcome!