### PR TITLE
Expand client docstrings

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -42,7 +42,7 @@
 
 ::: httpx.AsyncClient
     :docstring:
-    :members: headers cookies params request get head options post put patch delete build_request send
+    :members: headers cookies params request get head options post put patch delete build_request send aclose
 
 
 ## `Response`

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -206,6 +206,14 @@ class BaseClient:
     ) -> Request:
         """
         Build and return a request instance.
+
+        * The `params`, `headers` and `cookies` arguments
+        are merged with any values set on the client.
+        * The `url` argument is merged with any `base_url` set on the client.
+
+        See also: [Request instances][0]
+
+        [0]: /advanced/#request-instances
         """
         url = self._merge_url(url)
         headers = self._merge_headers(headers)
@@ -596,6 +604,22 @@ class Client(BaseClient):
         allow_redirects: bool = True,
         timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
     ) -> Response:
+        """
+        Build and send a request.
+
+        Roughly equivalent to:
+
+        ```python
+        request = client.build_request(...)
+        response = client.send(request, ...)
+        ```
+
+        See `Client.build_request()`, `Client.send()` and
+        [Merging of configuration][0] for how the various parameters
+        are merged with client-level configuration.
+
+        [0]: /advanced/#merging-of-configuration
+        """
         request = self.build_request(
             method=method,
             url=url,
@@ -619,6 +643,19 @@ class Client(BaseClient):
         allow_redirects: bool = True,
         timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
     ) -> Response:
+        """
+        Send a request.
+
+        The request is sent as-is, unmodified.
+
+        Typically you'll want to build one with `Client.build_request()`
+        so that any client-level configuration is merged into the request,
+        but passing an explicit `httpx.Request()` is supported as well.
+
+        See also: [Request instances][0]
+
+        [0]: /advanced/#request-instances
+        """
         timeout = self.timeout if isinstance(timeout, UnsetType) else Timeout(timeout)
 
         auth = self._build_auth(request, auth)
@@ -752,6 +789,11 @@ class Client(BaseClient):
         allow_redirects: bool = True,
         timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
     ) -> Response:
+        """
+        Send a `GET` request.
+
+        **Parameters**: See `httpx.request`.
+        """
         return self.request(
             "GET",
             url,
@@ -774,6 +816,11 @@ class Client(BaseClient):
         allow_redirects: bool = True,
         timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
     ) -> Response:
+        """
+        Send an `OPTIONS` request.
+
+        **Parameters**: See `httpx.request`.
+        """
         return self.request(
             "OPTIONS",
             url,
@@ -796,6 +843,11 @@ class Client(BaseClient):
         allow_redirects: bool = False,  # NOTE: Differs to usual default.
         timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
     ) -> Response:
+        """
+        Send a `HEAD` request.
+
+        **Parameters**: See `httpx.request`.
+        """
         return self.request(
             "HEAD",
             url,
@@ -821,6 +873,11 @@ class Client(BaseClient):
         allow_redirects: bool = True,
         timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
     ) -> Response:
+        """
+        Send a `POST` request.
+
+        **Parameters**: See `httpx.request`.
+        """
         return self.request(
             "POST",
             url,
@@ -849,6 +906,11 @@ class Client(BaseClient):
         allow_redirects: bool = True,
         timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
     ) -> Response:
+        """
+        Send a `PUT` request.
+
+        **Parameters**: See `httpx.request`.
+        """
         return self.request(
             "PUT",
             url,
@@ -877,6 +939,11 @@ class Client(BaseClient):
         allow_redirects: bool = True,
         timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
     ) -> Response:
+        """
+        Send a `PATCH` request.
+
+        **Parameters**: See `httpx.request`.
+        """
         return self.request(
             "PATCH",
             url,
@@ -902,6 +969,11 @@ class Client(BaseClient):
         allow_redirects: bool = True,
         timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
     ) -> Response:
+        """
+        Send a `DELETE` request.
+
+        **Parameters**: See `httpx.request`.
+        """
         return self.request(
             "DELETE",
             url,
@@ -914,6 +986,9 @@ class Client(BaseClient):
         )
 
     def close(self) -> None:
+        """
+        Close transport and proxies.
+        """
         self._transport.close()
         for proxy in self._proxies.values():
             if proxy is not None:
@@ -1130,6 +1205,22 @@ class AsyncClient(BaseClient):
         allow_redirects: bool = True,
         timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
     ) -> Response:
+        """
+        Build and send a request.
+
+        Roughly equivalent to:
+
+        ```python
+        request = client.build_request(...)
+        response = client.send(request, ...)
+        ```
+
+        See `AsyncClient.build_request()`, `AsyncClient.send()`
+        and [Merging of configuration][0] for how the various parameters
+        are merged with client-level configuration.
+
+        [0]: /advanced/#merging-of-configuration
+        """
         request = self.build_request(
             method=method,
             url=url,
@@ -1154,6 +1245,19 @@ class AsyncClient(BaseClient):
         allow_redirects: bool = True,
         timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
     ) -> Response:
