### PR TITLE
Context managed transports

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -1047,10 +1047,10 @@ class Client(BaseClient):
         exc_value: BaseException = None,
         traceback: TracebackType = None,
     ) -> None:
-        self._transport.__exit__()
+        self._transport.__exit__(exc_type, exc_value, traceback)
         for proxy in self._proxies.values():
             if proxy is not None:
-                proxy.__exit__()
+                proxy.__exit__(exc_type, exc_value, traceback)
 
 
 class AsyncClient(BaseClient):

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -1035,6 +1035,10 @@ class Client(BaseClient):
                 proxy.close()
 
     def __enter__(self) -> "Client":
+        self._transport.__enter__()
+        for proxy in self._proxies.values():
+            if proxy is not None:
+                proxy.__enter__()
         return self
 
     def __exit__(
@@ -1043,7 +1047,10 @@ class Client(BaseClient):
         exc_value: BaseException = None,
         traceback: TracebackType = None,
     ) -> None:
-        self.close()
+        self._transport.__exit__()
+        for proxy in self._proxies.values():
+            if proxy is not None:
+                proxy.__exit__()
 
 
 class AsyncClient(BaseClient):
@@ -1639,6 +1646,10 @@ class AsyncClient(BaseClient):
                 await proxy.aclose()
 
     async def __aenter__(self) -> "AsyncClient":
+        await self._transport.__aenter__()
+        for proxy in self._proxies.values():
+            if proxy is not None:
+                await proxy.__aenter__()
         return self
 
     async def __aexit__(
@@ -1647,7 +1658,10 @@ class AsyncClient(BaseClient):
         exc_value: BaseException = None,
         traceback: TracebackType = None,
     ) -> None:
-        await self.aclose()
+        await self._transport.__aexit__()
+        for proxy in self._proxies.values():
+            if proxy is not None:
+                await proxy.__aexit__()
 
 
 class StreamContextManager:

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -1658,10 +1658,10 @@ class AsyncClient(BaseClient):
         exc_value: BaseException = None,
         traceback: TracebackType = None,
     ) -> None:
-        await self._transport.__aexit__()
+        await self._transport.__aexit__(exc_type, exc_value, traceback)
         for proxy in self._proxies.values():
             if proxy is not None:
-                await proxy.__aexit__()
+                await proxy.__aexit__(exc_type, exc_value, traceback)
 
 
 class StreamContextManager:

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -182,8 +182,8 @@ async def test_context_managed_transport():
             await super().__aenter__()
             self.events.append("transport.__aenter__")
 
-        async def __aexit__(self):
-            await super().__aexit__()
+        async def __aexit__(self, *args):
+            await super().__aexit__(*args)
             self.events.append("transport.__aexit__")
 
     # Note that we're including 'proxies' here to *also* run through the

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 
+import httpcore
 import pytest
 
 import httpx
@@ -166,3 +167,38 @@ async def test_100_continue(server):
 
     assert response.status_code == 200
     assert response.content == data
+
+
+@pytest.mark.usefixtures("async_environment")
+async def test_context_managed_transport():
+    class Transport(httpcore.AsyncHTTPTransport):
+        def __init__(self):
+            self.events = []
+
+        async def aclose(self):
+            self.events.append("transport.aclose")
+
+        async def __aenter__(self):
+            await super().__aenter__()
+            self.events.append("transport.__aenter__")
+
+        async def __aexit__(self):
+            await super().__aexit__()
+            self.events.append("transport.__aexit__")
+
+    # Note that we're including 'proxies' here to *also* run through the
+    # proxy context management, although we can't easily test that at the
+    # moment, since we can't add proxies as transport instances.
+    #
+    # Once we have a more generalised Mount API we'll be able to remove this
+    # in favour of ensuring all mounts are context managed, which will
+    # also neccessarily include proxies.
+    transport = Transport()
+    async with httpx.AsyncClient(transport=transport, proxies="http://www.example.com"):
+        pass
+
+    assert transport.events == [
+        "transport.__aenter__",
+        "transport.aclose",
+        "transport.__aexit__",
+    ]

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -176,6 +176,10 @@ async def test_context_managed_transport():
             self.events = []
 
         async def aclose(self):
+            # The base implementation of httpcore.AsyncHTTPTransport just
+            # calls into `.aclose`, so simple transport cases can just override
+            # this method for any cleanup, where more complex cases
+            # might want to additionally override `__aenter__`/`__aexit__`.
             self.events.append("transport.aclose")
 
         async def __aenter__(self):

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 
+import httpcore
 import pytest
 
 import httpx
@@ -208,3 +209,37 @@ def test_pool_limits_deprecated():
 
     with pytest.warns(DeprecationWarning):
         httpx.AsyncClient(pool_limits=limits)
+
+
+def test_context_managed_transport():
+    class Transport(httpcore.SyncHTTPTransport):
+        def __init__(self):
+            self.events = []
+
+        def close(self):
+            self.events.append("transport.close")
+
+        def __enter__(self):
+            super().__enter__()
+            self.events.append("transport.__enter__")
+
+        def __exit__(self):
+            super().__exit__()
+            self.events.append("transport.__exit__")
+
+    # Note that we're including 'proxies' here to *also* run through the
+    # proxy context management, although we can't easily test that at the
+    # moment, since we can't add proxies as transport instances.
+    #
+    # Once we have a more generalised Mount API we'll be able to remove this
+    # in favour of ensuring all mounts are context managed, which will
+    # also neccessarily include proxies.
+    transport = Transport()
+    with httpx.Client(transport=transport, proxies="http://www.example.com"):
+        pass
+
+    assert transport.events == [
+        "transport.__enter__",
+        "transport.close",
+        "transport.__exit__",
+    ]

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -217,6 +217,10 @@ def test_context_managed_transport():
             self.events = []
 
         def close(self):
+            # The base implementation of httpcore.SyncHTTPTransport just
+            # calls into `.close`, so simple transport cases can just override
+            # this method for any cleanup, where more complex cases
+            # might want to additionally override `__enter__`/`__exit__`.
             self.events.append("transport.close")
 
         def __enter__(self):

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -223,8 +223,8 @@ def test_context_managed_transport():
             super().__enter__()
             self.events.append("transport.__enter__")
 
-        def __exit__(self):
-            super().__exit__()
+        def __exit__(self, *args):
+            super().__exit__(*args)
             self.events.append("transport.__exit__")
 
     # Note that we're including 'proxies' here to *also* run through the


### PR DESCRIPTION
Closes https://github.com/encode/httpx/issues/1145

Note that once #977 is addressed we'll be able to test the proxies case more elegantly.

We're not being clever here about "ensure other transports still close if an exceptions occurs during `__exit__` in one transport". (Or the other fiddly case, of ensuring the `__exit__` is called on any already `__enter__`'d transports, if an exception occurs during `__enter__`.)

I *think* we should probably treat that as a follow up, and it's *possible* that we might only want to do so once #977 is addressed.

I think thats probably an okay approach to take since it's not any *worse* than our existing behaviour, which anyway doesn't handle "ensure other transports still close if an exceptions occurs during `close` in one transport", and besides exceptions during transport `__enter__`/`__exit__` are pretty much unrecoverable issues, and it's not really any worse if they happen to potentially leave other transports hanging open.

(Actually having talked through it I'm not event convinced that we *should* bother handling that case at all, but either way let's talk it through as a follow-up)