### PR TITLE
Deprecate `URL.is_ssl`

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -140,6 +140,8 @@ class URL:
 
     @property
     def is_ssl(self) -> bool:
+        message = 'URL.is_ssl() is pending deprecation. Use url.scheme == "https"'
+        warnings.warn(message, DeprecationWarning)
         return self.scheme == "https"
 
     @property

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -178,7 +178,8 @@ def test_merge_url():
     client = httpx.Client(base_url="https://www.example.com/")
     request = client.build_request("GET", "http://www.example.com")
     assert request.url.scheme == "http"
-    assert not request.url.is_ssl
+    with pytest.warns(DeprecationWarning):
+        assert not request.url.is_ssl
 
 
 def test_pool_limits_deprecated():


### PR DESCRIPTION
This is one of those niggly little API bits that have only ended up in here because of implementation details.

We're not using `url.is_ssl` anywhere in our codebase, and now that we're agnostic to protocols *except* at the transport layer, this API doesn't feel right. (Eg `ftps://...` is an SSL URL, but would return false here.)

If any users *are* using this, they should migrate to a more explicit `if url.scheme == "https":`.