### PR TITLE
Close AsyncClient properly in `test_async_next_request`

### DIFF
--- a/tests/client/test_redirects.py
+++ b/tests/client/test_redirects.py
@@ -155,17 +155,17 @@ def test_next_request():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_async_next_request():
-    client = httpx.AsyncClient(transport=MockTransport(redirects))
-    request = client.build_request("POST", "https://example.org/redirect_303")
-    response = await client.send(request, allow_redirects=False)
-    assert response.status_code == httpx.codes.SEE_OTHER
-    assert response.url == "https://example.org/redirect_303"
-    assert response.next_request is not None
+    async with httpx.AsyncClient(transport=MockTransport(redirects)) as client:
+        request = client.build_request("POST", "https://example.org/redirect_303")
+        response = await client.send(request, allow_redirects=False)
+        assert response.status_code == httpx.codes.SEE_OTHER
+        assert response.url == "https://example.org/redirect_303"
+        assert response.next_request is not None
 
-    response = await client.send(response.next_request, allow_redirects=False)
-    assert response.status_code == httpx.codes.OK
-    assert response.url == "https://example.org/"
-    assert response.next_request is None
+        response = await client.send(response.next_request, allow_redirects=False)
+        assert response.status_code == httpx.codes.OK
+        assert response.url == "https://example.org/"
+        assert response.next_request is None
 
 
 def test_head_redirect():


### PR DESCRIPTION
`AsyncClient` in this test case was not being closed cleanly.