### PR TITLE
Event hooks

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -221,6 +221,54 @@ with httpx.Client(headers=headers) as client:
     ...
 ```
 
+## Event Hooks
+
+HTTPX allows you to register "event hooks" with the client, that are called
+every time a particular type of event takes place.
+
+There are currently two event hooks:
+
+* `request` - Called once a request is about to be sent. Passed the `request` instance.
+* `response` - Called once the response has been returned. Passed the `response` instance.
+
+These allow you to install client-wide functionality such as logging and monitoring.
+
+```python
+def log_request(request):
+    print(request)
+
+def log_response(response):
+    print(response)
+
+client = httpx.Client(event_hooks={'request': log_request, 'response': log_response})
+```
+
+You can also use these hooks to install response processing code, such as this
+example, which creates a client instance that always raises `httpx.HTTPStatusError`
+on 4xx and 5xx responses.
+
+```python
+def raise_on_4xx_5xx(response):
+    response.raise_for_status()
+
+client = httpx.Client(event_hooks={'response': raise_on_4xx_5xx})
+```
+
+You can also register multiple event hooks for each type of event, and can modify
+the event hooks either on client instantiation, or modify and inspect the
+event hooks using the `client.event_hooks` property.
+
+```python
+client = httpx.Client()
+client.event_hooks['request'] = [log_request]
+client.event_hooks['response'] = [log_response, raise_for_status]
+```
+
+!!! note
+    If you are using HTTPX's async support, then you need to be aware that
+    hooks registered with `httpx.AsyncClient` MUST be async functions,
+    rather than plain functions.
+
 ## .netrc Support
 
 HTTPX supports .netrc file. In `trust_env=True` cases, if auth parameter is

--- a/httpx/_api.py
+++ b/httpx/_api.py
@@ -35,6 +35,7 @@ def request(
     verify: VerifyTypes = True,
     cert: CertTypes = None,
     trust_env: bool = True,
+    event_hooks: dict = None,
 ) -> Response:
     """
     Sends an HTTP request.
@@ -84,7 +85,12 @@ def request(
     ```
     """
     with Client(
-        proxies=proxies, cert=cert, verify=verify, timeout=timeout, trust_env=trust_env,
+        proxies=proxies,
+        cert=cert,
+        verify=verify,
+        timeout=timeout,
+        trust_env=trust_env,
+        event_hooks=event_hooks,
     ) as client:
         return client.request(
             method=method,
@@ -117,6 +123,7 @@ def stream(
     verify: VerifyTypes = True,
     cert: CertTypes = None,
     trust_env: bool = True,
+    event_hooks: dict = None,
 ) -> StreamContextManager:
     """
     Alternative to `httpx.request()` that streams the response body
