### PR TITLE
Map httpcore exceptions for `Response` read methods

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -24,6 +24,7 @@ from ._decoders import (
     TextDecoder,
 )
 from ._exceptions import (
+    HTTPCORE_EXC_MAP,
     CookieConflict,
     HTTPStatusError,
     InvalidURL,
@@ -32,6 +33,7 @@ from ._exceptions import (
     ResponseClosed,
     ResponseNotRead,
     StreamConsumed,
+    map_exceptions,
 )
 from ._status_codes import codes
 from ._types import (
@@ -931,8 +933,9 @@ class Response:
             raise ResponseClosed()
 
         self.is_stream_consumed = True
-        for part in self._raw_stream:
-            yield part
+        with map_exceptions(HTTPCORE_EXC_MAP, request=self.request):
+            for part in self._raw_stream:
+                yield part
         self.close()
 
     def next(self) -> "Response":
@@ -1008,8 +1011,9 @@ class Response:
             raise ResponseClosed()
 
         self.is_stream_consumed = True
-        async for part in self._raw_stream:
-            yield part
+        with map_exceptions(HTTPCORE_EXC_MAP, request=self.request):
+            async for part in self._raw_stream:
+                yield part
         await self.aclose()
 
     async def anext(self) -> "Response":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,8 +76,8 @@ async def app(scope, receive, send):
     assert scope["type"] == "http"
     if scope["path"].startswith("/slow_response"):
         await slow_response(scope, receive, send)
-    elif scope["path"].startswith("/slow_stream"):
-        await slow_stream(scope, receive, send)
+    elif scope["path"].startswith("/slow_stream_response"):
+        await slow_stream_response(scope, receive, send)
     elif scope["path"].startswith("/status"):
         await status_code(scope, receive, send)
     elif scope["path"].startswith("/echo_body"):
@@ -113,7 +113,7 @@ async def slow_response(scope, receive, send):
     await send({"type": "http.response.body", "body": b"Hello, world!"})
 
 
-async def slow_stream(scope, receive, send):
+async def slow_stream_response(scope, receive, send):
     await send(
         {
             "type": "http.response.start",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,8 @@ async def app(scope, receive, send):
     assert scope["type"] == "http"
     if scope["path"].startswith("/slow_response"):
         await slow_response(scope, receive, send)
+    elif scope["path"].startswith("/slow_stream"):
+        await slow_stream(scope, receive, send)
     elif scope["path"].startswith("/status"):
         await status_code(scope, receive, send)
     elif scope["path"].startswith("/echo_body"):
@@ -109,6 +111,19 @@ async def slow_response(scope, receive, send):
         }
     )
     await send({"type": "http.response.body", "body": b"Hello, world!"})
+
+
+async def slow_stream(scope, receive, send):
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [[b"content-type", b"text/plain"]],
+        }
+    )
+
+    await sleep(1)
+    await send({"type": "http.response.body", "body": b"", "more_body": False})
 
 
 async def status_code(scope, receive, send):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -33,7 +33,7 @@ def test_httpcore_exception_mapping(server) -> None:
     with pytest.raises(httpx.ConnectError):
         httpx.get("http://doesnotexist")
 
-    # Make sure Response.iter_raw() exceptinos are mapped
+    # Make sure streaming methods also map exceptions.
     url = server.url.copy_with(path="/slow_stream_response")
     timeout = httpx.Timeout(None, read=0.1)
     with httpx.stream("GET", url, timeout=timeout) as stream:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -34,10 +34,10 @@ def test_httpcore_exception_mapping(server) -> None:
         httpx.get("http://doesnotexist")
 
     # Make sure Response.iter_raw() exceptinos are mapped
-    url = server.url.copy_with(path="/slow_stream")
-    timeout = httpx.Timeout(None, read=1e-6)
-    with pytest.raises(httpx.ReadTimeout):
-        with httpx.stream("GET", url, timeout=timeout) as stream:
+    url = server.url.copy_with(path="/slow_stream_response")
+    timeout = httpx.Timeout(None, read=0.1)
+    with httpx.stream("GET", url, timeout=timeout) as stream:
+        with pytest.raises(httpx.ReadTimeout):
             stream.read()
 
     # Make sure it also works with custom transports.


### PR DESCRIPTION
Fix #1188
Add `map_exceptions` to `Response.iter_raw` and `Response.aiter_raw`, making sure all `httpcore` exceptions are mapped.
And add a slow_stream response test to make sure `ReadTimeout` ocurred while the client is reading the response body, not in the request time.