### PR TITLE
Handle URL quoting username and password components.

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -56,10 +56,6 @@ from ._utils import (
 )
 
 
-def _quote(component: typing.Optional[str]) -> typing.Optional[str]:
-    return None if component is None else quote(component)
-
-
 class URL:
     def __init__(self, url: URLTypes = "", params: QueryParamTypes = None) -> None:
         if isinstance(url, str):
@@ -179,8 +175,8 @@ class URL:
         ):
             host = kwargs.pop("host", self.host)
             port = kwargs.pop("port", self.port)
-            username = _quote(kwargs.pop("username", self.username))
-            password = _quote(kwargs.pop("password", self.password))
+            username = quote(kwargs.pop("username", self.username) or "")
+            password = quote(kwargs.pop("password", self.password) or "")
 
             authority = host
             if port is not None:
@@ -197,7 +193,7 @@ class URL:
 
     def join(self, url: URLTypes) -> "URL":
         """
-        Return an absolute URL, using given this URL as the base.
+        Return an absolute URL, using this URL as the base.
         """
         if self.is_relative_url:
             return URL(url)

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -7,7 +7,7 @@ import urllib.request
 import warnings
 from collections.abc import MutableMapping
 from http.cookiejar import Cookie, CookieJar
-from urllib.parse import parse_qsl, urlencode
+from urllib.parse import parse_qsl, quote, unquote, urlencode
 
 import chardet
 import rfc3986
@@ -54,6 +54,10 @@ from ._utils import (
 )
 
 
+def _quote(component: typing.Optional[str]) -> typing.Optional[str]:
+    return None if component is None else quote(component)
+
+
 class URL:
     def __init__(self, url: URLTypes = "", params: QueryParamTypes = None) -> None:
         if isinstance(url, str):
@@ -94,12 +98,12 @@ class URL:
     @property
     def username(self) -> str:
         userinfo = self._uri_reference.userinfo or ""
-        return userinfo.partition(":")[0]
+        return unquote(userinfo.partition(":")[0])
 
     @property
     def password(self) -> str:
         userinfo = self._uri_reference.userinfo or ""
-        return userinfo.partition(":")[2]
+        return unquote(userinfo.partition(":")[2])
 
     @property
     def host(self) -> str:
@@ -169,8 +173,8 @@ class URL:
         ):
             host = kwargs.pop("host", self.host)
             port = kwargs.pop("port", self.port)
-            username = kwargs.pop("username", self.username)
-            password = kwargs.pop("password", self.password)
+            username = _quote(kwargs.pop("username", self.username))
+            password = _quote(kwargs.pop("password", self.password))
 
             authority = host
             if port is not None:

--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -185,3 +185,15 @@ def test_url_copywith_for_authority():
     for k, v in copy_with_kwargs.items():
         assert getattr(new, k) == v
     assert str(new) == "https://username:password@example.net:444"
+
+
+def test_url_copywith_for_userinfo():
+    copy_with_kwargs = {
+        "username": "tom@example.org",
+        "password": "abc123@ %",
+    }
+    url = URL("https://example.org")
+    new = url.copy_with(**copy_with_kwargs)
+    assert str(new) == "https://tom%40example.org:abc123%40%20%25@example.org"
+    assert new.username == "tom@example.org"
+    assert new.password == "abc123@ %"


### PR DESCRIPTION
So that...

```python
url = httpx.URL("https://tom%40example.org:abc123%40%20%25@example.org")
url.username == "tom@example.org"
url.password == "abc123@ %"
```

And...

```python
url = httpx.URL("https://example.org").copy_with(username="tom@example.org", password="abc123@ %")
url == "https://tom%40example.org:abc123%40%20%25@example.org"
```

Closes #858
Closes #328

Need to also have a think about what *exact* behaviour we're expecting from `.path`, `full_path`, and `.query`, but can treat those separately.