### PR TITLE
Neater `Host` header logic on redirects

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -464,7 +464,10 @@ class BaseClient:
             # Strip Authorization headers when responses are redirected away from
             # the origin.
             headers.pop("Authorization", None)
-            headers["Host"] = url.authority
+
+            # Remove the Host header, so that a new one with be auto-populated on
+            # the request instance.
+            headers.pop("Host", None)
 
         if method != request.method and method == "GET":
             # If we've switch to a 'GET' request, then strip any headers which


### PR DESCRIPTION
Instead of re-populating the `Host` header in the client on redirects away from the origin, we instead just remove it.

This is neater since the header will be re-populated by the `Request` instance, so we've only got one place where we need logic around populating it correctly.