### PR TITLE
Drop unecessary host="localhost" in https_server fixture to fix CI build

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -300,7 +300,6 @@ def https_server(cert_pem_file, cert_private_key_file):
         lifespan="off",
         ssl_certfile=cert_pem_file,
         ssl_keyfile=cert_private_key_file,
-        host="localhost",
         port=8001,
         loop="asyncio",
     )


### PR DESCRIPTION
Prompted by https://github.com/encode/httpx/pull/1364#issuecomment-715883069

Refs https://github.com/encode/uvicorn/issues/836

We're passing `host="localhost"`, which fails on uvicorn `0.12.2` (there's already a fix in `master` there for this: https://github.com/encode/uvicorn/pull/827), resulting in our test suite to hang (because the server fails to start, and we keep checking `server.ready` indefinitely).

This PR removes this flag entirely, since we actually don't need it. This means this PR can be merged regardless of uvicorn fixing support for non-IP `host` values. This should also get our CI builds to pass again.