### PR TITLE
Make Headers.keys(), Headers.values() and Headers.items() return set-like views instead of lists

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -405,23 +405,25 @@ class Headers(typing.MutableMapping[str, str]):
         """
         return self._list
 
-    def keys(self) -> typing.List[str]:  # type: ignore
-        return [key.decode(self.encoding) for key in self._dict.keys()]
+    def keys(self) -> typing.KeysView[str]:
+        return {key.decode(self.encoding): None for key in self._dict.keys()}.keys()
 
-    def values(self) -> typing.List[str]:  # type: ignore
-        return [value.decode(self.encoding) for value in self._dict.values()]
+    def values(self) -> typing.ValuesView[str]:
+        return {
+            key: value.decode(self.encoding) for key, value in self._dict.items()
+        }.values()
 
-    def items(self) -> typing.List[typing.Tuple[str, str]]:  # type: ignore
+    def items(self) -> typing.ItemsView[str, str]:
         """
-        Return a list of `(key, value)` pairs of headers. Concatenate headers
+        Return `(key, value)` items of headers. Concatenate headers
         into a single comma seperated value when a key occurs multiple times.
         """
-        return [
-            (key.decode(self.encoding), value.decode(self.encoding))
+        return {
+            key.decode(self.encoding): value.decode(self.encoding)
             for key, value in self._dict.items()
-        ]
+        }.items()
 
-    def multi_items(self) -> typing.List[typing.Tuple[str, str]]:  # type: ignore
+    def multi_items(self) -> typing.List[typing.Tuple[str, str]]:
         """
         Return a list of `(key, value)` pairs of headers. Allow multiple
         occurences of the same key without concatenating into a single
@@ -470,7 +472,7 @@ class Headers(typing.MutableMapping[str, str]):
             self[header] = headers[header]
 
     def copy(self) -> "Headers":
-        return Headers(self.items(), encoding=self.encoding)
+        return Headers(dict(self.items()), encoding=self.encoding)
 
     def __getitem__(self, key: str) -> str:
         """

--- a/tests/models/test_headers.py
+++ b/tests/models/test_headers.py
@@ -14,9 +14,9 @@ def test_headers():
     assert h.get("a") == "123, 456"
     assert h.get("nope", default=None) is None
     assert h.get_list("a") == ["123", "456"]
-    assert h.keys() == ["a", "b"]
-    assert h.values() == ["123, 456", "789"]
-    assert h.items() == [("a", "123, 456"), ("b", "789")]
+    assert list(h.keys()) == ["a", "b"]
+    assert list(h.values()) == ["123, 456", "789"]
+    assert list(h.items()) == [("a", "123, 456"), ("b", "789")]
     assert h.multi_items() == [("a", "123"), ("a", "456"), ("b", "789")]
     assert list(h) == ["a", "b"]
     assert dict(h) == {"a": "123, 456", "b": "789"}


### PR DESCRIPTION
Fixes #899

`Headers` inherits from `MutableMapping`, and part of implementing this protocol is returning "set-like views" in `.keys()`, `.values()` and `.items()` (similarly to how dicts do). Previously it was difficult (see #903), but since #1089 we have an internal `Headers._dict` which we can use to build and return native views.

Now `Headers` behave even more like a native mapping. :-)