### PR TITLE
Add repr to Cookies for displaying available cookies

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -1492,13 +1492,9 @@ class Cookies(MutableMapping):
         return False
 
     def __repr__(self) -> str:
-        template = "<Cookie {name}={value} for {domain} />"
-
         cookies_repr = ", ".join(
             [
-                template.format(
-                    name=cookie.name, value=cookie.value, domain=cookie.domain
-                )
+                f"<Cookie {cookie.name}={cookie.value} for {cookie.domain} />"
                 for cookie in self.jar
             ]
         )

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -1491,6 +1491,20 @@ class Cookies(MutableMapping):
             return True
         return False
 
+    def __repr__(self) -> str:
+        template = "<Cookie {name}={value} for {domain} />"
+
+        cookies_repr = ", ".join(
+            [
+                template.format(
+                    name=cookie.name, value=cookie.value, domain=cookie.domain
+                )
+                for cookie in self.jar
+            ]
+        )
+
+        return f"<Cookies[{cookies_repr}]>"
+
     class _CookieCompatRequest(urllib.request.Request):
         """
         Wraps a `Request` instance up in a compatibility interface suitable

--- a/test.py
+++ b/test.py
@@ -1,8 +1,0 @@
-import httpx
-
-
-if __name__ == '__main__':
-    r = httpx.get('https://www.example.org/')
-    r.cookies.set(name="foo", value="bar", domain="http://blah.com")
-    r.cookies.set(name="fizz", value="buzz", domain="http://hello.com")
-    print(repr(r.cookies))

--- a/test.py
+++ b/test.py
@@ -1,0 +1,8 @@
+import httpx
+
+
+if __name__ == '__main__':
+    r = httpx.get('https://www.example.org/')
+    r.cookies.set(name="foo", value="bar", domain="http://blah.com")
+    r.cookies.set(name="fizz", value="buzz", domain="http://hello.com")
+    print(repr(r.cookies))

--- a/tests/models/test_cookies.py
+++ b/tests/models/test_cookies.py
@@ -85,3 +85,14 @@ def test_cookies_can_be_a_list_of_tuples():
     assert len(cookies.items()) == 2
     for k, v in cookies_val:
         assert cookies[k] == v
+
+
+def test_cookies_repr():
+    cookies = httpx.Cookies()
+    cookies.set(name="foo", value="bar", domain="http://blah.com")
+    cookies.set(name="fizz", value="buzz", domain="http://hello.com")
+
+    assert (
+        repr(cookies)
+        == "<Cookies[<Cookie foo=bar for http://blah.com />, <Cookie fizz=buzz for http://hello.com />]>"
+    )


### PR DESCRIPTION
Simple test:

```python
import httpx


if __name__ == '__main__':
    r = httpx.get('https://www.example.org/')
    r.cookies.set(name="foo", value="bar", domain="http://blah.com")
    r.cookies.set(name="fizz", value="buzz", domain="http://hello.com")
    print(repr(r.cookies))
```

Results in:

```
<Cookies[<Cookie foo=bar for http://blah.com />, <Cookie fizz=buzz for http://hello.com />]>
```

Closes #1377 