### PR TITLE
Base URL improvements

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -66,13 +66,10 @@ class BaseClient:
         cookies: CookieTypes = None,
         timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
         max_redirects: int = DEFAULT_MAX_REDIRECTS,
-        base_url: URLTypes = None,
+        base_url: URLTypes = "",
         trust_env: bool = True,
     ):
-        if base_url is None:
-            self.base_url = URL("")
-        else:
-            self.base_url = URL(base_url)
+        self.base_url = URL(base_url)
 
         self.auth = auth
         self._params = QueryParams(params)
@@ -441,7 +438,7 @@ class Client(BaseClient):
         limits: Limits = DEFAULT_LIMITS,
         pool_limits: Limits = None,
         max_redirects: int = DEFAULT_MAX_REDIRECTS,
-        base_url: URLTypes = None,
+        base_url: URLTypes = "",
         transport: httpcore.SyncHTTPTransport = None,
         app: typing.Callable = None,
         trust_env: bool = True,
@@ -972,7 +969,7 @@ class AsyncClient(BaseClient):
         limits: Limits = DEFAULT_LIMITS,
         pool_limits: Limits = None,
         max_redirects: int = DEFAULT_MAX_REDIRECTS,
-        base_url: URLTypes = None,
+        base_url: URLTypes = "",
         transport: httpcore.AsyncHTTPTransport = None,
         app: typing.Callable = None,
         trust_env: bool = True,

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -69,7 +69,7 @@ class BaseClient:
         base_url: URLTypes = "",
         trust_env: bool = True,
     ):
-        self.base_url = URL(base_url)
+        self._base_url = URL(base_url)
 
         self.auth = auth
         self._params = QueryParams(params)
@@ -103,6 +103,17 @@ class BaseClient:
         else:
             proxy = Proxy(url=proxies) if isinstance(proxies, (str, URL)) else proxies
             return {"all": proxy}
+
+    @property
+    def base_url(self) -> URL:
+        """
+        Base URL to use when sending requests with relative URLs.
+        """
+        return self._base_url
+
+    @base_url.setter
+    def base_url(self, url: URLTypes) -> None:
+        self._base_url = URL(url)
 
     @property
     def headers(self) -> Headers:

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -208,7 +208,7 @@ class BaseClient:
         Merge a URL argument together with any 'base_url' on the client,
         to create the URL used for the outgoing request.
         """
-        return self.base_url.join(relative_url=url)
+        return self.base_url.join(url)
 
     def _merge_cookies(
         self, cookies: CookieTypes = None

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -69,7 +69,7 @@ class BaseClient:
         base_url: URLTypes = "",
         trust_env: bool = True,
     ):
-        self.base_url = self._enforce_trailing_slash(URL(base_url))
+        self._base_url = self._enforce_trailing_slash(URL(base_url))
 
         self.auth = auth
         self._params = QueryParams(params)
@@ -87,8 +87,7 @@ class BaseClient:
     def _enforce_trailing_slash(self, url: URL) -> URL:
         if url.path.endswith("/"):
             return url
-        else:
-            return url.copy_with(path=url.path + "/")
+        return url.copy_with(path=url.path + "/")
 
     def _get_proxy_map(
         self, proxies: typing.Optional[ProxiesTypes], allow_env_proxies: bool,

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -183,7 +183,7 @@ class URL:
 
         return URL(self._uri_reference.copy_with(**kwargs).unsplit(),)
 
-    def join(self, relative_url: URLTypes) -> "URL":
+    def join(self, url: URLTypes) -> "URL":
         """
         Return an absolute URL, using given this URL as the base.
         """

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -188,12 +188,12 @@ class URL:
         Return an absolute URL, using given this URL as the base.
         """
         if self.is_relative_url:
-            return URL(relative_url)
+            return URL(url)
 
         # We drop any fragment portion, because RFC 3986 strictly
         # treats URLs with a fragment portion as not being absolute URLs.
         base_uri = self._uri_reference.copy_with(fragment=None)
