### PR TITLE
Middleware API

### DIFF
--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -32,6 +32,7 @@ from ._exceptions import (
     WriteError,
     WriteTimeout,
 )
+from ._middleware import AsyncMiddleware, Middleware
 from ._models import URL, Cookies, Headers, QueryParams, Request, Response
 from ._status_codes import StatusCode, codes
 from ._transports.asgi import ASGITransport
@@ -55,6 +56,8 @@ __all__ = [
     "codes",
     "ASGITransport",
     "AsyncClient",
+    "AsyncMiddleware",
+    "Middleware",
     "Auth",
     "BasicAuth",
     "Client",

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -25,7 +25,7 @@ from ._exceptions import (
     TooManyRedirects,
     map_exceptions,
 )
-from ._middleware import Middleware, AsyncMiddleware
+from ._middleware import AsyncMiddleware, Middleware
 from ._models import URL, Cookies, Headers, QueryParams, Request, Response
 from ._status_codes import codes
 from ._transports.asgi import ASGITransport

--- a/httpx/_middleware.py
+++ b/httpx/_middleware.py
@@ -1,4 +1,5 @@
-from typing import Callable, Awaitable
+from typing import Awaitable, Callable
+
 from ._models import Request, Response
 
 

--- a/httpx/_middleware.py
+++ b/httpx/_middleware.py
@@ -1,0 +1,16 @@
+from typing import Callable, Awaitable
+from ._models import Request, Response
+
+
+class Middleware:
+    def send(
+        self, request: Request, call_next: Callable[[Request], Response]
+    ) -> Response:
+        raise NotImplementedError  # pragma: no cover
+
+
+class AsyncMiddleware:
+    async def asend(
+        self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
+        raise NotImplementedError  # pragma: no cover


### PR DESCRIPTION
And here I am pitching the idea of a middleware API again… :-)

As I mentioned in https://github.com/encode/httpx/issues/984#issuecomment-633234552, and more recently in https://github.com/encode/httpx/pull/1110#issuecomment-669450028, there is a variety of use cases that don't fall in the "make a custom transport" domain, the "subclass the client without using private API" domain. In general this is transport-agnostic feature that intercepts the request/response cycle, for example...

- Caching: look up the request key in a cache, and optionally return early with a response w/o hitting the transport.
- Throttling: defer the sending of the request until a throttle policy would be satisfied.
- HSTS (?): modify the request to use HTTPS if the requested website is on the HSTS Preload List.

After playing with ideas, this PR is all we would need to support a middleware API that would support the above use cases and, I believe, many more.

Core ideas are…

- Requests are passed through a stack of middleware. The processing stack is:

```console
# Process request...
middleware_1
    ... middleware_n
        send_handling_redirects() 
        # <Ultimately we dispatch to the transport>
        # Process the response...
    ... middleware_n
middleware_1
```

-