### PR TITLE
Remove all unused self params and convert to staticmethods

### DIFF
--- a/httpx/_auth.py
+++ b/httpx/_auth.py
@@ -75,8 +75,9 @@ class BasicAuth(Auth):
         request.headers["Authorization"] = self._auth_header
         yield request
 
+    @staticmethod
     def _build_auth_header(
-        self, username: typing.Union[str, bytes], password: typing.Union[str, bytes]
+        username: typing.Union[str, bytes], password: typing.Union[str, bytes]
     ) -> str:
         userpass = b":".join((to_bytes(username), to_bytes(password)))
         token = b64encode(userpass).decode()
@@ -120,8 +121,9 @@ class DigestAuth(Auth):
         request.headers["Authorization"] = self._build_auth_header(request, challenge)
         yield request
 
+    @staticmethod
     def _parse_challenge(
-        self, request: Request, response: Response
+        request: Request, response: Response
     ) -> "_DigestAuthChallenge":
         """
         Returns a challenge from a Digest WWW-Authenticate header.
@@ -200,7 +202,8 @@ class DigestAuth(Auth):
 
         return "Digest " + self._get_header_value(format_args)
 
-    def _get_client_nonce(self, nonce_count: int, nonce: bytes) -> bytes:
+    @staticmethod
+    def _get_client_nonce(nonce_count: int, nonce: bytes) -> bytes:
         s = str(nonce_count).encode()
         s += nonce
         s += time.ctime().encode()
@@ -208,7 +211,8 @@ class DigestAuth(Auth):
 
         return hashlib.sha1(s).hexdigest()[:16].encode()
 
-    def _get_header_value(self, header_fields: typing.Dict[str, bytes]) -> str:
+    @staticmethod
+    def _get_header_value(header_fields: typing.Dict[str, bytes]) -> str:
         NON_QUOTED_FIELDS = ("algorithm", "qop", "nc")
         QUOTED_TEMPLATE = '{}="{}"'
         NON_QUOTED_TEMPLATE = "{}={}"

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -82,13 +82,15 @@ class BaseClient:
     def trust_env(self) -> bool:
         return self._trust_env
 
-    def _enforce_trailing_slash(self, url: URL) -> URL:
+    @staticmethod
+    def _enforce_trailing_slash(url: URL) -> URL:
         if url.path.endswith("/"):
             return url
         return url.copy_with(path=url.path + "/")
 
+    @staticmethod
     def _get_proxy_map(
-        self, proxies: typing.Optional[ProxiesTypes], allow_env_proxies: bool,
+        proxies: typing.Optional[ProxiesTypes], allow_env_proxies: bool,
     ) -> typing.Dict[str, typing.Optional[Proxy]]:
         if proxies is None:
             if allow_env_proxies:
@@ -311,7 +313,8 @@ class BaseClient:
             method=method, url=url, headers=headers, cookies=cookies, stream=stream
         )
 
-    def _redirect_method(self, request: Request, response: Response) -> str:
+    @staticmethod
+    def _redirect_method(request: Request, response: Response) -> str:
         """
         When being redirected we may want to change the method of the request
         based on certain specs or browser behavior.
@@ -334,7 +337,8 @@ class BaseClient:
 
         return method
 
-    def _redirect_url(self, request: Request, response: Response) -> URL:
+    @staticmethod
+    def _redirect_url(request: Request, response: Response) -> URL:
         """
         Return the URL for the redirect to follow.
         """
@@ -358,7 +362,8 @@ class BaseClient:
 
         return url
 
-    def _redirect_headers(self, request: Request, url: URL, method: str) -> Headers:
+    @staticmethod
+    def _redirect_headers(request: Request, url: URL, method: str) -> Headers:
         """
         Return the headers that should be used for the redirect request.
         """
@@ -382,8 +387,9 @@ class BaseClient:
 
         return headers
 
+    @staticmethod
     def _redirect_stream(
-        self, request: Request, method: str
+        request: Request, method: str
     ) -> typing.Optional[ContentStream]:
         """
         Return the body that should be used for the redirect request.
@@ -522,8 +528,8 @@ class Client(BaseClient):
         }
         self._proxies = dict(sorted(self._proxies.items()))
 
+    @staticmethod
     def _init_transport(
-        self,
         verify: VerifyTypes = True,
         cert: CertTypes = None,
         http2: bool = False,
@@ -548,8 +554,8 @@ class Client(BaseClient):
             http2=http2,
         )
 
+    @staticmethod
     def _init_proxy_transport(
-        self,
         proxy: Proxy,
         verify: VerifyTypes = True,
         cert: CertTypes = None,
@@ -1056,8 +1062,8 @@ class AsyncClient(BaseClient):
         }
         self._proxies = dict(sorted(self._proxies.items()))
 
+    @staticmethod
     def _init_transport(
-        self,
         verify: VerifyTypes = True,
         cert: CertTypes = None,
         http2: bool = False,
@@ -1082,8 +1088,8 @@ class AsyncClient(BaseClient):
             http2=http2,
         )
 
+    @staticmethod
     def _init_proxy_transport(
-        self,
         proxy: Proxy,
         verify: VerifyTypes = True,
         cert: CertTypes = None,

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -397,7 +397,8 @@ class Proxy:
         self.headers = headers
         self.mode = mode
 
-    def _build_auth_header(self, username: str, password: str) -> str:
+    @staticmethod
+    def _build_auth_header(username: str, password: str) -> str:
         userpass = (username.encode("utf-8"), password.encode("utf-8"))
         token = b64encode(b":".join(userpass)).decode()
         return f"Basic {token}"

--- a/httpx/_content_streams.py
+++ b/httpx/_content_streams.py
@@ -215,7 +215,8 @@ class MultipartStream(ContentStream):
             data = self.render_data()
             return len(headers) + len(data)
 
-        def can_replay(self) -> bool:
+        @staticmethod
+        def can_replay() -> bool:
             return True
 
         def render(self) -> typing.Iterator[bytes]:


### PR DESCRIPTION
From the discussion in #1152, this PR converts all methods with an unused `self` to staticmethods.

This was not exactly agreed upon, so feel no obligations towards merging this if it's not to your taste. There is a case to be made for ignoring insignificant changes to reduce noise and keep history, but I do feel that small details add up. Anyway, thanks for having a look!