### PR TITLE
Drop redundant hasattr check

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -57,13 +57,13 @@ from ._utils import (
 class URL:
     def __init__(self, url: URLTypes = "", params: QueryParamTypes = None) -> None:
         if isinstance(url, str):
-            self._uri_reference = rfc3986.api.iri_reference(url).encode()
+            self._uri_reference = rfc3986.iri_reference(url).encode()
+            if self.is_absolute_url:
+                #  We don't want to normalize relative URLs, since doing so
+                # removes any leading `../` portion.
+                self._uri_reference = self._uri_reference.normalize()
         else:
             self._uri_reference = url._uri_reference
-
-        # Normalize scheme and domain name.
-        if self.is_absolute_url:
-            self._uri_reference = self._uri_reference.normalize()
 
         # Add any query parameters, merging with any in the URL if needed.
         if params:

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -947,8 +947,7 @@ class Response:
         if not self.is_closed:
             self.is_closed = True
             self._elapsed = self.request.timer.elapsed
-            if hasattr(self, "_raw_stream"):
-                self._raw_stream.close()
+            self._raw_stream.close()
 
     async def aread(self) -> bytes:
         """
@@ -1023,8 +1022,7 @@ class Response:
         if not self.is_closed:
             self.is_closed = True
             self._elapsed = self.request.timer.elapsed
-            if hasattr(self, "_raw_stream"):
-                await self._raw_stream.aclose()
+            await self._raw_stream.aclose()
 
 
 class Cookies(MutableMapping):


### PR DESCRIPTION
Remove a redundant `if hasattr(self, '_raw_stream')` check in the `Response` model code.

We *always* have a raw_stream instance attached to the response. The check is a relic of an older version of the codebase, where this wasn't always the case.

See the `Response.__init__` code for handling both the `None` and the not-`None` cases... https://github.com/encode/httpx/blob/cb620e67c76202e6f64d22e45fedc0eb7c41e69e/httpx/_models.py#L710-L713