### PR TITLE
Set `__module__ = 'httpx'` on everything we expose via the public API.

### DIFF
--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -114,4 +114,4 @@ __all__ = [
 _locals = locals()
 for name in __all__:
     if not name.startswith("__"):
-        setattr(_locals[name], "__module__", "httpx"). # noqa
+        setattr(_locals[name], "__module__", "httpx")  # noqa

--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -109,3 +109,9 @@ __all__ = [
     "DigestAuth",
     "WSGITransport",
 ]
+
+
+_locals = locals()
+for name in __all__:
+    if not name.startswith('__'):
+        setattr(_locals[name], '__module__', 'httpx')

--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -113,5 +113,5 @@ __all__ = [
 
 _locals = locals()
 for name in __all__:
-    if not name.startswith('__'):
-        setattr(_locals[name], '__module__', 'httpx')
+    if not name.startswith("__"):
+        setattr(_locals[name], "__module__", "httpx")

--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -114,4 +114,4 @@ __all__ = [
 _locals = locals()
 for name in __all__:
     if not name.startswith("__"):
-        setattr(_locals[name], "__module__", "httpx")
+        setattr(_locals[name], "__module__", "httpx"). # noqa


### PR DESCRIPTION
Set `__module__ = 'httpx'` on all our public API.

Primarily useful for classes that haven't declared a `__repr__` method, but might also improve the output of other code-introspection tooling?

Before:

```python
>>> import httpx
>>> httpx.DigestAuth(username='', password='')
<httpx._auth.DigestAuth object at 0x106682850>
```

After:

```python
>>> import httpx
>>> httpx.DigestAuth(username='', password='')
<httpx.DigestAuth object at 0x103529650>
```