@@ -128,7 +135,13 @@ def stream(
 
     [0]: /quickstart#streaming-responses
     """
-    client = Client(proxies=proxies, cert=cert, verify=verify, trust_env=trust_env)
+    client = Client(
+        proxies=proxies,
+        cert=cert,
+        verify=verify,
+        trust_env=trust_env,
+        event_hooks=event_hooks,
+    )
     request = Request(
         method=method,
         url=url,
@@ -162,6 +175,7 @@ def get(
     verify: VerifyTypes = True,
     timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
     trust_env: bool = True,
+    event_hooks: dict = None,
 ) -> Response:
     """
     Sends a `GET` request.
@@ -184,6 +198,7 @@ def get(
         verify=verify,
         timeout=timeout,
         trust_env=trust_env,
+        event_hooks=event_hooks,
     )
 
 
@@ -200,6 +215,7 @@ def options(
     verify: VerifyTypes = True,
     timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
     trust_env: bool = True,
+    event_hooks: dict = None,
 ) -> Response:
     """
     Sends an `OPTIONS` request.
@@ -222,6 +238,7 @@ def options(
         verify=verify,
         timeout=timeout,
         trust_env=trust_env,
+        event_hooks=event_hooks,
     )
 
 
@@ -238,6 +255,7 @@ def head(
     verify: VerifyTypes = True,
     timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
     trust_env: bool = True,
+    event_hooks: dict = None,
 ) -> Response:
     """
     Sends a `HEAD` request.
@@ -260,6 +278,7 @@ def head(
         verify=verify,
         timeout=timeout,
         trust_env=trust_env,
+        event_hooks=event_hooks,
     )
 
 
@@ -279,6 +298,7 @@ def post(
     verify: VerifyTypes = True,
     timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
     trust_env: bool = True,
+    event_hooks: dict = None,
 ) -> Response:
     """
     Sends a `POST` request.
@@ -301,6 +321,7 @@ def post(
         verify=verify,
         timeout=timeout,
         trust_env=trust_env,
+        event_hooks=event_hooks,
     )
 
 
@@ -320,6 +341,7 @@ def put(
     verify: VerifyTypes = True,
     timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
     trust_env: bool = True,
+    event_hooks: dict = None,
 ) -> Response:
     """
     Sends a `PUT` request.
@@ -342,6 +364,7 @@ def put(
         verify=verify,
         timeout=timeout,
         trust_env=trust_env,
+        event_hooks=event_hooks,
     )
 
 
@@ -361,6 +384,7 @@ def patch(
     verify: VerifyTypes = True,
     timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
     trust_env: bool = True,
+    event_hooks: dict = None,
 ) -> Response:
     """
     Sends a `PATCH` request.
@@ -383,6 +407,7 @@ def patch(
         verify=verify,
         timeout=timeout,
         trust_env=trust_env,
+        event_hooks=event_hooks,
     )
 
 
@@ -399,6 +424,7 @@ def delete(
     verify: VerifyTypes = True,
     timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
     trust_env: bool = True,
+    event_hooks: dict = None,
 ) -> Response:
     """
     Sends a `DELETE` request.
@@ -421,4 +447,5 @@ def delete(
         verify=verify,
         timeout=timeout,
         trust_env=trust_env,
+        event_hooks=event_hooks,
     )

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -121,6 +121,14 @@ class BaseClient:
         self._timeout = Timeout(timeout)
 
     @property
+    def event_hooks(self) -> EventHooks:
+        return self._event_hooks
+
+    @event_hooks.setter
+    def event_hooks(self, event_hooks: dict) -> None:
+        self._event_hooks = EventHooks(event_hooks)
+
+    @property
     def auth(self) -> typing.Optional[Auth]:
         """
         Authentication class used when none is passed at the request-level.

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -723,8 +723,12 @@ class Client(BaseClient):
             finally:
                 response.close()
 
-        for hook in self._event_hooks["response"]:
-            hook(response)
+        try:
+            for hook in self._event_hooks["response"]:
+                hook(response)
+        except Exception:
+            response.close()
+            raise
 
         return response
 
@@ -1334,8 +1338,12 @@ class AsyncClient(BaseClient):
             finally:
                 await response.aclose()
 
-        for hook in self._event_hooks["response"]:
-            await hook(response)
+        try:
+            for hook in self._event_hooks["response"]:
+                await hook(response)
+        except Exception:
+            await response.aclose()
+            raise
 
         return response
 

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -416,8 +416,6 @@ class EventHooks(MutableMapping):
         value = dict(*args, **kwargs)
         self._dict = {
             "request": self._as_list(value.get("request", [])),
-            "auth": self._as_list(value.get("auth", [])),
-            "redirect": self._as_list(value.get("redirect", [])),
             "response": self._as_list(value.get("response", [])),
         }
 

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -208,3 +208,43 @@ def test_pool_limits_deprecated():
 
     with pytest.warns(DeprecationWarning):
         httpx.AsyncClient(pool_limits=limits)
+
+
+def test_event_hooks(server):
+    events = []
+
+    def on_request(request):
+        events.append({"event": "request", "headers": dict(request.headers)})
+
+    def on_response(response):
+        headers = dict(response.headers)
+        headers["date"] = "Mon, 24 Aug 2020 13:18:40 GMT"
+        events.append({"event": "response", "headers": headers})
+
+    event_hooks = {"request": on_request, "response": on_response}
+
+    with httpx.Client(event_hooks=event_hooks) as http:
+        http.get(server.url, auth=("username", "password"))
+
+    assert events == [
+        {
+            "event": "request",
+            "headers": {
+                "host": "127.0.0.1:8000",
+                "user-agent": "python-httpx/0.14.2",
+                "accept": "*/*",
+                "accept-encoding": "gzip, deflate, br",
+                "connection": "keep-alive",
+                "authorization": "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
+            },
+        },
+        {
+            "event": "response",
+            "headers": {
+                "date": "Mon, 24 Aug 2020 13:18:40 GMT",
+                "server": "uvicorn",
+                "content-type": "text/plain",
+                "transfer-encoding": "chunked",
+            },
+        },
+    ]

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -248,3 +248,17 @@ def test_event_hooks(server):
             },
         },
     ]
+
+
+def test_event_hooks_raising_exception(server):
+    def raise_on_4xx_5xx(response):
+        response.raise_for_status()
+
+    event_hooks = {"response": raise_on_4xx_5xx}
+
+    with httpx.Client(event_hooks=event_hooks) as http:
+        url = server.url.copy_with(path="/status/400")
+        try:
+            http.get(url)
+        except httpx.HTTPStatusError as exc:
+            assert exc.response.is_closed

--- a/tests/client/test_properties.py
+++ b/tests/client/test_properties.py
@@ -1,36 +1,36 @@
-from httpx import URL, AsyncClient, Cookies, Headers, Timeout
+from httpx import URL, Client, Cookies, Headers, Timeout
 
 
 def test_client_base_url():
-    client = AsyncClient()
+    client = Client()
     client.base_url = "https://www.example.org/"  # type: ignore
     assert isinstance(client.base_url, URL)
     assert client.base_url == URL("https://www.example.org/")
 
 
 def test_client_base_url_without_trailing_slash():
-    client = AsyncClient()
+    client = Client()
     client.base_url = "https://www.example.org/path"  # type: ignore
     assert isinstance(client.base_url, URL)
     assert client.base_url == URL("https://www.example.org/path/")
 
 
 def test_client_base_url_with_trailing_slash():
-    client = AsyncClient()
+    client = Client()
     client.base_url = "https://www.example.org/path/"  # type: ignore
     assert isinstance(client.base_url, URL)
     assert client.base_url == URL("https://www.example.org/path/")
 
 
 def test_client_headers():
-    client = AsyncClient()
+    client = Client()
     client.headers = {"a": "b"}  # type: ignore
     assert isinstance(client.headers, Headers)
     assert client.headers["A"] == "b"
 
 
 def test_client_cookies():
-    client = AsyncClient()
+    client = Client()
     client.cookies = {"a": "b"}  # type: ignore
     assert isinstance(client.cookies, Cookies)
     mycookies = list(client.cookies.jar)
@@ -40,7 +40,7 @@ def test_client_cookies():
 
 def test_client_timeout():
     expected_timeout = 12.0
-    client = AsyncClient()
+    client = Client()
 
     client.timeout = expected_timeout  # type: ignore
 
@@ -49,3 +49,12 @@ def test_client_timeout():
     assert client.timeout.read == expected_timeout
     assert client.timeout.write == expected_timeout
     assert client.timeout.pool == expected_timeout
+
+
+def test_client_event_hooks():
+    def on_request(request):
+        pass  # pragma: nocover
+
+    client = Client()
+    client.event_hooks = {"request": on_request}  # type: ignore
+    assert client.event_hooks["request"] == [on_request]

--- a/tests/test_event_hooks.py
+++ b/tests/test_event_hooks.py
@@ -1,0 +1,110 @@
+from httpx._config import EventHooks
+
+
+def callable():
+    pass  # pragma: nocover
+
+
+def test_event_hooks_init():
+    # Empty init
+
+    e = EventHooks()
+    assert dict(e) == {"request": [], "auth": [], "redirect": [], "response": []}
+
+    # Init from args
+
+    e = EventHooks({"request": callable})
+    assert dict(e) == {
+        "request": [callable],
+        "auth": [],
+        "redirect": [],
+        "response": [],
+    }
+
+    e = EventHooks({"request": [callable]})
+    assert dict(e) == {
+        "request": [callable],
+        "auth": [],
+        "redirect": [],
+        "response": [],
+    }
+
+    e = EventHooks({"request": [callable, callable]})
+    assert dict(e) == {
+        "request": [callable, callable],
+        "auth": [],
+        "redirect": [],
+        "response": [],
+    }
+
+    # Init from kwargs
+
+    e = EventHooks(request=callable)
+    assert dict(e) == {
+        "request": [callable],
+        "auth": [],
+        "redirect": [],
+        "response": [],
+    }
+
+    e = EventHooks(request=[callable])
+    assert dict(e) == {
+        "request": [callable],
+        "auth": [],
+        "redirect": [],
+        "response": [],
+    }
+
+    e = EventHooks(request=[callable, callable])
+    assert dict(e) == {
+        "request": [callable, callable],
+        "auth": [],
+        "redirect": [],
+        "response": [],
+    }
+
+
+def test_del_event_hooks():
+    e = EventHooks({"request": callable})
+    del e["request"]
+    assert dict(e) == {
+        "request": [],
+        "auth": [],
+        "redirect": [],
+        "response": [],
+    }
+
+
+def test_set_event_hooks():
+    e = EventHooks()
+
+    e["request"] = callable
+    e["redirect"] = [callable]
+    e["response"] = [callable, callable]
+    assert dict(e) == {
+        "request": [callable],
+        "auth": [],
+        "redirect": [callable],
+        "response": [callable, callable],
+    }
+
+
+def test_event_hooks_basics():
+    e = EventHooks(request=callable, response=callable)
+    assert len(e) == 4
+    assert str(e) == (
+        "{"
+        f"'request': [{callable!r}], "
+        "'auth': [], "
+        "'redirect': [], "
+        f"'response': [{callable!r}]"
+        "}"
+    )
+    assert repr(e) == (
+        "EventHooks({"
+        f"'request': [{callable!r}], "
+        "'auth': [], "
+        "'redirect': [], "
+        f"'response': [{callable!r}]"
+        "})"
+    )

--- a/tests/test_event_hooks.py
+++ b/tests/test_event_hooks.py
@@ -9,31 +9,25 @@ def test_event_hooks_init():
     # Empty init
 
     e = EventHooks()
-    assert dict(e) == {"request": [], "auth": [], "redirect": [], "response": []}
+    assert dict(e) == {"request": [], "response": []}
 
     # Init from args
 
     e = EventHooks({"request": callable})
     assert dict(e) == {
         "request": [callable],
-        "auth": [],
-        "redirect": [],
         "response": [],
     }
 
     e = EventHooks({"request": [callable]})
     assert dict(e) == {
         "request": [callable],
-        "auth": [],
-        "redirect": [],
         "response": [],
     }
 
     e = EventHooks({"request": [callable, callable]})
     assert dict(e) == {
         "request": [callable, callable],
-        "auth": [],
-        "redirect": [],
         "response": [],
     }
 
@@ -42,24 +36,18 @@ def test_event_hooks_init():
     e = EventHooks(request=callable)
     assert dict(e) == {
         "request": [callable],
-        "auth": [],
-        "redirect": [],
         "response": [],
     }
 
     e = EventHooks(request=[callable])
     assert dict(e) == {
         "request": [callable],
-        "auth": [],
-        "redirect": [],
         "response": [],
     }
 
     e = EventHooks(request=[callable, callable])
     assert dict(e) == {
         "request": [callable, callable],
-        "auth": [],
-        "redirect": [],
         "response": [],
     }
 
@@ -69,8 +57,6 @@ def test_del_event_hooks():
     del e["request"]
     assert dict(e) == {
         "request": [],
-        "auth": [],
-        "redirect": [],
         "response": [],
     }
 
@@ -79,32 +65,17 @@ def test_set_event_hooks():
     e = EventHooks()
 
     e["request"] = callable
-    e["redirect"] = [callable]
     e["response"] = [callable, callable]
     assert dict(e) == {
         "request": [callable],
-        "auth": [],
-        "redirect": [callable],
         "response": [callable, callable],
     }
 
 
 def test_event_hooks_basics():
     e = EventHooks(request=callable, response=callable)
-    assert len(e) == 4
-    assert str(e) == (
-        "{"
-        f"'request': [{callable!r}], "
-        "'auth': [], "
-        "'redirect': [], "
-        f"'response': [{callable!r}]"
-        "}"
-    )
+    assert len(e) == 2
+    assert str(e) == (f"{{'request': [{callable!r}], 'response': [{callable!r}]}}")
     assert repr(e) == (
-        "EventHooks({"
-        f"'request': [{callable!r}], "
-        "'auth': [], "
-        "'redirect': [], "
-        f"'response': [{callable!r}]"
-        "})"
+        f"EventHooks({{'request': [{callable!r}], 'response': [{callable!r}]}})"
     )


### PR DESCRIPTION
Closes #790, based on the design outlined in https://github.com/encode/httpx/issues/790#issuecomment-679068648

I've narrowed this down to *only* `request` and `response` initially. I think that `auth` and `redirect` also make sense, but let's treat that separately. (I want to be careful, since it could be a bit fiddly making sure that raised exceptions within those hooks don't leave responses open.)

Also worth noting that we're not exposing the `EventHooks` data structure as public API. Event hooks are always set using a regular dictionary, but have smart behaviour when the property is updated, so that they *always* return lists of installed handlers, but can be set *either* from a list *or* from a single callable.

For example:

```python
client = httpx.Client()
assert dict(client.event_hooks) == {'request': [], 'response': []}

client.event_hooks['request'] = some_callable
assert dict(client.event_hooks) == {'request': [some_callable], 'response': []}

client.event_hooks['request'].append(some_other_callable)
assert dict(client.event_hooks) == {'request': [some_callable, some_other_callable], 'response': []}

del client.event_hooks['request']
assert dict(client.event_hooks) == {'request': [], 'response': []}
```

Rendered docs:

<img width="792" alt="Screenshot 2020-08-24 at 15 28 19" src="https://user-images.githubusercontent.com/647359/91056924-784de680-e61e-11ea-96fe-bbad1af5eca7.png">
