### PR TITLE
Replacing pytest-cov by coverage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ wheel
 # Tests & Linting
 autoflake
 black==20.8b1
+coverage==5.3
 cryptography
 flake8
 flake8-bugbear
@@ -24,7 +25,6 @@ mypy
 pytest==5.*
 pytest-asyncio
 pytest-trio
-pytest-cov
 trio
 trio-typing
 trustme

--- a/scripts/test
+++ b/scripts/test
@@ -11,7 +11,7 @@ if [ -z $GITHUB_ACTIONS ]; then
     scripts/check
 fi
 
-${PREFIX}pytest $@
+${PREFIX}coverage run -m pytest
 
 if [ -z $GITHUB_ACTIONS ]; then
     scripts/coverage

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,10 @@ profile = black
 combine_as_imports = True
 
 [tool:pytest]
-addopts = --cov=httpx --cov=tests -rxXs
+addopts = -rxXs
 markers =
   copied_from(source, changes=None): mark test as copied from somewhere else, along with a description of changes made to accodomate e.g. our test setup
+
+[coverage:run]
+omit = venv/*
+include = httpx/*, tests/*


### PR DESCRIPTION
After encode/uvicorn#809 and https://github.com/encode/httpcore/pull/218 it would be great to introduce the same changes in `httpx`
