### PR TITLE
Update README to reflect new estimate for v1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ HTTPX is a fully featured HTTP client for Python 3, which provides sync and asyn
 
 **Note**: _HTTPX should be considered in beta. We believe we've got the public API to
 a stable point now, but would strongly recommend pinning your dependencies to the `0.16.*`
-release, so that you're able to properly review [API changes between package updates](https://github.com/encode/httpx/blob/master/CHANGELOG.md). A 1.0 release is expected to be issued sometime in late 2020._
+release, so that you're able to properly review [API changes between package updates](https://github.com/encode/httpx/blob/master/CHANGELOG.md). A 1.0 release is expected to be issued sometime in 2021._
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ HTTPX is a fully featured HTTP client for Python 3, which provides sync and asyn
 
     We believe we've got the public API to a stable point now, but would strongly recommend pinning your dependencies to the `0.16.*` release, so that you're able to properly review [API changes between package updates](https://github.com/encode/httpx/blob/master/CHANGELOG.md).
 
-    A 1.0 release is expected to be issued sometime in late 2020.
+    A 1.0 release is expected to be issued sometime in 2021.
 
 ---
 


### PR DESCRIPTION
Updating Note related to current beta state of project in `README.md`.   

New estimate for v1 release is set to `sometime in 2021`.