### PR TITLE
URL.path: don't unquote slashes as this corrupts the path

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -234,7 +234,7 @@ class URL:
         assert url.path == "/pa th"
         """
         path = self._uri_reference.path or "/"
-        return unquote(path)
+        return "%2F".join(map(unquote, path.split("%2F")))
 
     @property
     def query(self) -> bytes:


### PR DESCRIPTION
This PR addresses issue https://github.com/encode/httpx/issues/1405

Using `unquote` in a blanket way on the path can result in corrupting the path if the path contains encoded slashes. This change has some precedent in https://docs.python.org/3/library/urllib.parse.html#urllib.parse.quote, where the default behaviour is to treat the slash as a special case.

Personally, I am not sure URL.path should be doing `unquote` at all. My preference would be to drop the `unquote` behaviour entirely. Nevertheless, with this PR at least `URL.path` does not corrupt paths.

I'd be happy to write some tests if this approach is approved.
