### PR TITLE
Refactor `encode` -> `encode_request`

### DIFF
--- a/httpx/_content_streams.py
+++ b/httpx/_content_streams.py
@@ -363,7 +363,7 @@ class MultipartStream(ContentStream):
             yield chunk
 
 
-def encode(
+def encode_request(
     content: RequestContent = None,
     data: RequestData = None,
     files: RequestFiles = None,

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -13,7 +13,7 @@ from urllib.parse import parse_qsl, quote, unquote, urlencode
 import rfc3986
 import rfc3986.exceptions
 
-from ._content_streams import ByteStream, ContentStream, encode, encode_response
+from ._content_streams import ByteStream, ContentStream, encode_request, encode_response
 from ._decoders import (
     SUPPORTED_DECODERS,
     ContentDecoder,
@@ -606,7 +606,7 @@ class Request:
         if stream is not None:
             self.stream = stream
         else:
-            self.stream = encode(content, data, files, json)
+            self.stream = encode_request(content, data, files, json)
 
         self._prepare()
 

--- a/tests/test_content_streams.py
+++ b/tests/test_content_streams.py
@@ -3,7 +3,7 @@ import io
 import pytest
 
 from httpx import StreamConsumed
-from httpx._content_streams import ContentStream, encode, encode_response
+from httpx._content_streams import ContentStream, encode_request, encode_response
 
 
 @pytest.mark.asyncio
@@ -20,7 +20,7 @@ async def test_base_content():
 
 @pytest.mark.asyncio
 async def test_empty_content():
-    stream = encode()
+    stream = encode_request()
     sync_content = b"".join([part for part in stream])
     async_content = b"".join([part async for part in stream])
 
@@ -32,7 +32,7 @@ async def test_empty_content():
 
 @pytest.mark.asyncio
 async def test_bytes_content():
-    stream = encode(content=b"Hello, world!")
+    stream = encode_request(content=b"Hello, world!")
     sync_content = b"".join([part for part in stream])
     async_content = b"".join([part async for part in stream])
 
@@ -42,7 +42,7 @@ async def test_bytes_content():
     assert async_content == b"Hello, world!"
 
     # Support 'data' for compat with requests.
-    stream = encode(data=b"Hello, world!")  # type: ignore
+    stream = encode_request(data=b"Hello, world!")  # type: ignore
     sync_content = b"".join([part for part in stream])
     async_content = b"".join([part async for part in stream])
 
@@ -58,7 +58,7 @@ async def test_iterator_content():
         yield b"Hello, "
         yield b"world!"
 
-    stream = encode(content=hello_world())
+    stream = encode_request(content=hello_world())
     content = b"".join([part for part in stream])
 
     assert not stream.can_replay()
@@ -72,7 +72,7 @@ async def test_iterator_content():
         [part for part in stream]
 
     # Support 'data' for compat with requests.
-    stream = encode(data=hello_world())  # type: ignore
+    stream = encode_request(data=hello_world())  # type: ignore
     content = b"".join([part for part in stream])
 
     assert not stream.can_replay()
@@ -86,7 +86,7 @@ async def test_aiterator_content():
         yield b"Hello, "
         yield b"world!"
 
-    stream = encode(content=hello_world())
+    stream = encode_request(content=hello_world())
     content = b"".join([part async for part in stream])
 
     assert not stream.can_replay()
@@ -100,7 +100,7 @@ async def test_aiterator_content():
         [part async for part in stream]
 
     # Support 'data' for compat with requests.
-    stream = encode(data=hello_world())  # type: ignore
+    stream = encode_request(data=hello_world())  # type: ignore
     content = b"".join([part async for part in stream])
 
     assert not stream.can_replay()
@@ -110,7 +110,7 @@ async def test_aiterator_content():
 
 @pytest.mark.asyncio
 async def test_json_content():
-    stream = encode(json={"Hello": "world!"})
+    stream = encode_request(json={"Hello": "world!"})
     sync_content = b"".join([part for part in stream])
     async_content = b"".join([part async for part in stream])
 
@@ -125,7 +125,7 @@ async def test_json_content():
 
 @pytest.mark.asyncio
 async def test_urlencoded_content():
-    stream = encode(data={"Hello": "world!"})
+    stream = encode_request(data={"Hello": "world!"})
     sync_content = b"".join([part for part in stream])
     async_content = b"".join([part async for part in stream])
 
@@ -141,7 +141,7 @@ async def test_urlencoded_content():
 @pytest.mark.asyncio
 async def test_multipart_files_content():
     files = {"file": io.BytesIO(b"<file content>")}
-    stream = encode(files=files, boundary=b"+++")
+    stream = encode_request(files=files, boundary=b"+++")
     sync_content = b"".join([part for part in stream])
     async_content = b"".join([part async for part in stream])
 
@@ -176,7 +176,7 @@ async def test_multipart_files_content():
 async def test_multipart_data_and_files_content():
     data = {"message": "Hello, world!"}
     files = {"file": io.BytesIO(b"<file content>")}
-    stream = encode(data=data, files=files, boundary=b"+++")
+    stream = encode_request(data=data, files=files, boundary=b"+++")
     sync_content = b"".join([part for part in stream])
     async_content = b"".join([part async for part in stream])
 
@@ -217,7 +217,7 @@ async def test_multipart_data_and_files_content():
 
 @pytest.mark.asyncio
 async def test_empty_request():
-    stream = encode(data={}, files={})
+    stream = encode_request(data={}, files={})
     sync_content = b"".join([part for part in stream])
     async_content = b"".join([part async for part in stream])
 
@@ -229,7 +229,7 @@ async def test_empty_request():
 
 def test_invalid_argument():
     with pytest.raises(TypeError):
-        encode(123)  # type: ignore
+        encode_request(123)  # type: ignore
 
 
 @pytest.mark.asyncio
@@ -238,7 +238,7 @@ async def test_multipart_multiple_files_single_input_content():
         ("file", io.BytesIO(b"<file content 1>")),
         ("file", io.BytesIO(b"<file content 2>")),
     ]
-    stream = encode(files=files, boundary=b"+++")
+    stream = encode_request(files=files, boundary=b"+++")
     sync_content = b"".join([part for part in stream])
     async_content = b"".join([part async for part in stream])
 

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -7,7 +7,7 @@ from unittest import mock
 import pytest
 
 import httpx
-from httpx._content_streams import MultipartStream, encode
+from httpx._content_streams import MultipartStream, encode_request
 from httpx._utils import format_form_param
 from tests.utils import MockTransport
 
@@ -110,7 +110,7 @@ def test_multipart_encode(tmp_path: typing.Any) -> None:
     with mock.patch("os.urandom", return_value=os.urandom(16)):
         boundary = os.urandom(16).hex()
 
-        stream = encode(data=data, files=files)
+        stream = encode_request(data=data, files=files)
         assert isinstance(stream, MultipartStream)
         assert stream.can_replay()
 
@@ -137,7 +137,7 @@ def test_multipart_encode_files_allows_filenames_as_none() -> None:
     with mock.patch("os.urandom", return_value=os.urandom(16)):
         boundary = os.urandom(16).hex()
 
-        stream = encode(data={}, files=files)
+        stream = encode_request(data={}, files=files)
         assert isinstance(stream, MultipartStream)
         assert stream.can_replay()
 
@@ -164,7 +164,7 @@ def test_multipart_encode_files_guesses_correct_content_type(
     with mock.patch("os.urandom", return_value=os.urandom(16)):
         boundary = os.urandom(16).hex()
 
-        stream = encode(data={}, files=files)
+        stream = encode_request(data={}, files=files)
         assert isinstance(stream, MultipartStream)
         assert stream.can_replay()
 
@@ -188,7 +188,7 @@ def test_multipart_encode_files_allows_bytes_or_str_content(
     with mock.patch("os.urandom", return_value=os.urandom(16)):
         boundary = os.urandom(16).hex()
 
-        stream = encode(data={}, files=files)
+        stream = encode_request(data={}, files=files)
         assert isinstance(stream, MultipartStream)
         assert stream.can_replay()
 
@@ -226,7 +226,7 @@ def test_multipart_encode_non_seekable_filelike() -> None:
 
     fileobj: typing.Any = IteratorIO(data())
     files = {"file": fileobj}
-    stream = encode(files=files, boundary=b"+++")
+    stream = encode_request(files=files, boundary=b"+++")
     assert not stream.can_replay()
 
     content = (


### PR DESCRIPTION
Now that we have an `encode_response` function, it makes sense for `encode` to be `encode_request`.