### PR TITLE
Use get_list consistently

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -334,7 +334,7 @@ class QueryParams(typing.Mapping[str, str]):
         message = (
             "QueryParams.getlist() is pending deprecation. Use QueryParams.get_list()"
         )
-        warnings.warn(message, PendingDeprecationWarning)
+        warnings.warn(message, DeprecationWarning)
         return self.get_list(key)
 
 
@@ -565,7 +565,7 @@ class Headers(typing.MutableMapping[str, str]):
 
     def getlist(self, key: str, split_commas: bool = False) -> typing.List[str]:
         message = "Headers.getlist() is pending deprecation. Use Headers.get_list()"
-        warnings.warn(message, PendingDeprecationWarning)
+        warnings.warn(message, DeprecationWarning)
         return self.get_list(key, split_commas=split_commas)
 
 

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -281,7 +281,7 @@ class QueryParams(typing.Mapping[str, str]):
 
         params = QueryParams(params)
         for param in params:
-            item, *extras = params.getlist(param)
+            item, *extras = params.get_list(param)
             self[param] = item
             if extras:
                 self._list.extend((param, e) for e in extras)
@@ -795,7 +795,7 @@ class Response:
         """
         if not hasattr(self, "_decoder"):
             decoders: typing.List[Decoder] = []
-            values = self.headers.getlist("content-encoding", split_commas=True)
+            values = self.headers.get_list("content-encoding", split_commas=True)
             for value in values:
                 value = value.strip().lower()
                 try:

--- a/tests/models/test_headers.py
+++ b/tests/models/test_headers.py
@@ -13,6 +13,7 @@ def test_headers():
     assert h["a"] == "123, 456"
     assert h.get("a") == "123, 456"
     assert h.get("nope", default=None) is None
+    assert h.getlist("a") == ["123", "456"]
     assert h.get_list("a") == ["123", "456"]
     assert list(h.keys()) == ["a", "b"]
     assert list(h.values()) == ["123, 456", "789"]

--- a/tests/models/test_headers.py
+++ b/tests/models/test_headers.py
@@ -13,8 +13,11 @@ def test_headers():
     assert h["a"] == "123, 456"
     assert h.get("a") == "123, 456"
     assert h.get("nope", default=None) is None
-    assert h.getlist("a") == ["123", "456"]
     assert h.get_list("a") == ["123", "456"]
+
+    with pytest.warns(DeprecationWarning):
+        assert h.getlist("a") == ["123", "456"]
+
     assert list(h.keys()) == ["a", "b"]
     assert list(h.values()) == ["123, 456", "789"]
     assert list(h.items()) == [("a", "123, 456"), ("b", "789")]

--- a/tests/models/test_queryparams.py
+++ b/tests/models/test_queryparams.py
@@ -19,8 +19,11 @@ def test_queryparams(source):
     assert q["a"] == "456"
     assert q.get("a") == "456"
     assert q.get("nope", default=None) is None
-    assert q.getlist("a") == ["123", "456"]
     assert q.get_list("a") == ["123", "456"]
+
+    with pytest.warns(DeprecationWarning):
+        assert q.getlist("a") == ["123", "456"]
+
     assert list(q.keys()) == ["a", "b"]
     assert list(q.values()) == ["456", "789"]
     assert list(q.items()) == [("a", "456"), ("b", "789")]

--- a/tests/models/test_queryparams.py
+++ b/tests/models/test_queryparams.py
@@ -19,6 +19,7 @@ def test_queryparams(source):
     assert q["a"] == "456"
     assert q.get("a") == "456"
     assert q.get("nope", default=None) is None
+    assert q.getlist("a") == ["123", "456"]
     assert q.get_list("a") == ["123", "456"]
     assert list(q.keys()) == ["a", "b"]
     assert list(q.values()) == ["456", "789"]


### PR DESCRIPTION
Pulled through from a nice catch in #1118

I'd assumed that we ought to pragma: nocover these cases, rather than test them, but on a second look this *does* seem to be the pragmatic option, so let's just roll with it.

Thanks to @j178 for this!