### PR TITLE
Adjust 1.0 expectations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ HTTPX is a fully featured HTTP client for Python 3, which provides sync and asyn
 
 **Note**: _HTTPX should be considered in beta. We believe we've got the public API to
 a stable point now, but would strongly recommend pinning your dependencies to the `0.14.*`
-release, so that you're able to properly review [API changes between package updates](https://github.com/encode/httpx/blob/master/CHANGELOG.md). A 1.0 release is expected to be issued sometime around september 2020._
+release, so that you're able to properly review [API changes between package updates](https://github.com/encode/httpx/blob/master/CHANGELOG.md). A 1.0 release is expected to be issued sometime in late 2020._
 
 ---
 


### PR DESCRIPTION
Not sure why I thought saying "expected September 2020" was a good idea.
Like *maybe* that'll happen, but no problem with us taking our time if there's areas we want to be really firm about first. *Eg finer details in the Transport API*.