### PR TITLE
Add progress to streaming download

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -236,10 +236,7 @@ from tqdm import tqdm
 with tempfile.NamedTemporaryFile() as download_file:
     url = "https://speed.hetzner.de/100MB.bin"
     with httpx.stream("GET", url) as response:
-        if "Content-Length" in response.headers:
-            total = int(response.headers["Content-Length"])
-        else:
-            total = None
+        total = int(response.headers["Content-Length"])
 
         with tqdm(total=total, unit_scale=True, unit_divisor=1024, unit="B") as progress:
             num_bytes_downloaded = response.num_bytes_downloaded

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -223,7 +223,7 @@ with httpx.Client(headers=headers) as client:
 
 ## Monitoring download progress
 
-If you need to monitor download progress of large responses, you can use stream and the `response.last_raw_chunk_size` property.
+If you need to monitor download progress of large responses, you can use stream and the `response.num_bytes_downloaded` property.
 
 For example, showing a progress bar using the [`tqdm`](https://github.com/tqdm/tqdm) library while a response is being downloaded could be done like this…
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -223,7 +223,7 @@ with httpx.Client(headers=headers) as client:
 
 ## Monitoring download progress
 
-If you need to monitor download progress of large responses, you can use stream and the `response.num_bytes_downloaded` property.
+If you need to monitor download progress of large responses, you can use response streaming and inspect the `response.num_bytes_downloaded` property.
 
 For example, showing a progress bar using the [`tqdm`](https://github.com/tqdm/tqdm) library while a response is being downloaded could be done like this…
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -221,6 +221,28 @@ with httpx.Client(headers=headers) as client:
     ...
 ```
 
+## Monitoring download progress
+
+If you need to monitor download progress, you can stream with using `response.last_raw_chunk_size` property.
+
+For example, you can build a nice progress bar using the `tqdm` library:
+
+```python
+import tempfile
+
+import httpx
+from tqdm import tqdm
+
+with tempfile.NamedTemporaryFile() as download_file:
+    data = b"@" * 1000000
+    with httpx.stream("POST", "https://httpbin.org/anything", data=data) as response:
+        content_length = int(response.headers["Content-Length"])
+        with tqdm(total=content_length) as progress:
+            for chunk in response.iter_bytes():
+                download_file.write(chunk)
+                progress.update(response.last_raw_chunk_size)
+```
+
 ## .netrc Support
 
 HTTPX supports .netrc file. In `trust_env=True` cases, if auth parameter is

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -225,6 +225,8 @@ with httpx.Client(headers=headers) as client:
 
 If you need to monitor download progress of large responses, you can use response streaming and inspect the `response.num_bytes_downloaded` property.
 
+This interface is required for properly determining download progress, because the total number of bytes returned by `response.content` or `response.iter_content()` will not always correspond with the raw content length of the response if HTTP response compression is being used.
+
 For example, showing a progress bar using the [`tqdm`](https://github.com/tqdm/tqdm) library while a response is being downloaded could be done like this…
 
 ```python

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -223,9 +223,9 @@ with httpx.Client(headers=headers) as client:
 
 ## Monitoring download progress
 
-If you need to monitor download progress, you can stream with using `response.last_raw_chunk_size` property.
+If you need to monitor download progress of large responses, you can use stream and the `response.last_raw_chunk_size` property.
 
-For example, you can build a nice progress bar using the `tqdm` library:
+For example, showing a progress bar using the [`tqdm`](https://github.com/tqdm/tqdm) library while a response is being downloaded could be done like this…
 
 ```python
 import tempfile

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -697,7 +697,7 @@ class Response:
             self._raw_stream = ByteStream(body=content or b"")
             self.read()
 
-        self._last_raw_chunk_size = 0
+        self._num_bytes_downloaded = 0
 
     @property
     def elapsed(self) -> datetime.timedelta:
@@ -888,8 +888,8 @@ class Response:
         return ldict
 
     @property
-    def last_raw_chunk_size(self) -> int:
-        return self._last_raw_chunk_size
+    def num_bytes_downloaded(self) -> int:
+        return self._num_bytes_downloaded
 
     def __repr__(self) -> str:
         return f"<Response [{self.status_code} {self.reason_phrase}]>"
@@ -957,10 +957,10 @@ class Response:
             raise ResponseClosed()
 
         self.is_stream_consumed = True
-        self._last_raw_chunk_size = 0
+        self._num_bytes_downloaded = 0
         with map_exceptions(HTTPCORE_EXC_MAP, request=self._request):
             for part in self._raw_stream:
-                self._last_raw_chunk_size = len(part)
+                self._num_bytes_downloaded += len(part)
                 yield part
         self.close()
 
@@ -1040,10 +1040,10 @@ class Response:
             raise ResponseClosed()
 
         self.is_stream_consumed = True
-        self._last_raw_chunk_size = 0
+        self._num_bytes_downloaded = 0
         with map_exceptions(HTTPCORE_EXC_MAP, request=self._request):
             async for part in self._raw_stream:
-                self._last_raw_chunk_size = len(part)
+                self._num_bytes_downloaded += len(part)
                 yield part
         await self.aclose()
 

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -235,8 +235,10 @@ def test_iter_raw_increments_updates_counter():
         stream=stream,
     )
 
+    num_downloaded = response.num_bytes_downloaded
     for part in response.iter_raw():
-        assert len(part) == response.last_raw_chunk_size
+        assert len(part) == (response.num_bytes_downloaded - num_downloaded)
+        num_downloaded = response.num_bytes_downloaded
 
 
 @pytest.mark.asyncio
@@ -262,8 +264,10 @@ async def test_aiter_raw_increments_updates_counter():
         stream=stream,
     )
 
+    num_downloaded = response.num_bytes_downloaded
     async for part in response.aiter_raw():
-        assert len(part) == response.last_raw_chunk_size
+        assert len(part) == (response.num_bytes_downloaded - num_downloaded)
+        num_downloaded = response.num_bytes_downloaded
 
 
 def test_iter_bytes():

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -227,6 +227,18 @@ def test_iter_raw():
     assert raw == b"Hello, world!"
 
 
+def test_iter_raw_increments_updates_counter():
+    stream = IteratorStream(iterator=streaming_body())
+
+    response = httpx.Response(
+        200,
+        stream=stream,
+    )
+
+    for part in response.iter_raw():
+        assert len(part) == response.last_raw_chunk_size
+
+
 @pytest.mark.asyncio
 async def test_aiter_raw():
     stream = AsyncIteratorStream(aiterator=async_streaming_body())
@@ -239,6 +251,19 @@ async def test_aiter_raw():
     async for part in response.aiter_raw():
         raw += part
     assert raw == b"Hello, world!"
+
+
+@pytest.mark.asyncio
+async def test_aiter_raw_increments_updates_counter():
+    stream = AsyncIteratorStream(aiterator=async_streaming_body())
+
+    response = httpx.Response(
+        200,
+        stream=stream,
+    )
+
+    async for part in response.aiter_raw():
+        assert len(part) == response.last_raw_chunk_size
 
 
 def test_iter_bytes():


### PR DESCRIPTION
Having found #1208, I tried to track last downloaded raw chunk of the response.

The question is:
1. should we also track decoded response chunks? I don't see any reason since decoded stream length might be vary from the raw stream length, and it has no bearing with downloading process (but may be I missed something)
