### PR TITLE
HTTP/2 becomes fully optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ Install with pip:
 $ pip install httpx
 ```
 
+Or, to include the optional HTTP/2 support, use:
+
+```shell
+$ pip install httpx[http2]
+```
+
 HTTPX requires Python 3.6+.
 
 ## Documentation
@@ -110,7 +116,7 @@ The HTTPX project relies on these excellent libraries:
 
 * `httpcore` - The underlying transport implementation for `httpx`.
   * `h11` - HTTP/1.1 support.
-  * `h2` - HTTP/2 support.
+  * `h2` - HTTP/2 support. *(Optional)*
 * `certifi` - SSL certificates.
 * `chardet` - Fallback auto-detection for response encoding.
 * `idna` - Internationalized domain name support.

--- a/docs/http2.md
+++ b/docs/http2.md
@@ -24,8 +24,14 @@ implementation may be considered the more robust option at this point in time.
 It is possible that a future version of `httpx` may enable HTTP/2 support by default.
 
 If you're issuing highly concurrent requests you might want to consider
-trying out our HTTP/2 support. You can do so by instantiating a client with
-HTTP/2 support enabled:
+trying out our HTTP/2 support. You can do so by first making sure to install
+the optional HTTP/2 dependencies...
+
+```shell
+$ pip install httpx[http2]
+```
+
+And then then instantiating a client with HTTP/2 support enabled:
 
 ```python
 client = httpx.AsyncClient(http2=True)
@@ -41,7 +47,7 @@ async with httpx.AsyncClient(http2=True) as client:
     ...
 ```
 
-HTTP/2 support is available on both `Client`, and `AsyncClient`, although it's
+HTTP/2 support is available on both `Client` and `AsyncClient`, although it's
 typically more useful in async contexts if you're issuing lots of concurrent
 requests.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -129,6 +129,12 @@ Install with pip:
 $ pip install httpx
 ```
 
+Or, to include the optional HTTP/2 support, use:
+
+```shell
+$ pip install httpx[http2]
+```
+
 HTTPX requires Python 3.6+
 
 [sync-support]: https://github.com/encode/httpx/issues/572

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -479,7 +479,7 @@ class Client(BaseClient):
 
         if http2:
             try:
-                import h2
+                import h2  # noqa
             except ImportError:  # pragma: nocover
                 raise ImportError(
                     "Using http2=True, but the 'h2' package is not installed. "
@@ -1012,7 +1012,7 @@ class AsyncClient(BaseClient):
 
         if http2:
             try:
-                import h2
+                import h2  # noqa
             except ImportError:  # pragma: nocover
                 raise ImportError(
                     "Using http2=True, but the 'h2' package is not installed. "

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -477,6 +477,15 @@ class Client(BaseClient):
             trust_env=trust_env,
         )
 
+        if http2:
+            try:
+                import h2
+            except ImportError:  # pragma: nocover
+                raise ImportError(
+                    "Using http2=True, but the 'h2' package is not installed. "
+                    "Make sure to install httpx using `pip install httpx[http2]`."
+                ) from None
+
         if pool_limits is not None:
             warn_deprecated(
                 "Client(..., pool_limits=...) is deprecated and will raise "
@@ -1000,6 +1009,15 @@ class AsyncClient(BaseClient):
             base_url=base_url,
             trust_env=trust_env,
         )
+
+        if http2:
+            try:
+                import h2
+            except ImportError:  # pragma: nocover
+                raise ImportError(
+                    "Using http2=True, but the 'h2' package is not installed. "
+                    "Make sure to install httpx using `pip install httpx[http2]`."
+                ) from None
 
         if pool_limits is not None:
             warn_deprecated(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e .
+-e .[http2]
 
 # Optional
 brotlipy==0.7.*

--- a/setup.py
+++ b/setup.py
@@ -60,8 +60,11 @@ setup(
         "chardet==3.*",
         "idna==2.*",
         "rfc3986>=1.3,<2",
-        "httpcore[http2]==0.10.*",
+        "httpcore==0.10.*",
     ],
+    extras_require={
+        "http2": "h2==3.*",
+    },
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Web Environment",

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -8,7 +8,7 @@ import httpx
 @pytest.mark.usefixtures("async_environment")
 async def test_get(server):
     url = server.url
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(http2=True) as client:
         response = await client.get(url)
     assert response.status_code == 200
     assert response.text == "Hello, world!"

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -7,7 +7,7 @@ import httpx
 
 def test_get(server):
     url = server.url
-    with httpx.Client() as http:
+    with httpx.Client(http2=True) as http:
         response = http.get(url)
     assert response.status_code == 200
     assert response.url == url


### PR DESCRIPTION
With this pull request, our HTTP/2 support becomes fully optional.

You can use either the basic install, for HTTP/1.1 only...

```shell
$ pip install httpx
```

Or the optionall extra, for HTTP/2 support...

```shell
$ pip install httpx[http2]
```