### PR TITLE
Refactoring of models api - 2

### DIFF
--- a/httpx/_auth.py
+++ b/httpx/_auth.py
@@ -224,7 +224,7 @@ class DigestAuth(Auth):
 
         A1 = b":".join((self._username, challenge.realm, self._password))
 
-        path = request.url.full_path.encode("utf-8")
+        path = request.url.raw_path
         A2 = b":".join((request.method.encode(), path))
         # TODO: implement auth-int
         HA2 = digest(A2)

--- a/tests/models/test_requests.py
+++ b/tests/models/test_requests.py
@@ -132,10 +132,10 @@ def test_url():
     request = httpx.Request("GET", url)
     assert request.url.scheme == "http"
     assert request.url.port is None
-    assert request.url.full_path == "/"
+    assert request.url.raw_path == b"/"
 
     url = "https://example.org/abc?foo=bar"
     request = httpx.Request("GET", url)
     assert request.url.scheme == "https"
     assert request.url.port is None
-    assert request.url.full_path == "/abc?foo=bar"
+    assert request.url.raw_path == b"/abc?foo=bar"

--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -67,7 +67,7 @@ def test_url():
     assert url.port == 123
     assert url.authority == "example.org:123"
     assert url.path == "/path/to/somewhere"
-    assert url.query == "abc=123"
+    assert url.query == b"abc=123"
     assert url.fragment == "anchor"
     assert (
         repr(url) == "URL('https://example.org:123/path/to/somewhere?abc=123#anchor')"


### PR DESCRIPTION
The second part of https://github.com/encode/httpx/issues/1275 changes (previous was [merged](https://github.com/encode/httpx/pull/1284))
What was done:
- Renamed `URL.full_path` to `.raw_path` (now its returns no-unquoted bytes)
- Made `URL.userinfo` return bytes instead of str
- Made `URL.query` return bytes instead of str