### PR TITLE
[PoC] Use context manager requests

### DIFF
--- a/httpx/_compat.py
+++ b/httpx/_compat.py
@@ -1,0 +1,9 @@
+try:
+    from contextlib import AsyncExitStack, asynccontextmanager  # type: ignore  # Py3.6
+except ImportError:  # pragma: no cover
+    # Python 3.6
+    from async_exit_stack import AsyncExitStack  # type: ignore  # noqa: F401
+    from async_generator import asynccontextmanager  # type: ignore  # noqa: F401
+
+# These will be imported by the unasynced code.
+from contextlib import ExitStack, contextmanager  # noqa: F401

--- a/httpx/_transports/asgi.py
+++ b/httpx/_transports/asgi.py
@@ -1,8 +1,9 @@
-from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, AsyncIterator, Callable, List, Optional, Tuple, Union
 from urllib.parse import unquote
 
 import httpcore
 import sniffio
+from .._compat import asynccontextmanager
 
 if TYPE_CHECKING:  # pragma: no cover
     import asyncio
@@ -68,6 +69,7 @@ class ASGITransport(httpcore.AsyncHTTPTransport):
         self.root_path = root_path
         self.client = client
 
+    @asynccontextmanager
     async def arequest(
         self,
         method: bytes,
@@ -75,7 +77,9 @@ class ASGITransport(httpcore.AsyncHTTPTransport):
         headers: List[Tuple[bytes, bytes]] = None,
         stream: httpcore.AsyncByteStream = None,
         ext: dict = None,
-    ) -> Tuple[int, List[Tuple[bytes, bytes]], httpcore.AsyncByteStream, dict]:
+    ) -> AsyncIterator[
+        Tuple[int, List[Tuple[bytes, bytes]], httpcore.AsyncByteStream, dict]
+    ]:
         headers = [] if headers is None else headers
         stream = httpcore.PlainByteStream(content=b"") if stream is None else stream
 
@@ -157,4 +161,4 @@ class ASGITransport(httpcore.AsyncHTTPTransport):
         stream = httpcore.PlainByteStream(content=b"".join(body_parts))
         ext = {}
 
-        return (status_code, response_headers, stream, ext)
+        yield (status_code, response_headers, stream, ext)

--- a/httpx/_transports/wsgi.py
+++ b/httpx/_transports/wsgi.py
@@ -1,6 +1,7 @@
 import io
 import itertools
 import typing
+from contextlib import contextmanager
 
 import httpcore
 
@@ -58,6 +59,7 @@ class WSGITransport(httpcore.SyncHTTPTransport):
         self.script_name = script_name
         self.remote_addr = remote_addr
 
+    @contextmanager
     def request(
         self,
         method: bytes,
@@ -65,8 +67,10 @@ class WSGITransport(httpcore.SyncHTTPTransport):
         headers: typing.List[typing.Tuple[bytes, bytes]] = None,
         stream: httpcore.SyncByteStream = None,
         ext: dict = None,
-    ) -> typing.Tuple[
-        int, typing.List[typing.Tuple[bytes, bytes]], httpcore.SyncByteStream, dict
+    ) -> typing.Iterator[
+        typing.Tuple[
+            int, typing.List[typing.Tuple[bytes, bytes]], httpcore.SyncByteStream, dict
+        ]
     ]:
         headers = [] if headers is None else headers
         stream = httpcore.PlainByteStream(content=b"") if stream is None else stream
@@ -125,4 +129,4 @@ class WSGITransport(httpcore.SyncHTTPTransport):
         stream = httpcore.IteratorByteStream(iterator=result)
         ext = {}
 
-        return (status_code, headers, stream, ext)
+        yield (status_code, headers, stream, ext)

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         "certifi",
         "sniffio",
         "rfc3986[idna2008]>=1.3,<2",
-        "httpcore==0.11.*",
+        "httpcore @ git+https://github.com/encode/httpcore@fm/request-context-manager#egg=httpcore",  # noqa
     ],
     extras_require={
         "http2": "h2==3.*",


### PR DESCRIPTION
Proof-of-concept pull request, that installs HTTPCore against https://github.com/encode/httpcore/pull/206 and demonstrates what would need to change to accomodate the new API.

This shouldn't be merged of course, but now I'm more confident that we can start by expecting the transport API to return either a response, _or_ a response context manager, and optionally enter the context via an exit stack.