### PR TITLE
Add support for `httpx.Response(content=..., text=..., html=..., json=...)`

### DIFF
--- a/httpx/_content_streams.py
+++ b/httpx/_content_streams.py
@@ -72,11 +72,8 @@ class IteratorStream(ContentStream):
     Request content encoded as plain bytes, using an byte iterator.
     """
 
-    def __init__(
-        self, iterator: typing.Iterator[bytes], close_func: typing.Callable = None
-    ) -> None:
+    def __init__(self, iterator: typing.Iterator[bytes]) -> None:
         self.iterator = iterator
-        self.close_func = close_func
         self.is_stream_consumed = False
 
     def can_replay(self) -> bool:
@@ -95,21 +92,14 @@ class IteratorStream(ContentStream):
     def __aiter__(self) -> typing.AsyncIterator[bytes]:
         raise RuntimeError("Attempted to call a async iterator on an sync stream.")
 
-    def close(self) -> None:
-        if self.close_func is not None:
-            self.close_func()
-
 
 class AsyncIteratorStream(ContentStream):
     """
     Request content encoded as plain bytes, using an async byte iterator.
     """
 
-    def __init__(
-        self, aiterator: typing.AsyncIterator[bytes], close_func: typing.Callable = None
-    ) -> None:
+    def __init__(self, aiterator: typing.AsyncIterator[bytes]) -> None:
         self.aiterator = aiterator
-        self.close_func = close_func
         self.is_stream_consumed = False
 
     def can_replay(self) -> bool:
@@ -127,10 +117,6 @@ class AsyncIteratorStream(ContentStream):
         self.is_stream_consumed = True
         async for part in self.aiterator:
             yield part
-
-    async def aclose(self) -> None:
-        if self.close_func is not None:
-            await self.close_func()
 
 
 class JSONStream(ContentStream):

--- a/httpx/_content_streams.py
+++ b/httpx/_content_streams.py
@@ -370,7 +370,7 @@ class MultipartStream(ContentStream):
             yield chunk
 
 
-def encode(
+def encode_request_body(
     data: RequestData = None,
     files: RequestFiles = None,
     json: typing.Any = None,

--- a/httpx/_content_streams.py
+++ b/httpx/_content_streams.py
@@ -402,3 +402,7 @@ def encode_request_body(
         return IteratorStream(iterator=data)
 
     raise TypeError(f"Unexpected type for 'data', {type(data)!r}")
+
+
+def encode_response_body(content: bytes = None) -> ContentStream:
+    return ByteStream(body=content or b"")

--- a/httpx/_content_streams.py
+++ b/httpx/_content_streams.py
@@ -370,6 +370,46 @@ class MultipartStream(ContentStream):
             yield chunk
 
 
+class TextStream(ContentStream):
+    """
+    Response content as plain text.
+    """
+
+    def __init__(self, text: str) -> None:
+        self.body = text.encode("utf-8")
+
+    def get_headers(self) -> typing.Dict[str, str]:
+        content_length = str(len(self.body))
+        content_type = "text/plain; charset=utf-8"
+        return {"Content-Length": content_length, "Content-Type": content_type}
+
+    def __iter__(self) -> typing.Iterator[bytes]:
+        yield self.body
+
+    async def __aiter__(self) -> typing.AsyncIterator[bytes]:
+        yield self.body
+
+
+class HTMLStream(ContentStream):
+    """
+    Response content as HTML.
+    """
+
+    def __init__(self, html: str) -> None:
+        self.body = html.encode("utf-8")
+
+    def get_headers(self) -> typing.Dict[str, str]:
+        content_length = str(len(self.body))
+        content_type = "text/html; charset=utf-8"
+        return {"Content-Length": content_length, "Content-Type": content_type}
+
+    def __iter__(self) -> typing.Iterator[bytes]:
+        yield self.body
+
+    async def __aiter__(self) -> typing.AsyncIterator[bytes]:
+        yield self.body
+
+
 def encode_request_body(
     data: RequestData = None,
     files: RequestFiles = None,
@@ -405,8 +445,12 @@ def encode_request_body(
 
 
 def encode_response_body(
-    content: bytes = None, json: typing.Any = None
+    content: bytes = None, text: str = None, html: str = None, json: typing.Any = None
 ) -> ContentStream:
-    if json is not None:
+    if text is not None:
+        return TextStream(text=text)
+    elif html is not None:
+        return HTMLStream(html=html)
+    elif json is not None:
         return JSONStream(json=json)
     return ByteStream(body=content or b"")

--- a/httpx/_content_streams.py
+++ b/httpx/_content_streams.py
@@ -404,5 +404,9 @@ def encode_request_body(
     raise TypeError(f"Unexpected type for 'data', {type(data)!r}")
 
 
-def encode_response_body(content: bytes = None) -> ContentStream:
+def encode_response_body(
+    content: bytes = None, json: typing.Any = None
+) -> ContentStream:
+    if json is not None:
+        return JSONStream(json=json)
     return ByteStream(body=content or b"")

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -696,11 +696,12 @@ class Response:
         self,
         status_code: int,
         *,
-        request: Request = None,
         http_version: str = None,
         headers: HeaderTypes = None,
-        stream: ContentStream = None,
         content: bytes = None,
+        json: typing.Any = None,
+        stream: ContentStream = None,
+        request: Request = None,
         history: typing.List["Response"] = None,
     ):
         self.status_code = status_code
@@ -718,7 +719,7 @@ class Response:
         if stream is not None:
             self._raw_stream = stream
         else:
-            self._raw_stream = encode_response_body(content)
+            self._raw_stream = encode_response_body(content=content, json=json)
             for key, value in self._raw_stream.get_headers().items():
                 self.headers.setdefault(key, value)
             self.read()

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -15,7 +15,7 @@ import rfc3986
 import rfc3986.exceptions
 
 from .__version__ import __version__
-from ._content_streams import ByteStream, ContentStream, encode
+from ._content_streams import ByteStream, ContentStream, encode_request_body
 from ._decoders import (
     SUPPORTED_DECODERS,
     Decoder,
@@ -609,7 +609,7 @@ class Request:
         if stream is not None:
             self.stream = stream
         else:
-            self.stream = encode(data, files, json)
+            self.stream = encode_request_body(data, files, json)
 
         self.timer = ElapsedTimer()
         self.prepare()

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -699,6 +699,8 @@ class Response:
         http_version: str = None,
         headers: HeaderTypes = None,
         content: bytes = None,
+        text: str = None,
+        html: str = None,
         json: typing.Any = None,
         stream: ContentStream = None,
         request: Request = None,
@@ -719,7 +721,9 @@ class Response:
         if stream is not None:
             self._raw_stream = stream
         else:
-            self._raw_stream = encode_response_body(content=content, json=json)
+            self._raw_stream = encode_response_body(
+                content=content, text=text, html=html, json=json
+            )
             for key, value in self._raw_stream.get_headers().items():
                 self.headers.setdefault(key, value)
             self.read()

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -15,7 +15,12 @@ import rfc3986
 import rfc3986.exceptions
 
 from .__version__ import __version__
-from ._content_streams import ByteStream, ContentStream, encode_request_body
+from ._content_streams import (
+    ByteStream,
+    ContentStream,
+    encode_request_body,
+    encode_response_body,
+)
 from ._decoders import (
     SUPPORTED_DECODERS,
     Decoder,
@@ -713,7 +718,7 @@ class Response:
         if stream is not None:
             self._raw_stream = stream
         else:
-            self._raw_stream = ByteStream(body=content or b"")
+            self._raw_stream = encode_response_body(content)
             self.read()
 
     @property

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -719,6 +719,8 @@ class Response:
             self._raw_stream = stream
         else:
             self._raw_stream = encode_response_body(content)
+            for key, value in self._raw_stream.get_headers().items():
+                self.headers.setdefault(key, value)
             self.read()
 
     @property

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -50,6 +50,7 @@ from ._types import (
     QueryParamTypes,
     RequestData,
     RequestFiles,
+    ResponseContent,
     URLTypes,
 )
 from ._utils import (
@@ -698,7 +699,7 @@ class Response:
         *,
         http_version: str = None,
         headers: HeaderTypes = None,
-        content: bytes = None,
+        content: ResponseContent = None,
         text: str = None,
         html: str = None,
         json: typing.Any = None,
@@ -726,7 +727,10 @@ class Response:
             )
             for key, value in self._raw_stream.get_headers().items():
                 self.headers.setdefault(key, value)
-            self.read()
+
+            if content is None or isinstance(content, bytes):
+                # Load the response body, except for streaming content.
+                self.read()
 
     @property
     def elapsed(self) -> datetime.timedelta:

--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -64,6 +64,7 @@ AuthTypes = Union[
 ]
 
 RequestData = Union[dict, str, bytes, Iterator[bytes], AsyncIterator[bytes]]
+ResponseContent = Union[bytes, Iterator[bytes], AsyncIterator[bytes]]
 
 FileContent = Union[IO[str], IO[bytes], str, bytes]
 FileTypes = Union[

--- a/tests/client/test_queryparams.py
+++ b/tests/client/test_queryparams.py
@@ -3,7 +3,7 @@ import typing
 import httpcore
 
 import httpx
-from httpx._content_streams import ContentStream, JSONStream
+from httpx._content_streams import JSONStream
 
 
 class MockTransport(httpcore.SyncHTTPTransport):
@@ -15,7 +15,11 @@ class MockTransport(httpcore.SyncHTTPTransport):
         stream: httpcore.SyncByteStream = None,
         timeout: typing.Mapping[str, typing.Optional[float]] = None,
     ) -> typing.Tuple[
-        bytes, int, bytes, typing.List[typing.Tuple[bytes, bytes]], ContentStream
+        bytes,
+        int,
+        bytes,
+        typing.List[typing.Tuple[bytes, bytes]],
+        httpcore.SyncByteStream,
     ]:
         body = JSONStream({"ok": "ok"})
         return b"HTTP/1.1", 200, b"OK", [], body

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -32,6 +32,7 @@ def test_response():
     assert response.request.method == "GET"
     assert response.request.url == "https://example.org"
     assert response.elapsed >= datetime.timedelta(0)
+    assert response.headers == httpx.Headers({"Content-Length": "13"})
     assert not response.is_error
 
 

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -6,7 +6,6 @@ import brotli
 import pytest
 
 import httpx
-from httpx._content_streams import AsyncIteratorStream, IteratorStream
 
 
 def streaming_body():
@@ -248,10 +247,9 @@ async def test_aread():
 
 
 def test_iter_raw():
-    stream = IteratorStream(iterator=streaming_body())
     response = httpx.Response(
         200,
-        stream=stream,
+        content=streaming_body(),
     )
 
     raw = b""
@@ -262,10 +260,9 @@ def test_iter_raw():
 
 @pytest.mark.asyncio
 async def test_aiter_raw():
-    stream = AsyncIteratorStream(aiterator=async_streaming_body())
     response = httpx.Response(
         200,
-        stream=stream,
+        content=async_streaming_body(),
     )
 
     raw = b""
@@ -350,10 +347,9 @@ async def test_aiter_lines():
 
 
 def test_sync_streaming_response():
-    stream = IteratorStream(iterator=streaming_body())
     response = httpx.Response(
         200,
-        stream=stream,
+        content=streaming_body(),
     )
 
     assert response.status_code == 200
@@ -368,10 +364,9 @@ def test_sync_streaming_response():
 
 @pytest.mark.asyncio
 async def test_async_streaming_response():
-    stream = AsyncIteratorStream(aiterator=async_streaming_body())
     response = httpx.Response(
         200,
-        stream=stream,
+        content=async_streaming_body(),
     )
 
     assert response.status_code == 200
@@ -385,10 +380,9 @@ async def test_async_streaming_response():
 
 
 def test_cannot_read_after_stream_consumed():
-    stream = IteratorStream(iterator=streaming_body())
     response = httpx.Response(
         200,
-        stream=stream,
+        content=streaming_body(),
     )
 
     content = b""
@@ -401,10 +395,9 @@ def test_cannot_read_after_stream_consumed():
 
 @pytest.mark.asyncio
 async def test_cannot_aread_after_stream_consumed():
-    stream = AsyncIteratorStream(aiterator=async_streaming_body())
     response = httpx.Response(
         200,
-        stream=stream,
+        content=async_streaming_body(),
     )
 
     content = b""
@@ -416,20 +409,13 @@ async def test_cannot_aread_after_stream_consumed():
 
 
 def test_cannot_read_after_response_closed():
-    is_closed = False
-
-    def close_func():
-        nonlocal is_closed
-        is_closed = True
-
-    stream = IteratorStream(iterator=streaming_body(), close_func=close_func)
     response = httpx.Response(
         200,
-        stream=stream,
+        content=streaming_body(),
     )
 
     response.close()
-    assert is_closed
+    assert response.is_closed
 
     with pytest.raises(httpx.ResponseClosed):
         response.read()
@@ -437,22 +423,13 @@ def test_cannot_read_after_response_closed():
 
 @pytest.mark.asyncio
 async def test_cannot_aread_after_response_closed():
-    is_closed = False
-
-    async def close_func():
-        nonlocal is_closed
-        is_closed = True
-
-    stream = AsyncIteratorStream(
-        aiterator=async_streaming_body(), close_func=close_func
-    )
     response = httpx.Response(
         200,
-        stream=stream,
+        content=async_streaming_body(),
     )
 
     await response.aclose()
-    assert is_closed
+    assert response.is_closed
 
     with pytest.raises(httpx.ResponseClosed):
         await response.aread()
@@ -460,10 +437,9 @@ async def test_cannot_aread_after_response_closed():
 
 @pytest.mark.asyncio
 async def test_elapsed_not_available_until_closed():
-    stream = AsyncIteratorStream(aiterator=async_streaming_body())
     response = httpx.Response(
         200,
-        stream=stream,
+        content=async_streaming_body(),
     )
 
     with pytest.raises(RuntimeError):

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -36,6 +36,16 @@ def test_response():
     assert not response.is_error
 
 
+def test_json_response():
+    response = httpx.Response(200, json={"Hello": "World!"})
+
+    assert response.status_code == 200
+    assert response.text == '{"Hello": "World!"}'
+    assert response.headers == httpx.Headers(
+        {"Content-Type": "application/json", "Content-Length": "19"}
+    )
+
+
 def test_raise_for_status():
     request = httpx.Request("GET", "https://example.org")
 

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -36,6 +36,26 @@ def test_response():
     assert not response.is_error
 
 
+def test_text_response():
+    response = httpx.Response(200, text="Hello, world!")
+
+    assert response.status_code == 200
+    assert response.text == "Hello, world!"
+    assert response.headers == httpx.Headers(
+        {"Content-Type": "text/plain; charset=utf-8", "Content-Length": "13"}
+    )
+
+
+def test_html_response():
+    response = httpx.Response(200, html="<html><h1>Hello, world!</h1></html>")
+
+    assert response.status_code == 200
+    assert response.text == "<html><h1>Hello, world!</h1></html>"
+    assert response.headers == httpx.Headers(
+        {"Content-Type": "text/html; charset=utf-8", "Content-Length": "35"}
+    )
+
+
 def test_json_response():
     response = httpx.Response(200, json={"Hello": "World!"})
 

--- a/tests/test_content_streams.py
+++ b/tests/test_content_streams.py
@@ -3,7 +3,7 @@ import io
 import pytest
 
 from httpx import StreamConsumed
-from httpx._content_streams import ContentStream, encode
+from httpx._content_streams import ContentStream, encode_request_body
 
 
 @pytest.mark.asyncio
@@ -20,7 +20,7 @@ async def test_base_content():
 
 @pytest.mark.asyncio
 async def test_empty_content():
-    stream = encode()
+    stream = encode_request_body()
     sync_content = b"".join([part for part in stream])
     async_content = b"".join([part async for part in stream])
 
@@ -32,7 +32,7 @@ async def test_empty_content():
 
 @pytest.mark.asyncio
 async def test_bytes_content():
-    stream = encode(data=b"Hello, world!")
+    stream = encode_request_body(data=b"Hello, world!")
     sync_content = b"".join([part for part in stream])
     async_content = b"".join([part async for part in stream])
 
@@ -48,7 +48,7 @@ async def test_iterator_content():
         yield b"Hello, "
         yield b"world!"
 
-    stream = encode(data=hello_world())
+    stream = encode_request_body(data=hello_world())
     content = b"".join([part for part in stream])
 
     assert not stream.can_replay()
@@ -68,7 +68,7 @@ async def test_aiterator_content():
         yield b"Hello, "
         yield b"world!"
 
-    stream = encode(data=hello_world())
+    stream = encode_request_body(data=hello_world())
     content = b"".join([part async for part in stream])
 
     assert not stream.can_replay()
@@ -84,7 +84,7 @@ async def test_aiterator_content():
 
 @pytest.mark.asyncio
 async def test_json_content():
-    stream = encode(json={"Hello": "world!"})
+    stream = encode_request_body(json={"Hello": "world!"})
     sync_content = b"".join([part for part in stream])
     async_content = b"".join([part async for part in stream])
 
@@ -99,7 +99,7 @@ async def test_json_content():
 
 @pytest.mark.asyncio
 async def test_urlencoded_content():
-    stream = encode(data={"Hello": "world!"})
+    stream = encode_request_body(data={"Hello": "world!"})
     sync_content = b"".join([part for part in stream])
     async_content = b"".join([part async for part in stream])
 
@@ -115,7 +115,7 @@ async def test_urlencoded_content():
 @pytest.mark.asyncio
 async def test_multipart_files_content():
     files = {"file": io.BytesIO(b"<file content>")}
-    stream = encode(files=files, boundary=b"+++")
+    stream = encode_request_body(files=files, boundary=b"+++")
     sync_content = b"".join([part for part in stream])
     async_content = b"".join([part async for part in stream])
 
@@ -150,7 +150,7 @@ async def test_multipart_files_content():
 async def test_multipart_data_and_files_content():
     data = {"message": "Hello, world!"}
     files = {"file": io.BytesIO(b"<file content>")}
-    stream = encode(data=data, files=files, boundary=b"+++")
+    stream = encode_request_body(data=data, files=files, boundary=b"+++")
     sync_content = b"".join([part for part in stream])
     async_content = b"".join([part async for part in stream])
 
@@ -191,7 +191,7 @@ async def test_multipart_data_and_files_content():
 
 @pytest.mark.asyncio
 async def test_empty_request():
-    stream = encode(data={}, files={})
+    stream = encode_request_body(data={}, files={})
     sync_content = b"".join([part for part in stream])
     async_content = b"".join([part async for part in stream])
 
@@ -203,7 +203,7 @@ async def test_empty_request():
 
 def test_invalid_argument():
     with pytest.raises(TypeError):
-        encode(123)  # type: ignore
+        encode_request_body(123)  # type: ignore
 
 
 @pytest.mark.asyncio
@@ -212,7 +212,7 @@ async def test_multipart_multiple_files_single_input_content():
         ("file", io.BytesIO(b"<file content 1>")),
         ("file", io.BytesIO(b"<file content 2>")),
     ]
-    stream = encode(files=files, boundary=b"+++")
+    stream = encode_request_body(files=files, boundary=b"+++")
     sync_content = b"".join([part for part in stream])
     async_content = b"".join([part async for part in stream])
 

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -4,7 +4,6 @@ import brotli
 import pytest
 
 import httpx
-from httpx._content_streams import AsyncIteratorStream
 from httpx._decoders import (
     BrotliDecoder,
     DeflateDecoder,
@@ -130,11 +129,10 @@ async def test_streaming():
         yield compressor.flush()
 
     headers = [(b"Content-Encoding", b"gzip")]
-    stream = AsyncIteratorStream(aiterator=compress(body))
     response = httpx.Response(
         200,
         headers=headers,
-        stream=stream,
+        content=compress(body),
     )
     assert not hasattr(response, "body")
     assert await response.aread() == body
@@ -199,19 +197,17 @@ async def test_text_decoder(data, encoding):
             yield chunk
 
     # Accessing `.text` on a read response.
-    stream = AsyncIteratorStream(aiterator=iterator())
     response = httpx.Response(
         200,
-        stream=stream,
+        content=iterator(),
     )
     await response.aread()
     assert response.text == (b"".join(data)).decode(encoding)
 
     # Streaming `.aiter_text` iteratively.
-    stream = AsyncIteratorStream(aiterator=iterator())
     response = httpx.Response(
         200,
-        stream=stream,
+        content=iterator(),
     )
     text = "".join([part async for part in response.aiter_text()])
     assert text == (b"".join(data)).decode(encoding)
@@ -224,11 +220,10 @@ async def test_text_decoder_known_encoding():
         yield b"\x83"
         yield b"\x89\x83x\x83\x8b"
 
-    stream = AsyncIteratorStream(aiterator=iterator())
     response = httpx.Response(
         200,
         headers=[(b"Content-Type", b"text/html; charset=shift-jis")],
-        stream=stream,
+        content=iterator(),
     )
 
     await response.aread()

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -8,7 +8,7 @@ import httpcore
 import pytest
 
 import httpx
-from httpx._content_streams import MultipartStream, encode
+from httpx._content_streams import MultipartStream, encode_request_body
 from httpx._utils import format_form_param
 
 
@@ -126,7 +126,7 @@ def test_multipart_encode(tmp_path: typing.Any) -> None:
     with mock.patch("os.urandom", return_value=os.urandom(16)):
         boundary = os.urandom(16).hex()
 
-        stream = encode(data=data, files=files)
+        stream = encode_request_body(data=data, files=files)
         assert isinstance(stream, MultipartStream)
         assert stream.can_replay()
 
@@ -153,7 +153,7 @@ def test_multipart_encode_files_allows_filenames_as_none() -> None:
     with mock.patch("os.urandom", return_value=os.urandom(16)):
         boundary = os.urandom(16).hex()
 
-        stream = encode(data={}, files=files)
+        stream = encode_request_body(data={}, files=files)
         assert isinstance(stream, MultipartStream)
         assert stream.can_replay()
 
@@ -180,7 +180,7 @@ def test_multipart_encode_files_guesses_correct_content_type(
     with mock.patch("os.urandom", return_value=os.urandom(16)):
         boundary = os.urandom(16).hex()
 
-        stream = encode(data={}, files=files)
+        stream = encode_request_body(data={}, files=files)
         assert isinstance(stream, MultipartStream)
         assert stream.can_replay()
 
@@ -204,7 +204,7 @@ def test_multipart_encode_files_allows_bytes_or_str_content(
     with mock.patch("os.urandom", return_value=os.urandom(16)):
         boundary = os.urandom(16).hex()
 
-        stream = encode(data={}, files=files)
+        stream = encode_request_body(data={}, files=files)
         assert isinstance(stream, MultipartStream)
         assert stream.can_replay()
 
@@ -242,7 +242,7 @@ def test_multipart_encode_non_seekable_filelike() -> None:
 
     fileobj: typing.Any = IteratorIO(data())
     files = {"file": fileobj}
-    stream = encode(files=files, boundary=b"+++")
+    stream = encode_request_body(files=files, boundary=b"+++")
     assert not stream.can_replay()
 
     content = (


### PR DESCRIPTION
Closes #1227

Adds support for eg...

* `httpx.Response(200, content=b'Hello, world')`
* `httpx.Response(200, text='Hello, world')`
* `httpx.Response(200, html='Hello, world')`
* `httpx.Response(200, json={'Hello': 'world'})`

Plus streaming cases...

* `httpx.Response(200, content=<byte iterator>)`
* `httpx.Response(200, content=<byte aiterator>)`

There are some test cases we'd be able to smarten up after this, but I'll leave that for a follow up.