### PR TITLE
Fix #1146 Set default allow_redirects to true

### DIFF
--- a/httpx/_api.py
+++ b/httpx/_api.py
@@ -214,7 +214,7 @@ def head(
     headers: HeaderTypes = None,
     cookies: CookieTypes = None,
     auth: AuthTypes = None,
-    allow_redirects: bool = True,  # Note: Aligns with usual default (except for Requests).
+    allow_redirects: bool = True,
     cert: CertTypes = None,
     verify: VerifyTypes = True,
     timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,

--- a/httpx/_api.py
+++ b/httpx/_api.py
@@ -214,7 +214,7 @@ def head(
     headers: HeaderTypes = None,
     cookies: CookieTypes = None,
     auth: AuthTypes = None,
-    allow_redirects: bool = False,  # Note: Differs to usual default.
+    allow_redirects: bool = True,  # Note: Aligns with usual default (except for Requests).
     cert: CertTypes = None,
     verify: VerifyTypes = True,
     timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -849,7 +849,7 @@ class Client(BaseClient):
         headers: HeaderTypes = None,
         cookies: CookieTypes = None,
         auth: typing.Union[AuthTypes, UnsetType] = UNSET,
-        allow_redirects: bool = False,  # NOTE: Differs to usual default.
+        allow_redirects: bool = True,  # Note: Aligns with usual default (except for Requests).
         timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
     ) -> Response:
         """
@@ -1453,7 +1453,7 @@ class AsyncClient(BaseClient):
         headers: HeaderTypes = None,
         cookies: CookieTypes = None,
         auth: typing.Union[AuthTypes, UnsetType] = UNSET,
-        allow_redirects: bool = False,  # NOTE: Differs to usual default.
+        allow_redirects: bool = True,  # Note: Aligns with usual default (except for Requests).
         timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
     ) -> Response:
         """

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -849,7 +849,7 @@ class Client(BaseClient):
         headers: HeaderTypes = None,
         cookies: CookieTypes = None,
         auth: typing.Union[AuthTypes, UnsetType] = UNSET,
-        allow_redirects: bool = True,  # Note: Aligns with usual default (except for Requests).
+        allow_redirects: bool = True,
         timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
     ) -> Response:
         """
@@ -1453,7 +1453,7 @@ class AsyncClient(BaseClient):
         headers: HeaderTypes = None,
         cookies: CookieTypes = None,
         auth: typing.Union[AuthTypes, UnsetType] = UNSET,
-        allow_redirects: bool = True,  # Note: Aligns with usual default (except for Requests).
+        allow_redirects: bool = True,
         timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
     ) -> Response:
         """


### PR DESCRIPTION
# Fix #1146

This PR sets default `allow_redirects` to `True`. It was `False` before this PR.

This will align our behavior with most other http request libraries, except for [Requests](https://requests.readthedocs.io/en/v0.8.4/api/#requests.request).
