### PR TITLE
Tighten client closed-state behaviour

### DIFF
--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -4,6 +4,7 @@ import httpcore
 import pytest
 
 import httpx
+from tests.utils import MockTransport
 
 
 @pytest.mark.usefixtures("async_environment")
@@ -208,43 +209,39 @@ async def test_context_managed_transport():
     ]
 
 
-@pytest.mark.usefixtures("async_environment")
-async def test_that_async_client_is_closed_by_default():
-    client = httpx.AsyncClient()
-
-    assert client.is_closed
+def hello_world(request):
+    return httpx.Response(200, text="Hello, world!")
 
 
 @pytest.mark.usefixtures("async_environment")
-async def test_that_send_cause_async_client_to_be_not_closed():
-    client = httpx.AsyncClient()
+async def test_client_closed_state_using_implicit_open():
+    client = httpx.AsyncClient(transport=MockTransport(hello_world))
 
+    assert not client.is_closed
     await client.get("http://example.com")
 
     assert not client.is_closed
-
     await client.aclose()
 
+    assert client.is_closed
+    with pytest.raises(RuntimeError):
+        await client.get("http://example.com")
+
 
 @pytest.mark.usefixtures("async_environment")
-async def test_that_async_client_is_not_closed_in_with_block():
-    async with httpx.AsyncClient() as client:
+async def test_client_closed_state_using_with_block():
+    async with httpx.AsyncClient(transport=MockTransport(hello_world)) as client:
         assert not client.is_closed
-
-
-@pytest.mark.usefixtures("async_environment")
-async def test_that_async_client_is_closed_after_with_block():
-    async with httpx.AsyncClient() as client:
-        pass
+        await client.get("http://example.com")
 
     assert client.is_closed
+    with pytest.raises(RuntimeError):
+        await client.get("http://example.com")
 
 
 @pytest.mark.usefixtures("async_environment")
-async def test_that_async_client_caused_warning_when_being_deleted():
-    async_client = httpx.AsyncClient()
-
-    await async_client.get("http://example.com")
-
+async def test_deleting_unclosed_async_client_causes_warning():
+    client = httpx.AsyncClient(transport=MockTransport(hello_world))
+    await client.get("http://example.com")
     with pytest.warns(UserWarning):
-        del async_client
+        del client

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -4,6 +4,7 @@ import httpcore
 import pytest
 
 import httpx
+from tests.utils import MockTransport
 
 
 def test_get(server):
@@ -247,27 +248,29 @@ def test_context_managed_transport():
     ]
 
 
-def test_that_client_is_closed_by_default():
-    client = httpx.Client()
-
-    assert client.is_closed
+def hello_world(request):
+    return httpx.Response(200, text="Hello, world!")
 
 
-def test_that_send_cause_client_to_be_not_closed():
-    client = httpx.Client()
+def test_client_closed_state_using_implicit_open():
+    client = httpx.Client(transport=MockTransport(hello_world))
 
+    assert not client.is_closed
     client.get("http://example.com")
 
     assert not client.is_closed
-
-
-def test_that_client_is_not_closed_in_with_block():
-    with httpx.Client() as client:
-        assert not client.is_closed
-
-
-def test_that_client_is_closed_after_with_block():
-    with httpx.Client() as client:
-        pass
+    client.close()
 
     assert client.is_closed
+    with pytest.raises(RuntimeError):
+        client.get("http://example.com")
+
+
+def test_client_closed_state_using_with_block():
+    with httpx.Client(transport=MockTransport(hello_world)) as client:
+        assert not client.is_closed
+        client.get("http://example.com")
+
+    assert client.is_closed
+    with pytest.raises(RuntimeError):
+        client.get("http://example.com")


### PR DESCRIPTION
Closes #1317
Closes #1332

Tighens up the client open/closed state by making it tri-state under the hood: `UNOPENED`/`OPENED`/`CLOSED`.

End result of the changes here, are that only the following styles are valid...

```python
client = httpx.Client()
client.request(...)
client.close()  # If omitted, this will be called on `__del__` with sync client, or raise a warning on `__del__` with async client.

# Cannot send requests anymore.
```

Or...

```python
with httpx.Client() as client:
    client.request(...)

# Cannot send requests anymore.
```

Because we're tri-state now we can make sure that simply importing but not using a client won't raise errors.
(Because under the hood, the client is initially in an `UNOPENED` state.)

```python
# If we don't actually use this client, then `__del__` won't raise a warning here.
client = httpx.AsyncClient()
```

* Clients may no longer used once closed. Calling `client.get(...)` and pals will raise a runtime error if attempted.
* Clients that have not sent a request should still call `.close()` on the underlying transports if closed.
* AsyncClients that have not been opened should not raise a warning if deleted.