### PR TITLE
WSGI 'PATH_INFO' should be URL unquoted

### DIFF
--- a/httpx/_transports/wsgi.py
+++ b/httpx/_transports/wsgi.py
@@ -1,6 +1,7 @@
 import io
 import itertools
 import typing
+from urllib.parse import unquote
 
 import httpcore
 
@@ -83,7 +84,7 @@ class WSGITransport(httpcore.SyncHTTPTransport):
             "wsgi.run_once": False,
             "REQUEST_METHOD": method.decode(),
             "SCRIPT_NAME": self.script_name,
-            "PATH_INFO": path.decode("ascii"),
+            "PATH_INFO": unquote(path.decode("ascii")),
             "QUERY_STRING": query.decode("ascii"),
             "SERVER_NAME": host.decode("ascii"),
             "SERVER_PORT": str(port),


### PR DESCRIPTION
Closes #1365

The WSGI `PATH_INFO` component should be unquoted, in the same way the ASGI `path` component is.

See current WSGI `PATH_INFO` handling...

https://github.com/encode/httpx/blob/f8f543057a9feb5330784401b5fed168c5288e36/httpx/_transports/wsgi.py#L86

And current ASGI `path` handling...

https://github.com/encode/httpx/blob/f8f543057a9feb5330784401b5fed168c5288e36/httpx/_transports/asgi.py#L92