### PR TITLE
Make status_code keyword-only

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -803,7 +803,7 @@ class Client(BaseClient):
                 timeout=timeout.as_dict(),
             )
         response = Response(
-            status_code,
+            status_code=status_code,
             http_version=http_version.decode("ascii"),
             headers=headers,
             stream=stream,  # type: ignore
@@ -1414,7 +1414,7 @@ class AsyncClient(BaseClient):
                 timeout=timeout.as_dict(),
             )
         response = Response(
-            status_code,
+            status_code=status_code,
             http_version=http_version.decode("ascii"),
             headers=headers,
             stream=stream,  # type: ignore

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -687,9 +687,9 @@ class Request:
 class Response:
     def __init__(
         self,
-        status_code: int,
         *,
         request: Request,
+        status_code: int = codes.OK,
         http_version: str = None,
         headers: HeaderTypes = None,
         stream: ContentStream = None,

--- a/tests/models/test_cookies.py
+++ b/tests/models/test_cookies.py
@@ -69,7 +69,7 @@ def test_multiple_set_cookie():
         ),
     ]
     request = httpx.Request("GET", "https://www.example.org")
-    response = httpx.Response(200, request=request, headers=headers)
+    response = httpx.Response(status_code=200, request=request, headers=headers)
 
     cookies = httpx.Cookies(jar)
     cookies.extract_cookies(response)

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -21,7 +21,9 @@ async def async_streaming_body():
 
 
 def test_response():
-    response = httpx.Response(200, content=b"Hello, world!", request=REQUEST)
+    response = httpx.Response(
+        status_code=200, content=b"Hello, world!", request=REQUEST
+    )
 
     assert response.status_code == 200
     assert response.reason_phrase == "OK"
@@ -32,7 +34,9 @@ def test_response():
 
 
 def test_response_repr():
-    response = httpx.Response(200, content=b"Hello, world!", request=REQUEST)
+    response = httpx.Response(
+        status_code=200, content=b"Hello, world!", request=REQUEST
+    )
     assert repr(response) == "<Response [200 OK]>"
 
 
@@ -42,7 +46,9 @@ def test_response_content_type_encoding():
     """
     headers = {"Content-Type": "text-plain; charset=latin-1"}
     content = "Latin 1: ÿ".encode("latin-1")
-    response = httpx.Response(200, content=content, headers=headers, request=REQUEST)
+    response = httpx.Response(
+        status_code=200, content=content, headers=headers, request=REQUEST
+    )
     assert response.text == "Latin 1: ÿ"
     assert response.encoding == "latin-1"
 
@@ -52,7 +58,7 @@ def test_response_autodetect_encoding():
     Autodetect encoding if there is no charset info in a Content-Type header.
     """
     content = "おはようございます。".encode("EUC-JP")
-    response = httpx.Response(200, content=content, request=REQUEST)
+    response = httpx.Response(status_code=200, content=content, request=REQUEST)
     assert response.text == "おはようございます。"
     assert response.encoding == "EUC-JP"
 
@@ -63,7 +69,9 @@ def test_response_fallback_to_autodetect():
     """
     headers = {"Content-Type": "text-plain; charset=invalid-codec-name"}
     content = "おはようございます。".encode("EUC-JP")
-    response = httpx.Response(200, content=content, headers=headers, request=REQUEST)
+    response = httpx.Response(
+        status_code=200, content=content, headers=headers, request=REQUEST
+    )
     assert response.text == "おはようございます。"
     assert response.encoding == "EUC-JP"
 
@@ -75,7 +83,9 @@ def test_response_default_text_encoding():
     """
     content = b"Hello, world!"
     headers = {"Content-Type": "text/plain"}
-    response = httpx.Response(200, content=content, headers=headers, request=REQUEST)
+    response = httpx.Response(
+        status_code=200, content=content, headers=headers, request=REQUEST
+    )
     assert response.status_code == 200
     assert response.encoding == "iso-8859-1"
     assert response.text == "Hello, world!"
@@ -85,7 +95,7 @@ def test_response_default_encoding():
     """
     Default to utf-8 if all else fails.
     """
