### PR TITLE
Use relative links for interlinking markdown files in docs

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -12,7 +12,7 @@
 
 #### More efficient usage of network resources
 
-When you make requests using the top-level API as documented in the [Quickstart](/quickstart) guide, HTTPX has to establish a new connection _for every single request_ (connections are not reused). As the number of requests to a host increases, this quickly becomes inefficient.
+When you make requests using the top-level API as documented in the [Quickstart](quickstart.md) guide, HTTPX has to establish a new connection _for every single request_ (connections are not reused). As the number of requests to a host increases, this quickly becomes inefficient.
 
 On the other hand, a `Client` instance uses [HTTP connection pooling](https://en.wikipedia.org/wiki/HTTP_persistent_connection). This means that when you make several requests to the same host, the `Client` will reuse the underlying TCP connection, instead of recreating one for every single request.
 
@@ -29,7 +29,7 @@ This can bring **significant performance improvements** compared to using the to
 - Cookie persistance across requests.
 - Applying configuration across all outgoing requests.
 - Sending requests through HTTP proxies.
-- Using [HTTP/2](/http2).
+- Using [HTTP/2](http2.md).
 
 The other sections on this page go into further detail about what you can do with a `Client` instance.
 
@@ -64,7 +64,7 @@ Once you have a `Client`, you can send requests using `.get()`, `.post()`, etc. 
 <Response [200 OK]>
 ```
 
-These methods accept the same arguments as `httpx.get()`, `httpx.post()`, etc. This means that all features documented in the [Quickstart](/quickstart) guide are also available at the client level.
+These methods accept the same arguments as `httpx.get()`, `httpx.post()`, etc. This means that all features documented in the [Quickstart](quickstart.md) guide are also available at the client level.
 
 For example, to send a request with custom headers:
 
@@ -143,7 +143,7 @@ For example, `base_url` allows you to prepend an URL to all outgoing requests:
 URL('http://httpbin.org/headers')
 ```
 
-For a list of all available client parameters, see the [`Client`](/api/#client) API reference.
+For a list of all available client parameters, see the [`Client`](api.md#client) API reference.
 
 ## Calling into Python Web Apps
 
@@ -190,7 +190,7 @@ with httpx.Client(transport=transport, base_url="http://testserver") as client:
 
 ## Request instances
 
-For maximum control on what gets sent over the wire, HTTPX supports building explicit [`Request`](/api#request) instances:
+For maximum control on what gets sent over the wire, HTTPX supports building explicit [`Request`](api.md#request) instances:
 
 ```python
 request = httpx.Request("GET", "https://example.com")
@@ -537,7 +537,7 @@ proxies = {
 
 HTTP proxying can also be configured through environment variables, although with less fine-grained control.
 
-See documentation on [`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`](/environment_variables/#http_proxy-https_proxy-all_proxy) for more information.
+See documentation on [`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`](environment_variables.md#http_proxy-https_proxy-all_proxy) for more information.
 
 ### Proxy mechanisms
 
@@ -675,7 +675,7 @@ client = httpx.Client(limits=limits)
 
 ## Multipart file encoding
 
-As mentioned in the [quickstart](/quickstart#sending-multipart-file-uploads)
+As mentioned in the [quickstart](quickstart.md#sending-multipart-file-uploads)
 multipart file encoding is available by passing a dictionary with the
 name of the payloads as keys and either tuple of elements or a file-like object or a string as values.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -98,9 +98,9 @@ client = httpx.Client(**kwargs)
 
 ## Request instantiation
 
-There is no notion of [prepared requests](https://requests.readthedocs.io/en/stable/user/advanced/#prepared-requests) in HTTPX. If you need to customize request instantiation, see [Request instances](/advanced#request-instances).
+There is no notion of [prepared requests](https://requests.readthedocs.io/en/stable/user/advanced/#prepared-requests) in HTTPX. If you need to customize request instantiation, see [Request instances](advanced.md#request-instances).
 
-Besides, `httpx.Request()` does not support the `auth`, `timeout`, `allow_redirects`, `proxies`, `verify` and `cert` parameters. However these are available in `httpx.request`, `httpx.get`, `httpx.post` etc., as well as on [`Client` instances](/advanced#client-instances).
+Besides, `httpx.Request()` does not support the `auth`, `timeout`, `allow_redirects`, `proxies`, `verify` and `cert` parameters. However these are available in `httpx.request`, `httpx.get`, `httpx.post` etc., as well as on [`Client` instances](advanced.md#client-instances).
 
 ## Mocking
 

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -141,7 +141,7 @@ The environment variables documented below are used as a convention by various H
 * [cURL](https://github.com/curl/curl/blob/master/docs/MANUAL.md#environment-variables)
 * [requests](https://github.com/psf/requests/blob/master/docs/user/advanced.rst#proxies)
 
-For more information on using proxies in HTTPX, see [HTTP Proxying](/advanced/#http-proxying).
+For more information on using proxies in HTTPX, see [HTTP Proxying](advanced.md#http-proxying).
 
 ### `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`
 

--- a/docs/third-party-packages.md
+++ b/docs/third-party-packages.md
@@ -45,4 +45,4 @@ A utility for record and repeat an http request.
 
 [GitHub](https://gist.github.com/florimondmanca/d56764d78d748eb9f73165da388e546e)
 
-This public gist provides an example implementation for a [custom transport](/advanced#custom-transports) implementation on top of the battle-tested [`urllib3`](https://urllib3.readthedocs.io) library.
+This public gist provides an example implementation for a [custom transport](advanced.md#custom-transports) implementation on top of the battle-tested [`urllib3`](https://urllib3.readthedocs.io) library.


### PR DESCRIPTION
Closes #1383

When interlinking in the docs, use relative links to the source markdown files, so that both the rendered docs, *and the documentation source files directly on GitHub* interlink correctly.