### PR TITLE
Document content encoding differences with Requests

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -35,7 +35,7 @@ However, for compatibility reasons with `requests`, we do still handle the case 
 
 HTTPX uses `utf-8` for encoding `str` request bodies. For example, when using `content=<str>` the request body will be encoded to `utf-8` before being sent over the wire. This differs from Requests which uses `latin1`. If you need an explicit encoding, pass encoded bytes explictly, e.g. `content=<str>.encode("latin1")`.
 
-For response bodies, assuming the server didn't send an explicit encoding then HTTPX will do its best to figure out an appropriate encoding. Unlike Requests which uses the `chardet` library, HTTPX relies on a plainer fallback strategy (basically attempting UTF-8, or using Windows 1252 as a fallback). This strategy should be robust enough to handle the vast majority of use cases.
+For response bodies, assuming the server didn't send an explicit encoding then HTTPX will do its best to figure out an appropriate encoding. Unlike Requests which uses the `chardet` library, HTTPX relies on a plainer fallback strategy (basically attempting UTF-8, or using Windows-1252 as a fallback). This strategy should be robust enough to handle the vast majority of use cases.
 
 ## Status Codes
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -33,9 +33,9 @@ However, for compatibility reasons with `requests`, we do still handle the case 
 
 ## Content encoding
 
-HTTPX uses `utf-8` for encoding `str` request bodies. For example, when using `content=<str>` the request body will be encoded to `utf-8` before being sent over the wire. will This differs from Requests which uses `latin1`. If you need an explicit encoding, pass encoded bytes explictly, e.g. `content=<str>.encode("latin1")`.
+HTTPX uses `utf-8` for encoding `str` request bodies. For example, when using `content=<str>` the request body will be encoded to `utf-8` before being sent over the wire. This differs from Requests which uses `latin1`. If you need an explicit encoding, pass encoded bytes explictly, e.g. `content=<str>.encode("latin1")`.
 
-For response bodies, assuming the server didn't send an explicit encoding then HTTPX will do its best to figure out an appropriate encoding. Unlike Requests which uses `chardet`, HTTPX relies on a plainer fallback strategy (basically attempt UTF-8, or use Windows 1252 as a fallback). This strategy should be robust enough to handle the vast majority of use cases.
+For response bodies, assuming the server didn't send an explicit encoding then HTTPX will do its best to figure out an appropriate encoding. Unlike Requests which uses the `chardet` library, HTTPX relies on a plainer fallback strategy (basically attempting UTF-8, or using Windows 1252 as a fallback). This strategy should be robust enough to handle the vast majority of use cases.
 
 ## Status Codes
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -31,6 +31,12 @@ httpx.post(..., data={"message": "Hello, world"})
 If you're using a type checking tool such as `mypy`, you'll see warnings issues if using test/byte content with the `data` argument.
 However, for compatibility reasons with `requests`, we do still handle the case where `data=...` is used with raw binary and text contents.
 
+## Content encoding
+
+HTTPX uses `utf-8` for encoding `str` request bodies. For example, when using `content=<str>` the request body will be encoded to `utf-8` before being sent over the wire. will This differs from Requests which uses `latin1`. If you need an explicit encoding, pass encoded bytes explictly, e.g. `content=<str>.encode("latin1")`.
+
+For response bodies, assuming the server didn't send an explicit encoding then HTTPX will do its best to figure out an appropriate encoding. Unlike Requests which uses `chardet`, HTTPX relies on a plainer fallback strategy (basically attempt UTF-8, or use Windows 1252 as a fallback). This strategy should be robust enough to handle the vast majority of use cases.
+
 ## Status Codes
 
 In our documentation we prefer the uppercased versions, such as `codes.NOT_FOUND`, but also provide lower-cased versions for API compatibility with `requests`.


### PR DESCRIPTION
Prompted by some discussion on Gitter:

A small addition to our Requests compatibility guide to discuss differences in request/response encodings.

Ideally the bulk of this should live in a "Discussions" section of the docs ("How does HTTPX deal with encodings?"), but until we have that then I guess it's okay to have this documented here. :-)

We do have a lengthy docstring in the code about this, but it's good to have some words in the public docs as well:

https://github.com/encode/httpx/blob/27df5e49c7a97a17f68862a3fa901c11e30a4b5a/httpx%2F_decoders.py#L248-L269