### PR TITLE
Clean up keyword argument name, using URL.join(url=...), not URL.join(relative_url=...).

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -208,7 +208,7 @@ class BaseClient:
         Merge a URL argument together with any 'base_url' on the client,
         to create the URL used for the outgoing request.
         """
-        return self.base_url.join(relative_url=url)
+        return self.base_url.join(url)
 
     def _merge_cookies(
         self, cookies: CookieTypes = None

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -183,7 +183,7 @@ class URL:
 
         return URL(self._uri_reference.copy_with(**kwargs).unsplit(),)
 
-    def join(self, relative_url: URLTypes) -> "URL":
+    def join(self, url: URLTypes) -> "URL":
         """
         Return an absolute URL, using given this URL as the base.
         """

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -188,12 +188,12 @@ class URL:
         Return an absolute URL, using given this URL as the base.
         """
         if self.is_relative_url:
-            return URL(relative_url)
+            return URL(url)
 
         # We drop any fragment portion, because RFC 3986 strictly
         # treats URLs with a fragment portion as not being absolute URLs.
         base_uri = self._uri_reference.copy_with(fragment=None)
-        relative_url = URL(relative_url)
+        relative_url = URL(url)
         return URL(relative_url._uri_reference.resolve_with(base_uri).unsplit())
 
     def __hash__(self) -> int:


### PR DESCRIPTION
Another niggly bit of API cleanup, that's a hangover from past implementation details.

Now that the `URL()` class is agnostic to relative/absolute URLs, the keyword argument naming in `URL.join(relative_url=...)` isn't appropriate.

I think we can get away with a unilateral rename, given that it's not *really* a very end-user facing bit of API, and it'll be called out in the 0.14 release notes.