### PR TITLE
Drop redundant hasattr check

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -956,8 +956,7 @@ class Response:
         if not self.is_closed:
             self.is_closed = True
             self._elapsed = self.request.timer.elapsed
-            if hasattr(self, "_raw_stream"):
-                self._raw_stream.close()
+            self._raw_stream.close()
 
     async def aread(self) -> bytes:
         """
@@ -1032,8 +1031,7 @@ class Response:
         if not self.is_closed:
             self.is_closed = True
             self._elapsed = self.request.timer.elapsed
-            if hasattr(self, "_raw_stream"):
-                await self._raw_stream.aclose()
+            await self._raw_stream.aclose()
 
 
 class Cookies(MutableMapping):


### PR DESCRIPTION
Remove a redundant `if hasattr(self, '_raw_stream')` check in the `Response` model code.

We *always* have a raw_stream instance attached to the response. The check is a relic of an older version of the codebase, where this wasn't always the case.

See the `Response.__init__` code for handling both the `None` and the not-`None` cases... https://github.com/encode/httpx/blob/cb620e67c76202e6f64d22e45fedc0eb7c41e69e/httpx/_models.py#L710-L713