### PR TITLE
Allow covariants of __enter__, __aenter__, and @classmethod

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -64,6 +64,8 @@ ACCEPT_ENCODING = ", ".join(
     [key for key in SUPPORTED_DECODERS.keys() if key != "identity"]
 )
 
+Self = typing.TypeVar("Self")
+
 
 class BaseClient:
     def __init__(
@@ -1105,7 +1107,7 @@ class Client(BaseClient):
                 if proxy is not None:
                     proxy.close()
 
-    def __enter__(self) -> "Client":
+    def __enter__(self) -> Self:
         self._transport.__enter__()
         for proxy in self._proxies.values():
             if proxy is not None:
@@ -1750,7 +1752,7 @@ class AsyncClient(BaseClient):
                 if proxy is not None:
                     await proxy.aclose()
 
-    async def __aenter__(self) -> "AsyncClient":
+    async def __aenter__(self) -> Self:
         await self._transport.__aenter__()
         for proxy in self._proxies.values():
             if proxy is not None:
@@ -1798,7 +1800,7 @@ class StreamContextManager:
         self.timeout = timeout
         self.close_client = close_client
 
-    def __enter__(self) -> "Response":
+    def __enter__(self) -> Self:
         assert isinstance(self.client, Client)
         self.response = self.client.send(
             request=self.request,
@@ -1820,7 +1822,7 @@ class StreamContextManager:
         if self.close_client:
             self.client.close()
 
-    async def __aenter__(self) -> "Response":
+    async def __aenter__(self) -> Self:
         assert isinstance(self.client, AsyncClient)
         self.response = await self.client.send(
             request=self.request,

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -19,6 +19,8 @@ from ._types import PrimitiveData
 if typing.TYPE_CHECKING:  # pragma: no cover
     from ._models import URL
 
+Self = typing.TypeVar("Self")
+
 
 _HTML5_FORM_ENCODING_REPLACEMENTS = {'"': "%22", "\\": "\\\\"}
 _HTML5_FORM_ENCODING_REPLACEMENTS.update(


### PR DESCRIPTION
The problem we currently have is the return type of classes such as
Client does not allow covariants when subclassing or context manager.
In other words:

```python
class Base:
    def __enter__(self) -> Base:  # XXX
        return self

class Derived(Base):
    ...

with Derived() as derived:
    ...
```

There are three approaches to improve type annotations.
1. Just do not type-annotate and let the type checker infer
   `return self`.
2. Use a generic type with a covariant bound
   `_AsyncClient = TypeVar('_AsyncClient', bound=AsyncClient)`
3. Use a generic type `T = TypeVar('T')` or `Self = TypeVar('Self')`

They have pros and cons.
1. It just works and is not friendly to developers as there is no type
   annotation at the first sight. A developer has to reveal its type via
   a type checker. Aslo, documentation tools that rely on type
   annotations lack the type. I haven't found any python docuementation
   tools that rely on type inference to infer `return self`. There are
   some tools simply check annotations.

2. This approach is correct and has a nice covariant bound that adds
   type safety. It is also nice to documentation tools and _somewhat_
   friendly to developers. Type checkers, pyright that I use, always
   shows the the bounded type '_AsyncClient' rather than the subtype.
   Aslo, it requires more key strokes. Not good, not good.

   It is used by `BaseException.with_traceback`
   See https://github.com/python/typeshed/pull/4298/files

3. This approach always type checks, and I believe it _will_ be the
   official solution in the future. Fun fact, Rust has a Self type
   keyword. It is slightly unfriendly to documentation, but is simple to
   implement and easy to understand for developers. Most importantly,
   type checkers love it.

   See https://github.com/python/mypy/issues/1212