### PR TITLE
Improve docs on client/request configuration merging

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -126,10 +126,10 @@ URL('https://example.com?client_id=client1')
 b'alice:ecila123'
 ```
 
-!!! warning "Gotcha: request-level `auth=None` may not do what you'd expect"
-    Even if `auth` can be overridden at the request level, it cannot be _disabled_ at the request level.
+!!! tip "Gotcha"
+    **Passing `auth=None` at the request-level is treated as "use the client-level auth", rather than "don't use auth".**
 
-    Like for headers, params and cookies, `client.get(..., auth=None)` will be treated as "use the client default", instead of "don't use auth". (This is the same than if you didn't pass `auth=None` at all.)
+    (This might be counter-intuitive given that _in general_ request-level `auth` will override the client-level value. But this is consistent with the behavior of request-level headers, query params and cookies, where `None` is treated as "don't change the client default".)
 
     In some cases you can get away with removing the `Authorization` header on the [request instance](#request-instances), but for complex auth flows this most likely won't be enough.
 


### PR DESCRIPTION
Fixes #1004 

Update the [Merging configuration](https://www.python-httpx.org/advanced/#merging-of-configuration) docs to resolve these items:

- Document what happens when mergeable configuration (headers, params, cookies) is passed `None` at the request level. Improve example snippet by using `X-Client-Header` and `X-Request-Header` example headers.

![Screenshot 2020-08-01 at 13 16 13](https://user-images.githubusercontent.com/15911462/89100690-5edbc500-d3f9-11ea-97e3-194c20fbbe73.png)

- Document the gotcha that request-level `auth=None` doesn't disable auth, even though request-level `auth` is advertised as generally taking precedence over client-level `auth`.

![Screenshot 2020-08-01 at 13 25 23](https://user-images.githubusercontent.com/15911462/89100793-82533f80-d3fa-11ea-96ef-1bc7c1f2250b.png)

