### PR TITLE
update arg name to `max_keepalive_connections`

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -669,7 +669,7 @@ allow. (Defaults 10)
 
 
 ```python
-limits = httpx.Limits(max_keepalive=5, max_connections=10)
+limits = httpx.Limits(max_keepalive_connections=5, max_connections=10)
 client = httpx.Client(limits=limits)
 ```
 


### PR DESCRIPTION
The old name `max_keepalive` was removed recently, so this updates the docs.