### PR TITLE
Fix automatic .read() when Response instances are created with content=<str>

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -900,7 +900,7 @@ class Response:
             headers, stream = encode_response(content, text, html, json)
             self._prepare(headers)
             self.stream = stream
-            if content is None or isinstance(content, bytes):
+            if content is None or isinstance(content, (bytes, str)):
                 # Load the response body, except for streaming content.
                 self.read()
 

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -38,6 +38,19 @@ def test_response():
     assert not response.is_error
 
 
+def test_response_content():
+    response = httpx.Response(200, content="Hello, world!")
+
+    assert response.status_code == 200
+    assert response.reason_phrase == "OK"
+    assert response.text == "Hello, world!"
+    assert response.headers == httpx.Headers(
+        {
+            "Content-Length": "13",
+        }
+    )
+
+
 def test_response_text():
     response = httpx.Response(200, text="Hello, world!")
 


### PR DESCRIPTION
Closes #1323

When `Response` instances were being instantiated directly, and when using `content=<str>` the response body was not automatically being read.

```python
response = httpx.Response(200, content="Hello, world!")

assert response.status_code == 200
assert response.reason_phrase == "OK"
assert response.text == "Hello, world!"
assert response.headers == httpx.Headers(
    {
        "Content-Length": "13",
    }
)
```