### PR TITLE
Allow passing an ext to a Request

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -849,13 +849,15 @@ class Client(BaseClient):
         timer = Timer()
         timer.sync_start()
 
+        ext = request.ext.copy()
+        ext["timeout"] = timeout.as_dict()
         with map_exceptions(HTTPCORE_EXC_MAP, request=request):
             (status_code, headers, stream, ext) = transport.request(
                 request.method.encode(),
                 request.url.raw,
                 headers=request.headers.raw,
                 stream=request.stream,  # type: ignore
-                ext={"timeout": timeout.as_dict()},
+                ext=ext,
             )
 
         def on_close(response: Response) -> None:
@@ -1494,13 +1496,15 @@ class AsyncClient(BaseClient):
         timer = Timer()
         await timer.async_start()
 
+        ext = request.ext.copy()
+        ext["timeout"] = timeout.as_dict()
         with map_exceptions(HTTPCORE_EXC_MAP, request=request):
             (status_code, headers, stream, ext,) = await transport.arequest(
                 request.method.encode(),
                 request.url.raw,
                 headers=request.headers.raw,
                 stream=request.stream,  # type: ignore
-                ext={"timeout": timeout.as_dict()},
+                ext=ext,
             )
 
         async def on_close(response: Response) -> None:

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -279,6 +279,7 @@ class BaseClient:
         params: QueryParamTypes = None,
         headers: HeaderTypes = None,
         cookies: CookieTypes = None,
+        ext: dict = None,
     ) -> Request:
         """
         Build and return a request instance.
@@ -305,6 +306,7 @@ class BaseClient:
             params=params,
             headers=headers,
             cookies=cookies,
+            ext=ext,
         )
 
     def _merge_url(self, url: URLTypes) -> URL:
@@ -687,6 +689,7 @@ class Client(BaseClient):
         params: QueryParamTypes = None,
         headers: HeaderTypes = None,
         cookies: CookieTypes = None,
+        ext: dict = None,
         auth: typing.Union[AuthTypes, UnsetType] = UNSET,
         allow_redirects: bool = True,
         timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
@@ -717,6 +720,7 @@ class Client(BaseClient):
             params=params,
             headers=headers,
             cookies=cookies,
+            ext=ext,
         )
         return self.send(
             request, auth=auth, allow_redirects=allow_redirects, timeout=timeout
@@ -1331,6 +1335,7 @@ class AsyncClient(BaseClient):
         params: QueryParamTypes = None,
         headers: HeaderTypes = None,
         cookies: CookieTypes = None,
+        ext: dict = None,
         auth: typing.Union[AuthTypes, UnsetType] = UNSET,
         allow_redirects: bool = True,
         timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
@@ -1361,6 +1366,7 @@ class AsyncClient(BaseClient):
             params=params,
             headers=headers,
             cookies=cookies,
+            ext=ext,
         )
         response = await self.send(
             request, auth=auth, allow_redirects=allow_redirects, timeout=timeout

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -760,6 +760,7 @@ class Request:
         files: RequestFiles = None,
         json: typing.Any = None,
         stream: ByteStream = None,
+        ext: dict = None,
     ):
         if isinstance(method, bytes):
             self.method = method.decode("ascii").upper()
@@ -769,6 +770,7 @@ class Request:
         self.headers = Headers(headers)
         if cookies:
             Cookies(cookies).set_cookie_header(self)
+        self.ext = {} if ext is None else ext
 
         if stream is not None:
             # There's an important distinction between `Request(content=...)`,


### PR DESCRIPTION
This is nice if we want to create a `Request` server side (or in a `Transport`).

See #1091

Also, do we actually want to update `Request.ext` rather than making a copy?