### PR TITLE
Rename PoolLimits to Limits

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -401,8 +401,8 @@ response = client.get('http://example.com/')
 
 ## Pool limit configuration
 
-You can control the connection pool size using the `pool_limits` keyword
-argument on the client. It takes instances of `httpx.PoolLimits` which define:
+You can control the connection pool size using the `limits` keyword
+argument on the client. It takes instances of `httpx.Limits` which define:
 
 - `max_keepalive`, number of allowable keep-alive connections, or `None` to always
 allow. (Defaults 10)
@@ -411,8 +411,8 @@ allow. (Defaults 10)
 
 
 ```python
-limits = httpx.PoolLimits(max_keepalive=5, max_connections=10)
-client = httpx.Client(pool_limits=limits)
+limits = httpx.Limits(max_keepalive=5, max_connections=10)
+client = httpx.Client(limits=limits)
 ```
 
 ## Multipart file encoding

--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -2,7 +2,7 @@ from .__version__ import __description__, __title__, __version__
 from ._api import delete, get, head, options, patch, post, put, request, stream
 from ._auth import Auth, BasicAuth, DigestAuth
 from ._client import AsyncClient, Client
-from ._config import PoolLimits, Proxy, Timeout, create_ssl_context
+from ._config import Limits, PoolLimits, Proxy, Timeout, create_ssl_context
 from ._exceptions import (
     CloseError,
     ConnectError,
@@ -59,6 +59,7 @@ __all__ = [
     "BasicAuth",
     "Client",
     "DigestAuth",
+    "Limits",
     "PoolLimits",
     "Proxy",
     "Timeout",

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -7,8 +7,8 @@ import httpcore
 
 from ._auth import Auth, BasicAuth, FunctionAuth
 from ._config import (
-    DEFAULT_MAX_REDIRECTS,
     DEFAULT_LIMITS,
+    DEFAULT_MAX_REDIRECTS,
     DEFAULT_TIMEOUT_CONFIG,
     UNSET,
     Limits,

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -9,7 +9,7 @@ import certifi
 
 from ._models import URL, Headers
 from ._types import CertTypes, HeaderTypes, TimeoutTypes, URLTypes, VerifyTypes
-from ._utils import get_ca_bundle_from_env, get_logger
+from ._utils import get_ca_bundle_from_env, get_logger, warn_deprecated
 
 DEFAULT_CIPHERS = ":".join(
     [
@@ -301,9 +301,9 @@ class Timeout:
         )
 
 
-class PoolLimits:
+class Limits:
     """
-    Limits on the number of connections in a connection pool.
+    Configuration for limits to various client behaviors.
 
     **Parameters:**
 
@@ -332,6 +332,17 @@ class PoolLimits:
             f"{class_name}(max_keepalive={self.max_keepalive}, "
             f"max_connections={self.max_connections})"
         )
+
+
+class PoolLimits(Limits):
+    def __init__(
+        self, *, max_keepalive: int = None, max_connections: int = None,
+    ) -> None:
+        warn_deprecated(
+            "httpx.PoolLimits(...) is deprecated and will raise errors in the future. "
+            "Use httpx.Limits(...) instead."
+        )
+        super().__init__(max_keepalive=max_keepalive, max_connections=max_connections)
 
 
 class Proxy:
@@ -373,5 +384,5 @@ class Proxy:
 
 
 DEFAULT_TIMEOUT_CONFIG = Timeout(timeout=5.0)
-DEFAULT_POOL_LIMITS = PoolLimits(max_keepalive=10, max_connections=100)
+DEFAULT_LIMITS = Limits(max_keepalive=10, max_connections=100)
 DEFAULT_MAX_REDIRECTS = 20

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -194,3 +194,13 @@ def test_merge_url_hsts(url: str, scheme: str, is_ssl: bool):
     request = client.build_request("GET", url)
     assert request.url.scheme == scheme
     assert request.url.is_ssl == is_ssl
+
+
+def test_pool_limits_deprecated():
+    limits = httpx.Limits()
+
+    with pytest.warns(DeprecationWarning):
+        httpx.Client(pool_limits=limits)
+
+    with pytest.warns(DeprecationWarning):
+        httpx.AsyncClient(pool_limits=limits)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -101,13 +101,18 @@ def test_create_ssl_context_with_get_request(server, cert_pem_file):
 
 
 def test_limits_repr():
-    limits = httpx.PoolLimits(max_connections=100)
-    assert repr(limits) == "PoolLimits(max_keepalive=None, max_connections=100)"
+    limits = httpx.Limits(max_connections=100)
+    assert repr(limits) == "Limits(max_keepalive=None, max_connections=100)"
 
 
 def test_limits_eq():
-    limits = httpx.PoolLimits(max_connections=100)
-    assert limits == httpx.PoolLimits(max_connections=100)
+    limits = httpx.Limits(max_connections=100)
+    assert limits == httpx.Limits(max_connections=100)
+
+
+def test_pool_limits_deprecated():
+    with pytest.warns(DeprecationWarning):
+        httpx.PoolLimits()
 
 
 def test_timeout_eq():

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -34,10 +34,10 @@ async def test_connect_timeout(server):
 
 @pytest.mark.usefixtures("async_environment")
 async def test_pool_timeout(server):
-    pool_limits = httpx.PoolLimits(max_connections=1)
+    limits = httpx.Limits(max_connections=1)
     timeout = httpx.Timeout(None, pool_timeout=1e-4)
 
-    async with httpx.AsyncClient(pool_limits=pool_limits, timeout=timeout) as client:
+    async with httpx.AsyncClient(limits=limits, timeout=timeout) as client:
         async with client.stream("GET", server.url):
             with pytest.raises(httpx.PoolTimeout):
                 await client.get("http://localhost:8000/")


### PR DESCRIPTION
Fixes #1094

Change the following with gentle deprecation:

- `httpx.PoolLimits(...)` becomes `httpx.Limits(...)`
- `Client(pool_limits=...)` becomes `Client(limits=...)`
- `AsyncClient(pool_limits=...)` becomes `AsyncClient(limits=...)`
