### PR TITLE
Resolve typo in code comment

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -465,7 +465,7 @@ class BaseClient:
             # the origin.
             headers.pop("Authorization", None)
 
-            # Remove the Host header, so that a new one with be auto-populated on
+            # Remove the Host header, so that a new one will be auto-populated on
             # the request instance.
             headers.pop("Host", None)
 


### PR DESCRIPTION
"Remove the Host header, so that a new one **with be** auto-populated" -> "Remove the Host header, so that a new one **will be** auto-populated"