### PR TITLE
Use sync client in test cases

### DIFF
--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -8,38 +8,37 @@ import httpcore
 import pytest
 
 import httpx
-from httpx._content_streams import AsyncIteratorStream, MultipartStream, encode
+from httpx._content_streams import MultipartStream, encode
 from httpx._utils import format_form_param
 
 
-class MockTransport(httpcore.AsyncHTTPTransport):
-    async def request(
+class MockTransport(httpcore.SyncHTTPTransport):
+    def request(
         self,
         method: bytes,
         url: typing.Tuple[bytes, bytes, typing.Optional[int], bytes],
         headers: typing.List[typing.Tuple[bytes, bytes]] = None,
-        stream: httpcore.AsyncByteStream = None,
+        stream: httpcore.SyncByteStream = None,
         timeout: typing.Mapping[str, typing.Optional[float]] = None,
     ) -> typing.Tuple[
         bytes,
         int,
         bytes,
         typing.List[typing.Tuple[bytes, bytes]],
-        httpcore.AsyncByteStream,
+        httpcore.SyncByteStream,
     ]:
         assert stream is not None
-        content = AsyncIteratorStream(aiterator=(part async for part in stream))
+        content = httpcore.IteratorByteStream(iterator=(part for part in stream))
         return b"HTTP/1.1", 200, b"OK", [], content
 
 
 @pytest.mark.parametrize(("value,output"), (("abc", b"abc"), (b"abc", b"abc")))
-@pytest.mark.asyncio
-async def test_multipart(value, output):
-    async with httpx.AsyncClient(transport=MockTransport()) as client:
+def test_multipart(value, output):
+    with httpx.Client(transport=MockTransport()) as client:
         # Test with a single-value 'data' argument, and a plain file 'files' argument.
         data = {"text": value}
         files = {"file": io.BytesIO(b"<file content>")}
-        response = await client.post("http://127.0.0.1:8000/", data=data, files=files)
+        response = client.post("http://127.0.0.1:8000/", data=data, files=files)
         assert response.status_code == 200
 
         # We're using the cgi module to verify the behavior here, which is a
@@ -59,13 +58,12 @@ async def test_multipart(value, output):
 
 
 @pytest.mark.parametrize(("key"), (b"abc", 1, 2.3, None))
-@pytest.mark.asyncio
-async def test_multipart_invalid_key(key):
-    async with httpx.AsyncClient(transport=MockTransport()) as client:
+def test_multipart_invalid_key(key):
+    with httpx.Client(transport=MockTransport()) as client:
         data = {key: "abc"}
         files = {"file": io.BytesIO(b"<file content>")}
         with pytest.raises(TypeError) as e:
-            await client.post(
+            client.post(
                 "http://127.0.0.1:8000/",
                 data=data,
                 files=files,
@@ -74,24 +72,22 @@ async def test_multipart_invalid_key(key):
 
 
 @pytest.mark.parametrize(("value"), (1, 2.3, None, [None, "abc"], {None: "abc"}))
-@pytest.mark.asyncio
-async def test_multipart_invalid_value(value):
-    async with httpx.AsyncClient(transport=MockTransport()) as client:
+def test_multipart_invalid_value(value):
+    with httpx.Client(transport=MockTransport()) as client:
         data = {"text": value}
         files = {"file": io.BytesIO(b"<file content>")}
         with pytest.raises(TypeError) as e:
-            await client.post("http://127.0.0.1:8000/", data=data, files=files)
+            client.post("http://127.0.0.1:8000/", data=data, files=files)
         assert "Invalid type for value" in str(e.value)
 
 
-@pytest.mark.asyncio
-async def test_multipart_file_tuple():
-    async with httpx.AsyncClient(transport=MockTransport()) as client:
+def test_multipart_file_tuple():
+    with httpx.Client(transport=MockTransport()) as client:
         # Test with a list of values 'data' argument,
         #     and a tuple style 'files' argument.
         data = {"text": ["abc"]}
         files = {"file": ("name.txt", io.BytesIO(b"<file content>"))}
-        response = await client.post("http://127.0.0.1:8000/", data=data, files=files)
+        response = client.post("http://127.0.0.1:8000/", data=data, files=files)
         assert response.status_code == 200
 
         # We're using the cgi module to verify the behavior here, which is a


### PR DESCRIPTION
Light bit of test case refactoring - use `httpx.Client` in multipart test cases.