### PR TITLE
Version 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.15.1 (September 23nd, 2020)
+
+### Fixed
+
+* ASGITransport now properly applies URL decoding to the `path` component, as-per the ASGI spec. (Pull #1307)
+
 ## 0.15.0 (September 22nd, 2020)
 
 ### Added

--- a/httpx/__version__.py
+++ b/httpx/__version__.py
@@ -1,3 +1,3 @@
 __title__ = "httpx"
 __description__ = "A next generation HTTP client, for Python 3."
-__version__ = "0.15.0"
+__version__ = "0.15.1"


### PR DESCRIPTION
## 0.15.1 (September 23nd, 2020)

### Fixed

* ASGITransport now properly applies URL decoding to the `path` component, as-per the ASGI spec. (Pull #1307)