### PR TITLE
Turn UNSET into a synonym for ellipsis

### DIFF
--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -1,3 +1,4 @@
+import builtins
 import os
 import ssl
 import typing
@@ -32,12 +33,8 @@ DEFAULT_CIPHERS = ":".join(
 
 logger = get_logger(__name__)
 
-
-class UnsetType:
-    pass  # pragma: nocover
-
-
-UNSET = UnsetType()
+UnsetType = builtins.ellipsis
+UNSET = ...
 
 
 def create_ssl_context(


### PR DESCRIPTION
Closes #1384, refs https://github.com/encode/httpx/issues/1384#issuecomment-723429932.

For consideration, but I quite like this :-)

This PR changes `UNSET` and `UnsetType` so they refer to `...` and `builtins.ellipsis` respectively, i.e. the ellipsis special value.

This is a first step that gets us the behavior we want (users can override by setting `auth=...`, `timeout=...`, and then comparing `if auth is ...: ...`). But there's an obvious follow-up to update our code to drop those references internally. We may want to decide to keep the `UnsetType` and `UNSET` names available in `0.17.*` but mark them as deprecated — we can decide of this as a follow-up.
