### PR TITLE
Refactoring of models api

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -606,9 +606,9 @@ class Request:
         else:
             self.stream = encode(data, files, json)
 
-        self.prepare()
+        self._prepare()
 
-    def prepare(self) -> None:
+    def _prepare(self) -> None:
         for key, value in self.stream.get_headers().items():
             # Ignore Transfer-Encoding if the Content-Length has been set explicitly.
             if key.lower() == "transfer-encoding" and "content-length" in self.headers:

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -242,7 +242,8 @@ class QueryParams(typing.Mapping[str, str]):
         value = args[0] if args else kwargs
 
         items: typing.Sequence[typing.Tuple[str, PrimitiveData]]
-        if value is None or isinstance(value, str):
+        if value is None or isinstance(value, (str, bytes)):
+            value = value.decode("ascii") if isinstance(value, bytes) else value
             items = parse_qsl(value)
         elif isinstance(value, QueryParams):
             items = value.multi_items()

--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -34,6 +34,7 @@ QueryParamTypes = Union[
     Mapping[str, Union[PrimitiveData, Sequence[PrimitiveData]]],
     List[Tuple[str, PrimitiveData]],
     str,
+    bytes,
     None,
 ]
 


### PR DESCRIPTION
Having working on https://github.com/encode/httpx/issues/1275 in https://github.com/encode/httpx/pull/1280, I've got a reasonable comment (from @StephenBrown2) that the PR could be split into several one to reduce problems with review.

In this PR I:
1. made `Request.prepare` private
1. Changed `QueryParamTypes` so that `QueryParams` accepts `bytes` 
  