-    response = httpx.Response(200, content=b"", request=REQUEST)
+    response = httpx.Response(status_code=200, content=b"", request=REQUEST)
     assert response.text == ""
     assert response.encoding == "utf-8"
 
@@ -95,7 +105,9 @@ def test_response_non_text_encoding():
     Default to apparent encoding for non-text content-type headers.
     """
     headers = {"Content-Type": "image/png"}
-    response = httpx.Response(200, content=b"xyz", headers=headers, request=REQUEST)
+    response = httpx.Response(
+        status_code=200, content=b"xyz", headers=headers, request=REQUEST
+    )
     assert response.text == "xyz"
     assert response.encoding == "ascii"
 
@@ -105,7 +117,10 @@ def test_response_set_explicit_encoding():
         "Content-Type": "text-plain; charset=utf-8"
     }  # Deliberately incorrect charset
     response = httpx.Response(
-        200, content="Latin 1: ÿ".encode("latin-1"), headers=headers, request=REQUEST
+        status_code=200,
+        content="Latin 1: ÿ".encode("latin-1"),
+        headers=headers,
+        request=REQUEST,
     )
     response.encoding = "latin-1"
     assert response.text == "Latin 1: ÿ"
@@ -114,7 +129,7 @@ def test_response_set_explicit_encoding():
 
 def test_response_force_encoding():
     response = httpx.Response(
-        200, content="Snowman: ☃".encode("utf-8"), request=REQUEST
+        status_code=200, content="Snowman: ☃".encode("utf-8"), request=REQUEST
     )
     response.encoding = "iso-8859-1"
     assert response.status_code == 200
@@ -124,7 +139,9 @@ def test_response_force_encoding():
 
 
 def test_read():
-    response = httpx.Response(200, content=b"Hello, world!", request=REQUEST)
+    response = httpx.Response(
+        status_code=200, content=b"Hello, world!", request=REQUEST
+    )
 
     assert response.status_code == 200
     assert response.text == "Hello, world!"
@@ -140,7 +157,9 @@ def test_read():
 
 @pytest.mark.asyncio
 async def test_aread():
-    response = httpx.Response(200, content=b"Hello, world!", request=REQUEST)
+    response = httpx.Response(
+        status_code=200, content=b"Hello, world!", request=REQUEST
+    )
 
     assert response.status_code == 200
     assert response.text == "Hello, world!"
@@ -156,7 +175,7 @@ async def test_aread():
 
 def test_iter_raw():
     stream = IteratorStream(iterator=streaming_body())
-    response = httpx.Response(200, stream=stream, request=REQUEST)
+    response = httpx.Response(status_code=200, stream=stream, request=REQUEST)
 
     raw = b""
     for part in response.iter_raw():
@@ -167,7 +186,7 @@ def test_iter_raw():
 @pytest.mark.asyncio
 async def test_aiter_raw():
     stream = AsyncIteratorStream(aiterator=async_streaming_body())
-    response = httpx.Response(200, stream=stream, request=REQUEST)
+    response = httpx.Response(status_code=200, stream=stream, request=REQUEST)
 
     raw = b""
     async for part in response.aiter_raw():
@@ -176,7 +195,9 @@ async def test_aiter_raw():
 
 
 def test_iter_bytes():
-    response = httpx.Response(200, content=b"Hello, world!", request=REQUEST)
+    response = httpx.Response(
+        status_code=200, content=b"Hello, world!", request=REQUEST
+    )
 
     content = b""
     for part in response.iter_bytes():
@@ -186,7 +207,9 @@ def test_iter_bytes():
 
 @pytest.mark.asyncio
 async def test_aiter_bytes():
-    response = httpx.Response(200, content=b"Hello, world!", request=REQUEST)
+    response = httpx.Response(
+        status_code=200, content=b"Hello, world!", request=REQUEST
+    )
 
     content = b""
     async for part in response.aiter_bytes():
@@ -195,7 +218,9 @@ async def test_aiter_bytes():
 
 
 def test_iter_text():
-    response = httpx.Response(200, content=b"Hello, world!", request=REQUEST)
+    response = httpx.Response(
+        status_code=200, content=b"Hello, world!", request=REQUEST
+    )
 
     content = ""
     for part in response.iter_text():
@@ -205,7 +230,9 @@ def test_iter_text():
 
 @pytest.mark.asyncio
 async def test_aiter_text():
-    response = httpx.Response(200, content=b"Hello, world!", request=REQUEST)
+    response = httpx.Response(
+        status_code=200, content=b"Hello, world!", request=REQUEST
+    )
 
     content = ""
     async for part in response.aiter_text():
@@ -214,7 +241,9 @@ async def test_aiter_text():
 
 
 def test_iter_lines():
-    response = httpx.Response(200, content=b"Hello,\nworld!", request=REQUEST)
+    response = httpx.Response(
+        status_code=200, content=b"Hello,\nworld!", request=REQUEST
+    )
 
     content = []
     for line in response.iter_lines():
@@ -224,7 +253,9 @@ def test_iter_lines():
 
 @pytest.mark.asyncio
 async def test_aiter_lines():
-    response = httpx.Response(200, content=b"Hello,\nworld!", request=REQUEST)
+    response = httpx.Response(
+        status_code=200, content=b"Hello,\nworld!", request=REQUEST
+    )
 
     content = []
     async for line in response.aiter_lines():
@@ -234,7 +265,7 @@ async def test_aiter_lines():
 
 def test_sync_streaming_response():
     stream = IteratorStream(iterator=streaming_body())
-    response = httpx.Response(200, stream=stream, request=REQUEST)
+    response = httpx.Response(status_code=200, stream=stream, request=REQUEST)
 
     assert response.status_code == 200
     assert not response.is_closed
@@ -249,7 +280,7 @@ def test_sync_streaming_response():
 @pytest.mark.asyncio
 async def test_async_streaming_response():
     stream = AsyncIteratorStream(aiterator=async_streaming_body())
-    response = httpx.Response(200, stream=stream, request=REQUEST)
+    response = httpx.Response(status_code=200, stream=stream, request=REQUEST)
 
     assert response.status_code == 200
     assert not response.is_closed
@@ -263,7 +294,7 @@ async def test_async_streaming_response():
 
 def test_cannot_read_after_stream_consumed():
     stream = IteratorStream(iterator=streaming_body())
-    response = httpx.Response(200, stream=stream, request=REQUEST)
+    response = httpx.Response(status_code=200, stream=stream, request=REQUEST)
 
     content = b""
     for part in response.iter_bytes():
@@ -276,7 +307,7 @@ def test_cannot_read_after_stream_consumed():
 @pytest.mark.asyncio
 async def test_cannot_aread_after_stream_consumed():
     stream = AsyncIteratorStream(aiterator=async_streaming_body())
-    response = httpx.Response(200, stream=stream, request=REQUEST)
+    response = httpx.Response(status_code=200, stream=stream, request=REQUEST)
 
     content = b""
     async for part in response.aiter_bytes():
@@ -294,7 +325,7 @@ def test_cannot_read_after_response_closed():
         is_closed = True
 
     stream = IteratorStream(iterator=streaming_body(), close_func=close_func)
-    response = httpx.Response(200, stream=stream, request=REQUEST)
+    response = httpx.Response(status_code=200, stream=stream, request=REQUEST)
 
     response.close()
     assert is_closed
@@ -314,7 +345,7 @@ async def test_cannot_aread_after_response_closed():
     stream = AsyncIteratorStream(
         aiterator=async_streaming_body(), close_func=close_func
     )
-    response = httpx.Response(200, stream=stream, request=REQUEST)
+    response = httpx.Response(status_code=200, stream=stream, request=REQUEST)
 
     await response.aclose()
     assert is_closed
@@ -326,14 +357,14 @@ async def test_cannot_aread_after_response_closed():
 @pytest.mark.asyncio
 async def test_elapsed_not_available_until_closed():
     stream = AsyncIteratorStream(aiterator=async_streaming_body())
-    response = httpx.Response(200, stream=stream, request=REQUEST)
+    response = httpx.Response(status_code=200, stream=stream, request=REQUEST)
 
     with pytest.raises(RuntimeError):
         response.elapsed
 
 
 def test_unknown_status_code():
-    response = httpx.Response(600, request=REQUEST)
+    response = httpx.Response(status_code=600, request=REQUEST)
     assert response.status_code == 600
     assert response.reason_phrase == ""
     assert response.text == ""
@@ -343,7 +374,9 @@ def test_json_with_specified_encoding():
     data = {"greeting": "hello", "recipient": "world"}
     content = json.dumps(data).encode("utf-16")
     headers = {"Content-Type": "application/json, charset=utf-16"}
-    response = httpx.Response(200, content=content, headers=headers, request=REQUEST)
+    response = httpx.Response(
+        status_code=200, content=content, headers=headers, request=REQUEST
+    )
     assert response.json() == data
 
 
@@ -351,7 +384,9 @@ def test_json_with_options():
     data = {"greeting": "hello", "recipient": "world", "amount": 1}
     content = json.dumps(data).encode("utf-16")
     headers = {"Content-Type": "application/json, charset=utf-16"}
-    response = httpx.Response(200, content=content, headers=headers, request=REQUEST)
+    response = httpx.Response(
+        status_code=200, content=content, headers=headers, request=REQUEST
+    )
     assert response.json(parse_int=str)["amount"] == "1"
 
 
@@ -359,7 +394,9 @@ def test_json_without_specified_encoding():
     data = {"greeting": "hello", "recipient": "world"}
     content = json.dumps(data).encode("utf-32-be")
     headers = {"Content-Type": "application/json"}
-    response = httpx.Response(200, content=content, headers=headers, request=REQUEST)
+    response = httpx.Response(
+        status_code=200, content=content, headers=headers, request=REQUEST
+    )
     assert response.json() == data
 
 
@@ -370,7 +407,7 @@ def test_json_without_specified_encoding_decode_error():
     # force incorrect guess from `guess_json_utf` to trigger error
     with mock.patch("httpx._models.guess_json_utf", return_value="utf-32"):
         response = httpx.Response(
-            200, content=content, headers=headers, request=REQUEST
+            status_code=200, content=content, headers=headers, request=REQUEST
         )
         with pytest.raises(json.JSONDecodeError):
             response.json()
@@ -393,5 +430,7 @@ def test_json_without_specified_encoding_decode_error():
     ],
 )
 def test_link_headers(headers, expected):
-    response = httpx.Response(200, content=None, headers=headers, request=REQUEST)
+    response = httpx.Response(
+        status_code=200, content=None, headers=headers, request=REQUEST
+    )
     assert response.links == expected

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -29,7 +29,7 @@ def test_deflate():
 
     headers = [(b"Content-Encoding", b"deflate")]
     response = httpx.Response(
-        200, headers=headers, content=compressed_body, request=REQUEST
+        status_code=200, headers=headers, content=compressed_body, request=REQUEST
     )
     assert response.content == body
 
@@ -45,7 +45,7 @@ def test_zlib():
 
     headers = [(b"Content-Encoding", b"deflate")]
     response = httpx.Response(
-        200, headers=headers, content=compressed_body, request=REQUEST
+        status_code=200, headers=headers, content=compressed_body, request=REQUEST
     )
     assert response.content == body
 
@@ -57,7 +57,7 @@ def test_gzip():
 
     headers = [(b"Content-Encoding", b"gzip")]
     response = httpx.Response(
-        200, headers=headers, content=compressed_body, request=REQUEST
+        status_code=200, headers=headers, content=compressed_body, request=REQUEST
     )
     assert response.content == body
 
@@ -68,7 +68,7 @@ def test_brotli():
 
     headers = [(b"Content-Encoding", b"br")]
     response = httpx.Response(
-        200, headers=headers, content=compressed_body, request=REQUEST
+        status_code=200, headers=headers, content=compressed_body, request=REQUEST
     )
     assert response.content == body
 
@@ -86,7 +86,7 @@ def test_multi():
 
     headers = [(b"Content-Encoding", b"deflate, gzip")]
     response = httpx.Response(
-        200, headers=headers, content=compressed_body, request=REQUEST
+        status_code=200, headers=headers, content=compressed_body, request=REQUEST
     )
     assert response.content == body
 
@@ -97,13 +97,13 @@ def test_multi_with_identity():
 
     headers = [(b"Content-Encoding", b"br, identity")]
     response = httpx.Response(
-        200, headers=headers, content=compressed_body, request=REQUEST
+        status_code=200, headers=headers, content=compressed_body, request=REQUEST
     )
     assert response.content == body
 
     headers = [(b"Content-Encoding", b"identity, br")]
     response = httpx.Response(
-        200, headers=headers, content=compressed_body, request=REQUEST
+        status_code=200, headers=headers, content=compressed_body, request=REQUEST
     )
     assert response.content == body
 
@@ -119,7 +119,9 @@ async def test_streaming():
 
     headers = [(b"Content-Encoding", b"gzip")]
     stream = AsyncIteratorStream(aiterator=compress(body))
-    response = httpx.Response(200, headers=headers, stream=stream, request=REQUEST)
+    response = httpx.Response(
+        status_code=200, headers=headers, stream=stream, request=REQUEST
+    )
     assert not hasattr(response, "body")
     assert await response.aread() == body
 
@@ -127,7 +129,9 @@ async def test_streaming():
 @pytest.mark.parametrize("header_value", (b"deflate", b"gzip", b"br", b"identity"))
 def test_empty_content(header_value):
     headers = [(b"Content-Encoding", header_value)]
-    response = httpx.Response(200, headers=headers, content=b"", request=REQUEST)
+    response = httpx.Response(
+        status_code=200, headers=headers, content=b"", request=REQUEST
+    )
     assert response.content == b""
 
 
@@ -147,7 +151,9 @@ def test_decoding_errors(header_value):
     body = b"test 123"
     compressed_body = brotli.compress(body)[3:]
     with pytest.raises(httpx.DecodingError):
-        httpx.Response(200, headers=headers, content=compressed_body, request=REQUEST)
+        httpx.Response(
+            status_code=200, headers=headers, content=compressed_body, request=REQUEST
+        )
 
 
 @pytest.mark.parametrize(
@@ -176,13 +182,13 @@ async def test_text_decoder(data, encoding):
 
     # Accessing `.text` on a read response.
     stream = AsyncIteratorStream(aiterator=iterator())
-    response = httpx.Response(200, stream=stream, request=REQUEST)
+    response = httpx.Response(status_code=200, stream=stream, request=REQUEST)
     await response.aread()
     assert response.text == (b"".join(data)).decode(encoding)
 
     # Streaming `.aiter_text` iteratively.
     stream = AsyncIteratorStream(aiterator=iterator())
-    response = httpx.Response(200, stream=stream, request=REQUEST)
+    response = httpx.Response(status_code=200, stream=stream, request=REQUEST)
     text = "".join([part async for part in response.aiter_text()])
     assert text == (b"".join(data)).decode(encoding)
 
@@ -196,7 +202,7 @@ async def test_text_decoder_known_encoding():
 
     stream = AsyncIteratorStream(aiterator=iterator())
     response = httpx.Response(
-        200,
+        status_code=200,
         headers=[(b"Content-Type", b"text/html; charset=shift-jis")],
         stream=stream,
         request=REQUEST,
@@ -290,5 +296,7 @@ def test_invalid_content_encoding_header():
     headers = [(b"Content-Encoding", b"invalid-header")]
     body = b"test 123"
 
-    response = httpx.Response(200, headers=headers, content=body, request=REQUEST)
+    response = httpx.Response(
+        status_code=200, headers=headers, content=body, request=REQUEST
+    )
     assert response.content == body

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -169,11 +169,18 @@ def test_decoding_errors(header_value):
     with pytest.raises(httpx.DecodingError):
         request = httpx.Request("GET", "https://example.org")
         httpx.Response(
-            status_code=200, headers=headers, content=compressed_body, request=request
+            status_code=200,
+            headers=headers,
+            content=compressed_body,
+            request=request,
         )
 
     with pytest.raises(ValueError):
-        httpx.Response(status_code=200, headers=headers, content=compressed_body)
+        httpx.Response(
+            status_code=200,
+            headers=headers,
+            content=compressed_body,
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Make `status_code` a keyword-only argument, and defaulting it to 200. 

First part of #1227 .