### PR TITLE
Include invalid name/value when raising TypeError in DataField

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -379,7 +379,7 @@ class BaseClient:
         elif callable(auth):
             return FunctionAuth(func=auth)
         else:
-            raise TypeError('Invalid "auth" argument.')
+            raise TypeError(f'Invalid "auth" argument: {auth!r}')
 
     def _build_request_auth(
         self, request: Request, auth: typing.Union[AuthTypes, UnsetType] = UNSET

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -130,7 +130,7 @@ class URL:
             self._uri_reference = url._uri_reference
         else:
             raise TypeError(
-                f"Invalid type for url.  Expected str or httpx.URL, got {type(url)}"
+                f"Invalid type for url.  Expected str or httpx.URL, got {type(url)}: {url!r}"
             )
 
         # Add any query parameters, merging with any in the URL if needed.

--- a/httpx/_multipart.py
+++ b/httpx/_multipart.py
@@ -19,11 +19,13 @@ class DataField:
 
     def __init__(self, name: str, value: typing.Union[str, bytes]) -> None:
         if not isinstance(name, str):
-            raise TypeError(f"Invalid type for name. Expected str, "
-                            f"got {type(name).__name__}: {name!r}")
+            raise TypeError(
+                f"Invalid type for name. Expected str, got {type(name)}: {name!r}"
+            )
         if not isinstance(value, (str, bytes)):
-            raise TypeError(f"Invalid type for value. Expected str or bytes, "
-                            f"got {type(value).__name__}: {value!r}")
+            raise TypeError(
+                f"Invalid type for value. Expected str or bytes, got {type(value)}: {value!r}"
+            )
         self.name = name
         self.value = value
 

--- a/httpx/_multipart.py
+++ b/httpx/_multipart.py
@@ -19,9 +19,11 @@ class DataField:
 
     def __init__(self, name: str, value: typing.Union[str, bytes]) -> None:
         if not isinstance(name, str):
-            raise TypeError("Invalid type for name. Expected str.")
+            raise TypeError(f"Invalid type for name. Expected str, "
+                            f"got {type(name).__name__}: {name!r}")
         if not isinstance(value, (str, bytes)):
-            raise TypeError("Invalid type for value. Expected str or bytes.")
+            raise TypeError(f"Invalid type for value. Expected str or bytes, "
+                            f"got {type(value).__name__}: {value!r}")
         self.name = name
         self.value = value
 

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -55,6 +55,7 @@ def test_multipart_invalid_key(key):
             files=files,
         )
     assert "Invalid type for name" in str(e.value)
+    assert repr(key) in str(e.value)
 
 
 @pytest.mark.parametrize(("value"), (1, 2.3, None, [None, "abc"], {None: "abc"}))


### PR DESCRIPTION
I couldn't find a straight-forward way to test invalid values.