### PR TITLE
Version 0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.15.2 (September 23nd, 2020)
+
+### Fixed
+
+* Fixed `response.elapsed` property. (Pull #1313)
+* Fixed client authentication interaction with `.stream()`. (Pull #1312)
+
 ## 0.15.1 (September 23nd, 2020)
 
 ### Fixed

--- a/httpx/__version__.py
+++ b/httpx/__version__.py
@@ -1,3 +1,3 @@
 __title__ = "httpx"
 __description__ = "A next generation HTTP client, for Python 3."
-__version__ = "0.15.1"
+__version__ = "0.15.2"

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -859,7 +859,7 @@ class Client(BaseClient):
             )
 
         def on_close(response: Response) -> None:
-            response.elapsed = datetime.timedelta(timer.sync_elapsed())
+            response.elapsed = datetime.timedelta(seconds=timer.sync_elapsed())
             if hasattr(stream, "close"):
                 stream.close()
 
@@ -1504,7 +1504,7 @@ class AsyncClient(BaseClient):
             )
 
         async def on_close(response: Response) -> None:
-            response.elapsed = datetime.timedelta(await timer.async_elapsed())
+            response.elapsed = datetime.timedelta(seconds=await timer.async_elapsed())
             if hasattr(stream, "close"):
                 await stream.aclose()
 


### PR DESCRIPTION
## 0.15.2 (September 23nd, 2020)

### Fixed

* Fixed `response.elapsed` property. (Pull #1313)
* Fixed client authentication interaction with `.stream()`. (Pull #1312)