### PR TITLE
Remove seed-isort-config

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,5 @@ trio
 trio-typing
 trustme
 uvicorn
-seed-isort-config
 
 attrs>=19.3.0  # See: https://github.com/encode/httpx/pull/566#issuecomment-559862665

--- a/scripts/lint
+++ b/scripts/lint
@@ -9,6 +9,5 @@ export SOURCE_FILES="httpx tests"
 set -x
 
 ${PREFIX}autoflake --in-place --recursive $SOURCE_FILES
-${PREFIX}seed-isort-config --application-directories=httpx
 ${PREFIX}isort --project=httpx $SOURCE_FILES
 ${PREFIX}black --target-version=py36 $SOURCE_FILES

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,8 +13,6 @@ check_untyped_defs = True
 [tool:isort]
 profile = black
 combine_as_imports = True
-known_first_party = httpx,tests
-known_third_party = brotli,certifi,cryptography,httpcore,pytest,rfc3986,setuptools,sniffio,trio,trustme,uvicorn
 
 [tool:pytest]
 addopts = --cov=httpx --cov=tests -rxXs


### PR DESCRIPTION
As of isort 5 seed-isort-config is no longer needed.

We can get rid of some explicit config too as it's now more clever.