-        relative_url = URL(relative_url)
+        relative_url = URL(url)
         return URL(relative_url._uri_reference.resolve_with(base_uri).unsplit())
 
     def __hash__(self) -> int:

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -55,7 +55,7 @@ from ._utils import (
 
 
 class URL:
-    def __init__(self, url: URLTypes, params: QueryParamTypes = None) -> None:
+    def __init__(self, url: URLTypes = "", params: QueryParamTypes = None) -> None:
         if isinstance(url, str):
             self._uri_reference = rfc3986.api.iri_reference(url).encode()
         else:

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -178,6 +178,7 @@ def test_merge_absolute_url():
     client = httpx.Client(base_url="https://www.example.com/")
     request = client.build_request("GET", "http://www.example.com/")
     assert request.url == httpx.URL("http://www.example.com/")
+    assert not request.url.is_ssl
 
 
 def test_merge_relative_url():

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -174,11 +174,28 @@ def test_base_url(server):
     assert response.url == base_url
 
 
-def test_merge_url():
+def test_merge_absolute_url():
     client = httpx.Client(base_url="https://www.example.com/")
-    request = client.build_request("GET", "http://www.example.com")
-    assert request.url.scheme == "http"
-    assert not request.url.is_ssl
+    request = client.build_request("GET", "http://www.example.com/")
+    assert request.url == httpx.URL("http://www.example.com/")
+
+
+def test_merge_relative_url():
+    client = httpx.Client(base_url="https://www.example.com/")
+    request = client.build_request("GET", "/testing/123")
+    assert request.url == httpx.URL("https://www.example.com/testing/123")
+
+
+def test_merge_relative_url_with_path():
+    client = httpx.Client(base_url="https://www.example.com/some/path")
+    request = client.build_request("GET", "/testing/123")
+    assert request.url == httpx.URL("https://www.example.com/some/path/testing/123")
+
+
+def test_merge_relative_url_with_dotted_path():
+    client = httpx.Client(base_url="https://www.example.com/some/path")
+    request = client.build_request("GET", "../testing/123")
+    assert request.url == httpx.URL("https://www.example.com/some/testing/123")
 
 
 def test_pool_limits_deprecated():

--- a/tests/client/test_properties.py
+++ b/tests/client/test_properties.py
@@ -1,4 +1,11 @@
-from httpx import AsyncClient, Cookies, Headers
+from httpx import URL, AsyncClient, Cookies, Headers
+
+
+def test_client_base_url():
+    client = AsyncClient()
+    client.base_url = "https://www.example.org/"  # type: ignore
+    assert isinstance(client.base_url, URL)
+    assert client.base_url == URL("https://www.example.org/")
 
 
 def test_client_headers():

--- a/tests/client/test_properties.py
+++ b/tests/client/test_properties.py
@@ -8,6 +8,20 @@ def test_client_base_url():
     assert client.base_url == URL("https://www.example.org/")
 
 
+def test_client_base_url_without_trailing_slash():
+    client = AsyncClient()
+    client.base_url = "https://www.example.org/path"  # type: ignore
+    assert isinstance(client.base_url, URL)
+    assert client.base_url == URL("https://www.example.org/path/")
+
+
+def test_client_base_url_with_trailing_slash():
+    client = AsyncClient()
+    client.base_url = "https://www.example.org/path/"  # type: ignore
+    assert isinstance(client.base_url, URL)
+    assert client.base_url == URL("https://www.example.org/path/")
+
+
 def test_client_headers():
     client = AsyncClient()
     client.headers = {"a": "b"}  # type: ignore


### PR DESCRIPTION
* Support no-argument invocation of `httpx.URL()`.
* Support `client.base_url = ...` as a property.
* Resolve `base_url` joining behaviour.

So, an alternative implementation that closes #846, prompted by work in #1117.

The implementation here handles this by...

* Always ensuring that `base_url` includes a trailing slash on the path. Eg. `https://www.example.com/subpath/`.
* Always stripping any leading `/` when joining relative URLs.

This ends up given the behaviours you'd naturally expect from `base_url` usage, and also supports dotted paths, eg `../foo/bar`


