### PR TITLE
Added chunk_size to Response.iter_bytes() and Response.aiter_bytes() (#394)

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -47,6 +47,8 @@ from ._types import (
     URLTypes,
 )
 from ._utils import (
+    async_drain_by_chunks,
+    drain_by_chunks,
     flatten_queryparams,
     guess_json_utf,
     is_known_encoding,
@@ -913,11 +915,14 @@ class Response:
             self._content = b"".join(self.iter_bytes())
         return self._content
 
-    def iter_bytes(self) -> typing.Iterator[bytes]:
+    def iter_bytes(self, chunk_size: int = 512) -> typing.Iterator[bytes]:
         """
         A byte-iterator over the decoded response content.
         This allows us to handle gzip, deflate, and brotli encoded responses.
         """
+        yield from drain_by_chunks(self.__iter_bytes(), chunk_size)
+
+    def __iter_bytes(self) -> typing.Iterator[bytes]:
         if hasattr(self, "_content"):
             yield self._content
         else:
@@ -996,11 +1001,15 @@ class Response:
             self._content = b"".join([part async for part in self.aiter_bytes()])
         return self._content
 
-    async def aiter_bytes(self) -> typing.AsyncIterator[bytes]:
+    async def aiter_bytes(self, chunk_size: int = 512) -> typing.AsyncIterator[bytes]:
         """
         A byte-iterator over the decoded response content.
         This allows us to handle gzip, deflate, and brotli encoded responses.
         """
+        async for chunk in async_drain_by_chunks(self.__aiter_bytes(), chunk_size):
+            yield chunk
+
+    async def __aiter_bytes(self) -> typing.AsyncIterator[bytes]:
         if hasattr(self, "_content"):
             yield self._content
         else:

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -270,27 +270,29 @@ async def test_aiter_raw_increments_updates_counter():
         num_downloaded = response.num_bytes_downloaded
 
 
-def test_iter_bytes():
+@pytest.mark.parametrize("chunk_size", [2, 20, None])
+def test_iter_bytes(chunk_size):
     response = httpx.Response(
         200,
         content=b"Hello, world!",
     )
 
     content = b""
-    for part in response.iter_bytes():
+    for part in response.iter_bytes(chunk_size):
         content += part
     assert content == b"Hello, world!"
 
 
 @pytest.mark.asyncio
-async def test_aiter_bytes():
+@pytest.mark.parametrize("chunk_size", [2, 20, None])
+async def test_aiter_bytes(chunk_size):
     response = httpx.Response(
         200,
         content=b"Hello, world!",
     )
 
     content = b""
-    async for part in response.aiter_bytes():
+    async for part in response.aiter_bytes(chunk_size):
         content += part
     assert content == b"Hello, world!"
 


### PR DESCRIPTION
Working on #394 , I added the `chunk_size` argument  to `Response.iter_bytes()` and `Response.aiter_bytes()` wrapping these iterators by `drain_by_chunks()` and `async_drain_by_chunks()` (I didn't use decorators to make debugging easier). The same way might be applied to  `(a)iter_text`

But I still don't know what the expected behaviour of `(a)iter_line` and `(a)iter_raw` (so therefore I omit them in the PR)

For now the code might look like:
```python
>>> import httpx
>>> response = httpx.Response(200, content=b"1234567890")
>>> for it in response.iter_bytes(3):
>>>    print(it.decode())
123
456
789
0
>>> # it's done for requests compatibility: 
>>> # https://github.com/encode/httpx/issues/394#issuecomment-598820965
>>> for it in response.iter_bytes(None):
>>>     print(it.decode())
1234567890
```