### PR TITLE
Correctly handle ipv6 addresses as a part of URL

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -108,6 +108,10 @@ class URL:
                 raw_scheme, raw_host, port, raw_path = url
                 scheme = raw_scheme.decode("ascii")
                 host = raw_host.decode("ascii")
+                if host and ":" in host and host[0] != "[":
+                    # it's an IPv6 address, so it should be enclosed in "[" and "]"
+                    # ref: https://tools.ietf.org/html/rfc2732#section-2
+                    host = f"[{host}]"
                 port_str = "" if port is None else f":{port}"
                 path = raw_path.decode("ascii")
                 url = f"{scheme}://{host}{port_str}{path}"
@@ -186,8 +190,17 @@ class URL:
 
         url = httpx.URL("http://中国.icom.museum")
         assert url.host == "xn--fiqs8s.icom.museum"
+
+        url = httpx.URL("https://[::ffff:192.168.0.1]")
+        assert url.host == "::ffff:192.168.0.1"
         """
-        return self._uri_reference.host or ""
+        host: str = self._uri_reference.host
+
+        if host and ":" in host and host[0] == "[":
+            # it's an IPv6 address
+            host = host.lstrip("[").rstrip("]")
+
+        return host or ""
 
     @property
     def port(self) -> typing.Optional[int]:
@@ -336,6 +349,11 @@ class URL:
             # Consolidate host and port into  netloc.
             host = kwargs.pop("host", self.host) or ""
             port = kwargs.pop("port", self.port)
+
+            if host and ":" in host and host[0] != "[":
+                # it's an IPv6 address, so it should be hidden under bracket
+                host = f"[{host}]"
+
             kwargs["netloc"] = f"{host}:{port}" if port is not None else host
 
         if "userinfo" in kwargs or "netloc" in kwargs:

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -111,6 +111,7 @@ class URL:
                 if host and ":" in host and host[0] != "[":
                     # it's an IPv6 address, so it should be enclosed in "[" and "]"
                     # ref: https://tools.ietf.org/html/rfc2732#section-2
+                    # ref: https://tools.ietf.org/html/rfc3986#section-3.2.2
                     host = f"[{host}]"
                 port_str = "" if port is None else f":{port}"
                 path = raw_path.decode("ascii")

--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -289,12 +289,8 @@ def test_url_with_url_encoded_path():
     assert url.raw_path == b"/path%20to%20somewhere"
 
 
-@pytest.mark.parametrize(
-    "url_str",
-    ["http://[::ffff:192.168.0.1]:5678/"],
-)
-def test_ipv6_ulr(url_str):
-    url = httpx.URL(url_str)
+def test_ipv6_url():
+    url = httpx.URL("http://[::ffff:192.168.0.1]:5678/")
 
     assert url.host == "::ffff:192.168.0.1"
     assert url.netloc == "[::ffff:192.168.0.1]:5678"

--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -287,3 +287,41 @@ def test_url_with_url_encoded_path():
     assert url.path == "/path to somewhere"
     assert url.query == b""
     assert url.raw_path == b"/path%20to%20somewhere"
+
+
+@pytest.mark.parametrize(
+    "url_str",
+    ["http://[::ffff:192.168.0.1]:5678/"],
+)
+def test_ipv6_ulr(url_str):
+    url = httpx.URL(url_str)
+
+    assert url.host == "::ffff:192.168.0.1"
+    assert url.netloc == "[::ffff:192.168.0.1]:5678"
+
+
+@pytest.mark.parametrize(
+    "url_str",
+    [
+        "http://192.168.0.1:1234",
+        "http://example.com:1234",
+        "http://[::ffff:192.168.0.2]:1234",
+    ],
+)
+@pytest.mark.parametrize("new_host", ["[::ffff:192.168.0.1]", "::ffff:192.168.0.1"])
+def test_ipv6_url_copy_with_host(url_str, new_host):
+    url = httpx.URL(url_str).copy_with(host=new_host)
+
+    assert url.host == "::ffff:192.168.0.1"
+    assert url.netloc == "[::ffff:192.168.0.1]:1234"
+    assert str(url) == "http://[::ffff:192.168.0.1]:1234"
+
+
+@pytest.mark.parametrize("host", [b"[::ffff:192.168.0.1]", b"::ffff:192.168.0.1"])
+def test_ipv6_url_from_raw_url(host):
+    raw_url = (b"https", host, 443, b"/")
+    url = httpx.URL(raw_url)
+
+    assert url.host == "::ffff:192.168.0.1"
+    assert url.netloc == "[::ffff:192.168.0.1]:443"
+    assert str(url) == "https://[::ffff:192.168.0.1]:443/"

--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -301,7 +301,7 @@ def test_ipv6_url():
     [
         "http://127.0.0.1:1234",
         "http://example.com:1234",
-        "http://[::ffff:192.168.0.2]:1234",
+        "http://[::ffff:127.0.0.1]:1234",
     ],
 )
 @pytest.mark.parametrize("new_host", ["[::ffff:192.168.0.1]", "::ffff:192.168.0.1"])

--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -299,7 +299,7 @@ def test_ipv6_url():
 @pytest.mark.parametrize(
     "url_str",
     [
-        "http://192.168.0.1:1234",
+        "http://127.0.0.1:1234",
         "http://example.com:1234",
         "http://[::ffff:192.168.0.2]:1234",
     ],


### PR DESCRIPTION
Closes https://github.com/encode/httpx/issues/1311

There was a bug with processing an ipv6 address as a part of request URL.

What has been changed:
1. I implemented the functionality from https://github.com/encode/httpx/issues/1311#issuecomment-704224592
1. Also I found the problem in `URL` constructor. If we pass a `RawURL` with ipv6 as a host, then host should be enclosed by square brackets, otherwise `rfc3986.iri_reference(...)` won't process it