+        """
+        Send a request.
+
+        The request is sent as-is, unmodified.
+
+        Typically you'll want to build one with `AsyncClient.build_request()`
+        so that any client-level configuration is merged into the request,
+        but passing an explicit `httpx.Request()` is supported as well.
+
+        See also: [Request instances][0]
+
+        [0]: /advanced/#request-instances
+        """
         timeout = self.timeout if isinstance(timeout, UnsetType) else Timeout(timeout)
 
         auth = self._build_auth(request, auth)
@@ -1289,6 +1393,11 @@ class AsyncClient(BaseClient):
         allow_redirects: bool = True,
         timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
     ) -> Response:
+        """
+        Send a `GET` request.
+
+        **Parameters**: See `httpx.request`.
+        """
         return await self.request(
             "GET",
             url,
@@ -1311,6 +1420,11 @@ class AsyncClient(BaseClient):
         allow_redirects: bool = True,
         timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
     ) -> Response:
+        """
+        Send an `OPTIONS` request.
+
+        **Parameters**: See `httpx.request`.
+        """
         return await self.request(
             "OPTIONS",
             url,
@@ -1333,6 +1447,11 @@ class AsyncClient(BaseClient):
         allow_redirects: bool = False,  # NOTE: Differs to usual default.
         timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
     ) -> Response:
+        """
+        Send a `HEAD` request.
+
+        **Parameters**: See `httpx.request`.
+        """
         return await self.request(
             "HEAD",
             url,
@@ -1358,6 +1477,11 @@ class AsyncClient(BaseClient):
         allow_redirects: bool = True,
         timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
     ) -> Response:
+        """
+        Send a `POST` request.
+
+        **Parameters**: See `httpx.request`.
+        """
         return await self.request(
             "POST",
             url,
@@ -1386,6 +1510,11 @@ class AsyncClient(BaseClient):
         allow_redirects: bool = True,
         timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
     ) -> Response:
+        """
+        Send a `PUT` request.
+
+        **Parameters**: See `httpx.request`.
+        """
         return await self.request(
             "PUT",
             url,
@@ -1414,6 +1543,11 @@ class AsyncClient(BaseClient):
         allow_redirects: bool = True,
         timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
     ) -> Response:
+        """
+        Send a `PATCH` request.
+
+        **Parameters**: See `httpx.request`.
+        """
         return await self.request(
             "PATCH",
             url,
@@ -1439,6 +1573,11 @@ class AsyncClient(BaseClient):
         allow_redirects: bool = True,
         timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
     ) -> Response:
+        """
+        Send a `DELETE` request.
+
+        **Parameters**: See `httpx.request`.
+        """
         return await self.request(
             "DELETE",
             url,
@@ -1451,6 +1590,9 @@ class AsyncClient(BaseClient):
         )
 
     async def aclose(self) -> None:
+        """
+        Close transport and proxies.
+        """
         await self._transport.aclose()
         for proxy in self._proxies.values():
             if proxy is not None:

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -607,7 +607,7 @@ class Client(BaseClient):
         """
         Build and send a request.
 
-        Roughly equivalent to:
+        Equivalent to:
 
         ```python
         request = client.build_request(...)
@@ -1208,7 +1208,7 @@ class AsyncClient(BaseClient):
         """
         Build and send a request.
 
-        Roughly equivalent to:
+        Equivalent to:
 
         ```python
         request = client.build_request(...)


### PR DESCRIPTION
Hi, from a short discussion in Gitter, I expanded some docstrings in client methods. This is perhaps continuation to the closed #397.

I decided to offer a minimal change, as I've not really had the chance of asking your opinion on anything. I tried to stay close to the style you already have in place. That being said, I have some questions.
- Should the verb docstrings refer to the documentation of the corresponding verb in parameters instead of `request`, or should they contain full duplicate parameter lists? Or would you rather have no documentation in them?
- Should the docstrings be in root form (imperative? sorry, I'm not a native English speaker) or not? HTTPX uses both, I decided on root, which I do prefer, i.e. "send a request" instead of "sends".

Some additional points that I came across. Perhaps they should be dealt with in separate issues. Feel free to simply reject them, as some are opinionated.
- Many docstrings that have a timeout parameter seem to cut oddly like `..., timeout=)`, most likely because of the `UNSET` value. But it looks odd.
- Stream-related things are still undocumented, even the top level `httpx.stream()`, but I can't claim to know enough of them quite yet
- Some client methods could be converted to static, as in they have an unused `self`
- Parameter lists are a bit off-putting, mainly because of the asterisks. Maybe this is because of the way mkdocs needs to handle them, but still, `help(func)` isn't exactly the easiest to read. But this is a minor inconvenience.
- `help` displays references to objects as they are in the file tree, e.g. `transport: httpcore._sync.base.SyncHTTPTransport = None` and some default values as references, e.g. `<httpx._config.UnsetType object at 0x0000028FDB590748>`. Two things could be done to improve the situation: "relocate" objects as they are imported, and define proper `repr`s for default values. By relocating I mean editing the `module` attribute of objects, as [here](https://github.com/felix-hilden/tekore/blob/master/tekore/__init__.py#L120). They are accessed from the top namespace after all.

Thank you for your consideration, and for the awesome package!