### PR TITLE
Handle multiple auth headers correctly

### DIFF
--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -361,7 +361,7 @@ def test_digest_auth_returns_no_auth_if_alternate_auth_scheme() -> None:
     auth = DigestAuth(username="tomchristie", password="password123")
     auth_header = b"Token ..."
 
-    client = Client(
+    client = httpx.Client(
         transport=SyncMockTransport(auth_header=auth_header, status_code=401)
     )
     response = client.get(url, auth=auth)


### PR DESCRIPTION
Closes #1234 by correctly treating WWW-Authenticate headers as possibly occurring multiple times, and only dealing with “Digest” headers, and just ignoring other types of authentications.