### PR TITLE
Check for proper method to close stream in asynchronous case

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -1505,7 +1505,7 @@ class AsyncClient(BaseClient):
 
         async def on_close(response: Response) -> None:
             response.elapsed = datetime.timedelta(seconds=await timer.async_elapsed())
-            if hasattr(stream, "close"):
+            if hasattr(stream, "aclose"):
                 await stream.aclose()
 
         response = Response(


### PR DESCRIPTION
Asynchronous ``httpcore`` streams do not have ``close()`` method, they provide ``aclose()``. Fixes #1315 .