### PR TITLE
Warn a ResourceWarning when AsyncClient hasn't been closed (#871)

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -1253,6 +1253,9 @@ class AsyncClient(BaseClient):
 
         [0]: /advanced/#merging-of-configuration
         """
+        if self.is_closed:
+            raise RuntimeError("Unable to send request using closed client")
+
         request = self.build_request(
             method=method,
             url=url,
@@ -1625,11 +1628,21 @@ class AsyncClient(BaseClient):
         """
         Close transport and proxies.
         """
+        if self.is_closed:
+            raise RuntimeError("Unable to close already closed client")
+
         await self._transport.aclose()
         for proxy in self._proxies.values():
             if proxy is not None:
                 await proxy.aclose()
         self._is_closed = True
+
+    @property
+    def is_closed(self) -> bool:
+        """
+        Check if the client being closed
+        """
+        return self._is_closed
 
     async def __aenter__(self) -> "AsyncClient":
         return self

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -166,3 +166,25 @@ async def test_100_continue(server):
 
     assert response.status_code == 200
     assert response.content == data
+
+
+@pytest.mark.usefixtures("async_environment")
+async def test_unclosed_client_caused_warning():
+    with pytest.warns(ResourceWarning):
+        client = httpx.AsyncClient()
+        del client
+
+    with pytest.warns(None) as wb:
+
+        async with httpx.AsyncClient() as client:  # noqa: F841
+            pass
+
+        assert len(wb.list) == 0
+
+
+@pytest.mark.usefixtures("async_environment")
+async def test_that_client_is_closed_after_with_block():
+    async with httpx.AsyncClient() as client:
+        pass
+
+    assert client._is_closed

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -187,4 +187,33 @@ async def test_that_client_is_closed_after_with_block():
     async with httpx.AsyncClient() as client:
         pass
 
-    assert client._is_closed
+    assert client.is_closed
+
+
+@pytest.mark.usefixtures("async_environment")
+async def test_that_client_is_closed_after_aclose():
+    client = httpx.AsyncClient()
+
+    await client.aclose()
+
+    assert client.is_closed
+
+
+@pytest.mark.usefixtures("async_environment")
+async def test_that_client_cannot_be_closed_after_being_closed():
+    client = httpx.AsyncClient()
+
+    await client.aclose()
+
+    with pytest.raises(RuntimeError):
+        await client.aclose()
+
+
+@pytest.mark.usefixtures("async_environment")
+async def test_that_client_cannot_send_request_after_being_closed():
+    client = httpx.AsyncClient()
+
+    await client.aclose()
+
+    with pytest.raises(RuntimeError):
+        await client.get("http://example.com")


### PR DESCRIPTION
I added a warning in the `__del__` function inside the `AsyncClient` (I'm not sure if we can do more)