### PR TITLE
Add keepalive_expiry to Limits config

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -64,7 +64,6 @@ U = typing.TypeVar("U", bound="AsyncClient")
 
 logger = get_logger(__name__)
 
-KEEPALIVE_EXPIRY = 5.0
 USER_AGENT = f"python-httpx/{__version__}"
 ACCEPT_ENCODING = ", ".join(
     [key for key in SUPPORTED_DECODERS.keys() if key != "identity"]
@@ -656,7 +655,7 @@ class Client(BaseClient):
             ssl_context=ssl_context,
             max_connections=limits.max_connections,
             max_keepalive_connections=limits.max_keepalive_connections,
-            keepalive_expiry=KEEPALIVE_EXPIRY,
+            keepalive_expiry=limits.keepalive_expiry,
             http2=http2,
         )
 
@@ -678,7 +677,7 @@ class Client(BaseClient):
             ssl_context=ssl_context,
             max_connections=limits.max_connections,
             max_keepalive_connections=limits.max_keepalive_connections,
-            keepalive_expiry=KEEPALIVE_EXPIRY,
+            keepalive_expiry=limits.keepalive_expiry,
             http2=http2,
         )
 
@@ -1299,7 +1298,7 @@ class AsyncClient(BaseClient):
             ssl_context=ssl_context,
             max_connections=limits.max_connections,
             max_keepalive_connections=limits.max_keepalive_connections,
-            keepalive_expiry=KEEPALIVE_EXPIRY,
+            keepalive_expiry=limits.keepalive_expiry,
             http2=http2,
         )
 
@@ -1321,7 +1320,7 @@ class AsyncClient(BaseClient):
             ssl_context=ssl_context,
             max_connections=limits.max_connections,
             max_keepalive_connections=limits.max_keepalive_connections,
-            keepalive_expiry=KEEPALIVE_EXPIRY,
+            keepalive_expiry=limits.keepalive_expiry,
             http2=http2,
         )
 

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -294,7 +294,7 @@ class Limits:
         *,
         max_connections: int = None,
         max_keepalive_connections: int = None,
-        keepalive_expiry: float = 5.0,
+        keepalive_expiry: typing.Optional[float] = 5.0,
     ):
         self.max_connections = max_connections
         self.max_keepalive_connections = max_keepalive_connections

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -294,22 +294,26 @@ class Limits:
         *,
         max_connections: int = None,
         max_keepalive_connections: int = None,
+        keepalive_expiry: float = 5.0,
     ):
         self.max_connections = max_connections
         self.max_keepalive_connections = max_keepalive_connections
+        self.keepalive_expiry = keepalive_expiry
 
     def __eq__(self, other: typing.Any) -> bool:
         return (
             isinstance(other, self.__class__)
             and self.max_connections == other.max_connections
             and self.max_keepalive_connections == other.max_keepalive_connections
+            and self.keepalive_expiry == other.keepalive_expiry
         )
 
     def __repr__(self) -> str:
         class_name = self.__class__.__name__
         return (
             f"{class_name}(max_connections={self.max_connections}, "
-            f"max_keepalive_connections={self.max_keepalive_connections})"
+            f"max_keepalive_connections={self.max_keepalive_connections}, "
+            f"keepalive_expiry={self.keepalive_expiry})"
         )
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -102,7 +102,8 @@ def test_create_ssl_context_with_get_request(server, cert_pem_file):
 
 def test_limits_repr():
     limits = httpx.Limits(max_connections=100)
-    assert repr(limits) == "Limits(max_connections=100, max_keepalive_connections=None)"
+    expected = "Limits(max_connections=100, max_keepalive_connections=None, keepalive_expiry=5.0)"
+    assert repr(limits) == expected
 
 
 def test_limits_eq():


### PR DESCRIPTION
Closes #1395

We do *also* want #1302, but I think it makes sense to include `keepalive_expiry` in the `Limits` config either ways around.