### PR TITLE
Fix function name in event hooks docs

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -265,7 +265,7 @@ the installed hooks.
 ```python
 client = httpx.Client()
 client.event_hooks['request'] = [log_request]
-client.event_hooks['response'] = [log_response, raise_for_status]
+client.event_hooks['response'] = [log_response, raise_on_4xx_5xx]
 ```
 
 !!! note


### PR DESCRIPTION
Noticed that there was a copy-pasta in the docs for #1246