### PR TITLE
Silence PIE786 in some cases

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -763,7 +763,7 @@ class Client(BaseClient):
                 next_request = auth_flow.send(response)
             except StopIteration:
                 return response
-            except BaseException as exc:
+            except Exception as exc:
                 response.close()
                 raise exc from None
             else:
@@ -1386,7 +1386,7 @@ class AsyncClient(BaseClient):
                 next_request = await auth_flow.asend(response)
             except StopAsyncIteration:
                 return response
-            except BaseException as exc:
+            except Exception as exc:
                 await response.aclose()
                 raise exc from None
             else:

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -763,7 +763,7 @@ class Client(BaseClient):
                 next_request = auth_flow.send(response)
             except StopIteration:
                 return response
-            except Exception as exc:
+            except Exception as exc:  # noqa: PIE786
                 response.close()
                 raise exc from None
             else:
@@ -1386,7 +1386,7 @@ class AsyncClient(BaseClient):
                 next_request = await auth_flow.asend(response)
             except StopAsyncIteration:
                 return response
-            except Exception as exc:
+            except Exception as exc:  # noqa: PIE786
                 await response.aclose()
                 raise exc from None
             else:

--- a/httpx/_exceptions.py
+++ b/httpx/_exceptions.py
@@ -340,7 +340,7 @@ def map_exceptions(
 ) -> typing.Iterator[None]:
     try:
         yield
-    except Exception as exc:
+    except Exception as exc:  # noqa: PIE786
         mapped_exc = None
 
         for from_exc, to_exc in mapping.items():

--- a/httpx/_transports/asgi.py
+++ b/httpx/_transports/asgi.py
@@ -145,7 +145,7 @@ class ASGITransport(httpcore.AsyncHTTPTransport):
 
         try:
             await self.app(scope, receive, send)
-        except Exception:
+        except Exception:  # noqa: PIE786
             if self.raise_app_exceptions or not response_complete.is_set():
                 raise
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-ignore = W503, E203, B305, PIE786
+ignore = W503, E203, B305
 max-line-length = 88
 
 [mypy]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-ignore = W503, E203, B305
+ignore = W503, E203, B305, PIE786
 max-line-length = 88
 
 [mypy]


### PR DESCRIPTION
I've got a problem in my pr: [build link](https://github.com/encode/httpx/pull/1280/checks?check_run_id=1102709981)

The problem (PIE786) caused by some too broad exception handlers (as flake thinks). I suppressed the error

I think that error caused by `flake8-pie` [released today](https://pypi.org/project/flake8-pie/#history) :-)