### PR TITLE
Swap auth/redirects ordering

### DIFF
--- a/tests/client/test_redirects.py
+++ b/tests/client/test_redirects.py
@@ -323,11 +323,19 @@ def test_redirect_loop():
         client.get("https://example.org/redirect_loop")
 
 
-def test_cross_domain_redirect():
+def test_cross_domain_redirect_with_auth_header():
     client = httpx.Client(transport=SyncMockTransport())
     url = "https://example.com/cross_domain"
     headers = {"Authorization": "abc"}
     response = client.get(url, headers=headers)
+    assert response.url == "https://example.org/cross_domain_target"
+    assert "authorization" not in response.json()["headers"]
+
+
+def test_cross_domain_redirect_with_auth():
+    client = httpx.Client(transport=SyncMockTransport())
+    url = "https://example.com/cross_domain"
+    response = client.get(url, auth=("user", "pass"))
     assert response.url == "https://example.org/cross_domain_target"
     assert "authorization" not in response.json()["headers"]
 


### PR DESCRIPTION
Internal refactoring to swap the order in which we handle auth/redirects.

Needed because `request` event hooks ought to be triggered after any initial authentication is applied to the request, but should not re-occur after redirects.

The flow also just generally makes more sense to be now:

Create the request -> Apply any authentication -> Follow any redirects -> Send the request to the network

For the sake of reviews I haven't re-ordered the methods, but I'll issue a follow-up PR to this which will swap them around so that the code ordering follows the execution flow.