### PR TITLE
Tweak transport closing

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -1119,13 +1119,12 @@ class Client(BaseClient):
         exc_value: BaseException = None,
         traceback: TracebackType = None,
     ) -> None:
-        if not self.is_closed:
-            self._is_closed = True
+        self._is_closed = True
 
-            self._transport.__exit__(exc_type, exc_value, traceback)
-            for proxy in self._proxies.values():
-                if proxy is not None:
-                    proxy.__exit__(exc_type, exc_value, traceback)
+        self._transport.__exit__(exc_type, exc_value, traceback)
+        for proxy in self._proxies.values():
+            if proxy is not None:
+                proxy.__exit__(exc_type, exc_value, traceback)
 
     def __del__(self) -> None:
         self.close()
@@ -1764,12 +1763,11 @@ class AsyncClient(BaseClient):
         exc_value: BaseException = None,
         traceback: TracebackType = None,
     ) -> None:
-        if not self.is_closed:
-            self._is_closed = True
-            await self._transport.__aexit__(exc_type, exc_value, traceback)
-            for proxy in self._proxies.values():
-                if proxy is not None:
-                    await proxy.__aexit__(exc_type, exc_value, traceback)
+        self._is_closed = True
+        await self._transport.__aexit__(exc_type, exc_value, traceback)
+        for proxy in self._proxies.values():
+            if proxy is not None:
+                await proxy.__aexit__(exc_type, exc_value, traceback)
 
     def __del__(self) -> None:
         if not self.is_closed:

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -209,10 +209,10 @@ async def test_context_managed_transport():
 
 
 @pytest.mark.usefixtures("async_environment")
-async def test_that_async_client_is_closed_by_default():
+async def test_that_async_client_is_not_closed_by_default():
     client = httpx.AsyncClient()
 
-    assert client.is_closed
+    assert not client.is_closed
 
 
 @pytest.mark.usefixtures("async_environment")

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -247,10 +247,10 @@ def test_context_managed_transport():
     ]
 
 
-def test_that_client_is_closed_by_default():
+def test_that_client_is_not_closed_by_default():
     client = httpx.Client()
 
-    assert client.is_closed
+    assert not client.is_closed
 
 
 def test_that_send_cause_client_to_be_not_closed():


### PR DESCRIPTION
Closes #1317

* Always close transports if `client.close()` is called, even if no requests have been made.
* Treat client instances as "open" as soon as they're instantiated, even if no requests have been made.