### PR TITLE
response cookies fix

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -1196,6 +1196,6 @@ class Cookies(MutableMapping):
 
         def info(self) -> email.message.Message:
             info = email.message.Message()
-            for key, value in self.response.headers.items():
+            for key, value in self.response.headers.multi_items():
                 info[key] = value
             return info


### PR DESCRIPTION
Fix response cookies in 0.14.0. Didn't return all headers. This error is described here #1151 

I apologize if I did not correctly formulate, this is my first PR
