### PR TITLE
Updates compatibility guide to address event hooks

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -135,3 +135,14 @@ while request is not None:
     response = client.send(request, allow_redirects=False)
     request = response.next_request
 ```
+
+## Event Hooks
+
+`requests` allows event hooks to mutate `Request` and `Response` objects. See examples given in the documentation for `requests`: [link](https://requests.readthedocs.io/en/master/user/advanced/#event-hooks).
+
+In HTTPX, event hooks may access properties of requests and responses, but event hook callbacks cannot mutate the original request/response. 
+
+If you are looking for more control, consider checking out [Custom Transports](https://www.python-httpx.org/advanced/#custom-transports).
+
+
+

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -138,11 +138,8 @@ while request is not None:
 
 ## Event Hooks
 
-`requests` allows event hooks to mutate `Request` and `Response` objects. See examples given in the documentation for `requests`: [link](https://requests.readthedocs.io/en/master/user/advanced/#event-hooks).
+`requests` allows event hooks to mutate `Request` and `Response` objects. See [examples](https://requests.readthedocs.io/en/master/user/advanced/#event-hooks) given in the documentation for `requests`.
 
 In HTTPX, event hooks may access properties of requests and responses, but event hook callbacks cannot mutate the original request/response. 
 
-If you are looking for more control, consider checking out [Custom Transports](https://www.python-httpx.org/advanced/#custom-transports).
-
-
-
+If you are looking for more control, consider checking out [Custom Transports](advanced.md#custom-transports).


### PR DESCRIPTION
In `requests`, event hook callbacks can mutate response/request objects. In HTTPX, this is not the case.
Added text to address this difference, and added a link to the best alternate HTTPX offers in this circumstance.
 
More context:
https://github.com/encode/httpx/issues/1343#issuecomment-703223097