### PR TITLE
Cleanup docstring leftover for #1183

### DIFF
--- a/httpx/_api.py
+++ b/httpx/_api.py
@@ -226,9 +226,7 @@ def head(
     **Parameters**: See `httpx.request`.
 
     Note that the `data`, `files`, and `json` parameters are not available on
-    this function, as `HEAD` requests should not include a request body. The
-    `HEAD` method also differs from the other cases in that `allow_redirects`
-    defaults to `False`.
+    this function, as `HEAD` requests should not include a request body.
     """
     return request(
         "HEAD",


### PR DESCRIPTION
Remove description about `head(..., allow_redirects=False)` (left by #1183)