### PR TITLE
Properly preserve encoded slashes when using `base_url`

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -120,9 +120,9 @@ class BaseClient:
         return self._trust_env
 
     def _enforce_trailing_slash(self, url: URL) -> URL:
-        if url.path.endswith("/"):
+        if url.raw_path.endswith(b"/"):
             return url
-        return url.copy_with(path=url.path + "/")
+        return url.copy_with(raw_path=url.raw_path + b"/")
 
     def _get_proxy_map(
         self, proxies: typing.Optional[ProxiesTypes], allow_env_proxies: bool
@@ -327,7 +327,7 @@ class BaseClient:
         if merge_url.is_relative_url:
             # We always ensure the base_url paths include the trailing '/',
             # and always strip any leading '/' from the merge URL.
-            merge_url = merge_url.copy_with(path=merge_url.path.lstrip("/"))
+            merge_url = merge_url.copy_with(raw_path=merge_url.raw_path.lstrip(b"/"))
             return self.base_url.join(merge_url)
         return merge_url
 

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -198,6 +198,16 @@ def test_merge_relative_url_with_dotted_path():
     assert request.url == "https://www.example.com/some/testing/123"
 
 
+def test_merge_relative_url_with_encoded_slashes():
+    client = httpx.Client(base_url="https://www.example.com/")
+    request = client.build_request("GET", "/testing%2F123")
+    assert request.url == "https://www.example.com/testing%2F123"
+
+    client = httpx.Client(base_url="https://www.example.com/base%2Fpath")
+    request = client.build_request("GET", "/testing")
+    assert request.url == "https://www.example.com/base%2Fpath/testing"
+
+
 def test_pool_limits_deprecated():
     limits = httpx.Limits()
 


### PR DESCRIPTION
**Update**: Prompted by #1405 

An alternative to #1406 that tweaks URL merging to operate on `.raw_path`, rather than `.path`. Rationale: `.path` is URL-decoded and might swallow pre-existing `%2F` characters into `/`. On the other hand `.raw_path` doesn't do URL-decoding, so it is suitable for handling encoded slashes as well.