### PR TITLE
Fixed warnings in unit tests suite, caused by #1127 PR

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -107,7 +107,7 @@ class BaseClient:
             return new_proxies
         else:
             proxy = Proxy(url=proxies) if isinstance(proxies, (str, URL)) else proxies
-            return {"all": proxy}
+            return {"all://": proxy}
 
     @property
     def timeout(self) -> Timeout:
@@ -1034,6 +1034,7 @@ class AsyncClient(BaseClient):
             app=app,
             trust_env=trust_env,
         )
+
         self._proxies: typing.Dict[
             URLPattern, typing.Optional[httpcore.AsyncHTTPTransport]
         ] = {

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -312,7 +312,9 @@ def get_environment_proxies() -> typing.Dict[str, typing.Optional[str]]:
     for scheme in ("http", "https", "all"):
         if proxy_info.get(scheme):
             hostname = proxy_info[scheme]
-            mounts[scheme] = hostname if "://" in hostname else f"http://{hostname}"
+            mounts[f"{scheme}://"] = (
+                hostname if "://" in hostname else f"http://{hostname}"
+            )
 
     no_proxy_hosts = [host.strip() for host in proxy_info.get("no", "").split(",")]
     for hostname in no_proxy_hosts:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -192,12 +192,12 @@ async def test_elapsed_timer():
     ["environment", "proxies"],
     [
         ({}, {}),
-        ({"HTTP_PROXY": "http://127.0.0.1"}, {"http": "http://127.0.0.1"}),
+        ({"HTTP_PROXY": "http://127.0.0.1"}, {"http://": "http://127.0.0.1"}),
         (
             {"https_proxy": "http://127.0.0.1", "HTTP_PROXY": "https://127.0.0.1"},
-            {"https": "http://127.0.0.1", "http": "https://127.0.0.1"},
+            {"https://": "http://127.0.0.1", "http://": "https://127.0.0.1"},
         ),
-        ({"all_proxy": "http://127.0.0.1"}, {"all": "http://127.0.0.1"}),
+        ({"all_proxy": "http://127.0.0.1"}, {"all://": "http://127.0.0.1"}),
         ({"TRAVIS_APT_PROXY": "http://127.0.0.1"}, {}),
     ],
 )
@@ -247,9 +247,7 @@ def test_not_same_origin():
         ("all://example.com", "https://example.com", True,),
         ("http://", "http://example.com", True,),
         ("http://", "https://example.com", False,),
-        ("http", "http://example.com", True,),
-        ("http", "https://example.com", False,),
-        ("all", "https://example.com:123", True,),
+        ("all://", "https://example.com:123", True,),
         ("", "https://example.com:123", True,),
     ],
 )


### PR DESCRIPTION
@tomchristie 

I'm sorry, I've missed that the changes from #1127 caused several warnings during test suite executing. I've fixed that

**UPD** Probably we can enhance CI adding `-W error` to the `pytest` invocation?