### PR TITLE
NetRC lookups should use host, not host+port

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -382,7 +382,7 @@ class BaseClient:
             return BasicAuth(username=username, password=password)
 
         if self.trust_env and "Authorization" not in request.headers:
-            credentials = self._netrc.get_credentials(request.url.authority)
+            credentials = self._netrc.get_credentials(request.url.host)
             if credentials is not None:
                 return BasicAuth(username=credentials[0], password=credentials[1])
 

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -147,13 +147,11 @@ class NetRCInfo:
                     pass
         return self._netrc_info
 
-    def get_credentials(
-        self, authority: str
-    ) -> typing.Optional[typing.Tuple[str, str]]:
+    def get_credentials(self, host: str) -> typing.Optional[typing.Tuple[str, str]]:
         if self.netrc_info is None:
             return None
 
-        auth_info = self.netrc_info.authenticators(authority)
+        auth_info = self.netrc_info.authenticators(host)
         if auth_info is None or auth_info[2] is None:
             return None
         return (auth_info[0], auth_info[2])


### PR DESCRIPTION
For instance, see requests... https://github.com/psf/requests/blob/967a05bfffcb68f97296eda197b062221c2ebc0d/requests/utils.py#L196