### PR TITLE
client.trust_env becomes read-only

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -81,8 +81,12 @@ class BaseClient:
         self._cookies = Cookies(cookies)
         self.timeout = Timeout(timeout)
         self.max_redirects = max_redirects
-        self.trust_env = trust_env
+        self._trust_env = trust_env
         self._netrc = NetRCInfo()
+
+    @property
+    def trust_env(self) -> bool:
+        return self._trust_env
 
     def _get_proxy_map(
         self, proxies: typing.Optional[ProxiesTypes], trust_env: bool,


### PR DESCRIPTION
Refs #1066 

Setting `client.trust_env = <bool>` isn't valid since it won't change already-initialized transports, so this PR changes it to a read-only property.

Light breaking change potentially, but I don't think it makes sense to add a deprecation path with a setter here.