### PR TITLE
Setting `app=...` or `transport=...` should bypass environment proxies.

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -473,7 +473,10 @@ class Client(BaseClient):
             )
             limits = pool_limits
 
-        proxy_map = self._get_proxy_map(proxies, trust_env)
+        if app is None and transport is None:
+            proxy_map = self._get_proxy_map(proxies, trust_env)
+        else:
+            proxy_map = {}
 
         self._transport = self._init_transport(
             verify=verify,
@@ -1003,7 +1006,10 @@ class AsyncClient(BaseClient):
             )
             limits = pool_limits
 
-        proxy_map = self._get_proxy_map(proxies, trust_env)
+        if app is None and transport is None:
+            proxy_map = self._get_proxy_map(proxies, trust_env)
+        else:
+            proxy_map = None
 
         self._transport = self._init_transport(
             verify=verify,

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -89,10 +89,10 @@ class BaseClient:
         return self._trust_env
 
     def _get_proxy_map(
-        self, proxies: typing.Optional[ProxiesTypes], trust_env: bool,
+        self, proxies: typing.Optional[ProxiesTypes], allow_env_proxies: bool,
     ) -> typing.Dict[str, typing.Optional[Proxy]]:
         if proxies is None:
-            if trust_env:
+            if allow_env_proxies:
                 return {
                     key: None if url is None else Proxy(url=url)
                     for key, url in get_environment_proxies().items()
@@ -473,10 +473,8 @@ class Client(BaseClient):
             )
             limits = pool_limits
 
-        if app is None and transport is None:
-            proxy_map = self._get_proxy_map(proxies, trust_env)
-        else:
-            proxy_map = {}
+        allow_env_proxies = trust_env and app is None and transport is None
+        proxy_map = self._get_proxy_map(proxies, allow_env_proxies)
 
         self._transport = self._init_transport(
             verify=verify,
@@ -1006,10 +1004,8 @@ class AsyncClient(BaseClient):
             )
             limits = pool_limits
 
-        if app is None and transport is None:
-            proxy_map = self._get_proxy_map(proxies, trust_env)
-        else:
-            proxy_map = None
+        allow_env_proxies = trust_env and app is None and transport is None
+        proxy_map = self._get_proxy_map(proxies, allow_env_proxies)
 
         self._transport = self._init_transport(
             verify=verify,


### PR DESCRIPTION
If either `app=...` or `transport=...` are passed explicitly, then no env-var proxies should be used.

Closes #1039

Eg.

```python
# Disregard any `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY` environment settings in these contexts...
client = httpx.Client(app=my_flask_app)
client = httpx.Client(transport=httpx.AsyncTransport(my_starlette_app)
```