### PR TITLE
Made Request.prepare private (i.e. renamed it to _prepare)

### DIFF
--- a/httpx/_auth.py
+++ b/httpx/_auth.py
@@ -224,7 +224,7 @@ class DigestAuth(Auth):
 
         A1 = b":".join((self._username, challenge.realm, self._password))
 
-        path = request.url.full_path.encode("utf-8")
+        path = request.url.raw_path
         A2 = b":".join((request.method.encode(), path))
         # TODO: implement auth-int
         HA2 = digest(A2)

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -606,9 +606,9 @@ class Request:
         else:
             self.stream = encode(data, files, json)
 
-        self.prepare()
+        self._prepare()
 
-    def prepare(self) -> None:
+    def _prepare(self) -> None:
         for key, value in self.stream.get_headers().items():
             # Ignore Transfer-Encoding if the Content-Length has been set explicitly.
             if key.lower() == "transfer-encoding" and "content-length" in self.headers:

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -242,7 +242,8 @@ class QueryParams(typing.Mapping[str, str]):
         value = args[0] if args else kwargs
 
         items: typing.Sequence[typing.Tuple[str, PrimitiveData]]
-        if value is None or isinstance(value, str):
+        if value is None or isinstance(value, (str, bytes)):
+            value = value.decode("ascii") if isinstance(value, bytes) else value
             items = parse_qsl(value)
         elif isinstance(value, QueryParams):
             items = value.multi_items()

--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -34,6 +34,7 @@ QueryParamTypes = Union[
     Mapping[str, Union[PrimitiveData, Sequence[PrimitiveData]]],
     List[Tuple[str, PrimitiveData]],
     str,
+    bytes,
     None,
 ]
 

--- a/tests/models/test_requests.py
+++ b/tests/models/test_requests.py
@@ -132,10 +132,10 @@ def test_url():
     request = httpx.Request("GET", url)
     assert request.url.scheme == "http"
     assert request.url.port is None
-    assert request.url.full_path == "/"
+    assert request.url.raw_path == b"/"
 
     url = "https://example.org/abc?foo=bar"
     request = httpx.Request("GET", url)
     assert request.url.scheme == "https"
     assert request.url.port is None
-    assert request.url.full_path == "/abc?foo=bar"
+    assert request.url.raw_path == b"/abc?foo=bar"

--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -67,7 +67,7 @@ def test_url():
     assert url.port == 123
     assert url.authority == "example.org:123"
     assert url.path == "/path/to/somewhere"
-    assert url.query == "abc=123"
+    assert url.query == b"abc=123"
     assert url.fragment == "anchor"
     assert (
         repr(url) == "URL('https://example.org:123/path/to/somewhere?abc=123#anchor')"


### PR DESCRIPTION
I created a PR regarding to https://github.com/encode/httpx/issues/1275

I renamed `Request.prepare` to `_prepare` making this method private

