### PR TITLE
expose UNSET

### DIFF
--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -2,7 +2,7 @@ from .__version__ import __description__, __title__, __version__
 from ._api import delete, get, head, options, patch, post, put, request, stream
 from ._auth import Auth, BasicAuth, DigestAuth
 from ._client import AsyncClient, Client
-from ._config import Limits, Proxy, Timeout, create_ssl_context
+from ._config import UNSET, Limits, Proxy, Timeout, create_ssl_context
 from ._exceptions import (
     CloseError,
     ConnectError,
@@ -93,6 +93,7 @@ __all__ = [
     "TimeoutException",
     "TooManyRedirects",
     "TransportError",
+    "UNSET",
     "UnsupportedProtocol",
     "URL",
     "WriteError",


### PR DESCRIPTION
Since UNSET is widely used in lots of functions' parameters. When people want to subclass and rewrite a method, or create a function to call httpx, they will need to use this UNSET to define their own parameters too.

A simple example:

```python
def request_token(client, auth=UNSET, **kwargs):
    url = 'https://example.com/token'
    return client.get(url, auth=auth, **kwargs)
```

Here are some real examples:

1. https://github.com/lepture/authlib/blob/v0.15.2/authlib/integrations/httpx_client/oauth2_client.py#L117
2. https://github.com/lepture/authlib/blob/v0.15.2/authlib/integrations/httpx_client/oauth2_client.py#L136