### PR TITLE
Add `response.next_request`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -31,7 +31,7 @@
 
 ::: httpx.delete
     :docstring:
-    
+
 ::: httpx.stream
     :docstring:
 
@@ -63,6 +63,7 @@
 * `.encoding` - **str**
 * `.is_redirect` - **bool**
 * `.request` - **Request**
+* `.next_request` - **Optional[Request]**
 * `.cookies` - **Cookies**
 * `.history` - **List[Response]**
 * `.elapsed` - **[timedelta](https://docs.python.org/3/library/datetime.html)**

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -115,3 +115,17 @@ On the other hand, HTTPX uses [HTTPCore](https://github.com/encode/httpcore) as 
 ## Query Parameters
 
 `requests` omits `params` whose values are `None` (e.g. `requests.get(..., params={"foo": None})`). This is not supported by HTTPX.
+
+## Determining the next redirect request
+
+When using `allow_redirects=False`, the `requests` library exposes an attribute `response.next`, which can be used to obtain the next redirect request.
+
+In HTTPX, this attribute is instead named `response.next_request`. For example:
+
+```python
+client = httpx.Client()
+request = client.build_request("GET", ...)
+while request is not None:
+    response = client.send(request, allow_redirects=False)
+    request = response.next_request
+```

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -832,6 +832,7 @@ class Client(BaseClient):
             history = history + [response]
 
             if not allow_redirects:
+                response.next_request = request
                 response.call_next = functools.partial(
                     self._send_handling_redirects,
                     request=request,
@@ -1475,6 +1476,7 @@ class AsyncClient(BaseClient):
             history = history + [response]
 
             if not allow_redirects:
+                response.next_request = request
                 response.call_next = functools.partial(
                     self._send_handling_redirects,
                     request=request,

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -876,6 +876,10 @@ class Response:
 
         self._request: typing.Optional[Request] = request
 
+        # When allow_redirects=False and a redirect is received,
+        # the client will set `response.next_request`.
+        self._next_request: typing.Optional[Request] = None
+
         self.call_next: typing.Optional[typing.Callable] = None
 
         self.ext = {} if ext is None else ext
@@ -1191,6 +1195,24 @@ class Response:
             raise NotRedirectResponse(message)
         assert self.call_next is not None
         return self.call_next()
+
+    @property
+    def next_request(self) -> "Request":
+        """
+        Get the next request for a redirect response.
+        """
+        if not self.is_redirect:
+            message = (
+                "Called .next(), but the response was not a redirect. "
+                "Calling code should check `response.is_redirect` first."
+            )
+            raise NotRedirectResponse(message)
+        assert self._next_request is not None
+        return self._next_request
+
+    @next_request.setter
+    def next_request(self, next_request: Request) -> None:
+        self._next_request = next_request
 
     def close(self) -> None:
         """

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -878,7 +878,7 @@ class Response:
 
         # When allow_redirects=False and a redirect is received,
         # the client will set `response.next_request`.
-        self._next_request: typing.Optional[Request] = None
+        self.next_request: typing.Optional[Request] = None
 
         self.call_next: typing.Optional[typing.Callable] = None
 
@@ -1195,24 +1195,6 @@ class Response:
             raise NotRedirectResponse(message)
         assert self.call_next is not None
         return self.call_next()
-
-    @property
-    def next_request(self) -> "Request":
-        """
-        Get the next request for a redirect response.
-        """
-        if not self.is_redirect:
-            message = (
-                "Called .next(), but the response was not a redirect. "
-                "Calling code should check `response.is_redirect` first."
-            )
-            raise NotRedirectResponse(message)
-        assert self._next_request is not None
-        return self._next_request
-
-    @next_request.setter
-    def next_request(self, next_request: Request) -> None:
-        self._next_request = next_request
 
     def close(self) -> None:
         """

--- a/tests/client/test_redirects.py
+++ b/tests/client/test_redirects.py
@@ -166,6 +166,25 @@ def test_disallow_redirects():
     assert len(response.history) == 1
 
 
+def test_next_request():
+    client = httpx.Client(transport=MockTransport(redirects))
+    request = client.build_request("POST", "https://example.org/redirect_303")
+    response = client.send(request, allow_redirects=False)
+    assert response.status_code == httpx.codes.SEE_OTHER
+    assert response.url == "https://example.org/redirect_303"
+    assert response.is_redirect
+    assert len(response.history) == 0
+
+    response = client.send(response.next_request, allow_redirects=False)
+    assert response.status_code == httpx.codes.OK
+    assert response.url == "https://example.org/"
+    assert not response.is_redirect
+    assert len(response.history) == 0
+
+    with pytest.raises(httpx.NotRedirectResponse):
+        response.next_request
+
+
 def test_head_redirect():
     """
     Contrary to Requests, redirects remain enabled by default for HEAD requests.

--- a/tests/client/test_redirects.py
+++ b/tests/client/test_redirects.py
@@ -172,17 +172,12 @@ def test_next_request():
     response = client.send(request, allow_redirects=False)
     assert response.status_code == httpx.codes.SEE_OTHER
     assert response.url == "https://example.org/redirect_303"
-    assert response.is_redirect
-    assert len(response.history) == 0
+    assert response.next_request is not None
 
     response = client.send(response.next_request, allow_redirects=False)
     assert response.status_code == httpx.codes.OK
     assert response.url == "https://example.org/"
-    assert not response.is_redirect
-    assert len(response.history) == 0
-
-    with pytest.raises(httpx.NotRedirectResponse):
-        response.next_request
+    assert response.next_request is None
 
 
 def test_head_redirect():


### PR DESCRIPTION
Currently when using `allow_redirects=False`, we have interfaces for `response.next()` and `response.anext()`,
which can be used to issue the next redirect request.

The intent of these is to mirror the interface from `requests`, which also has a `response.next`.

*However* It turns out that I've made an error in what I thought the interface we were mirroring does. When using `requests` with `allow_redirects=False`, the `response.next` *isn't* a callable. It's an optional request instance, that can be used with `client.send(...)` to send the next response.

Since one of our desired aims is for full parity with requests, we *ought* to be covering that API, and *not* the callable `.next` interface that we're currently exposing.

```python
client = httpx.Client()
request = client.build_request("GET", ...)
while request is not None:
    response = client.send(request, allow_redirects=False)
    request = response.next_request
```

This pull request adds `response.next_request` as a more clearly named version of the requests API.

In the next version bump I think we should follow up on this PR by removing `response.next()` and `response.anext()` as unnecessary bits of API.