### PR TITLE
Allow handler to optionally be async when MockTransport is used with AsyncClient

### DIFF
--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -301,3 +301,16 @@ async def test_mounted_transport():
         response = await client.get("custom://www.example.com")
         assert response.status_code == 200
         assert response.json() == {"app": "mounted"}
+
+
+@pytest.mark.usefixtures("async_environment")
+async def test_async_mock_transport():
+    async def hello_world(request):
+        return httpx.Response(200, text="Hello, world!")
+
+    transport = httpx.MockTransport(hello_world)
+
+    async with httpx.AsyncClient(transport=transport) as client:
+        response = await client.get("https://www.example.com")
+        assert response.status_code == 200
+        assert response.text == "Hello, world!"


### PR DESCRIPTION
Prompted by https://github.com/encode/httpx/pull/1401#issuecomment-756465514

Allow usages like...

```python
async def hello_world(request):
    return httpx.Response(200, text="Hello, world!")

transport = httpx.MockTransport(hello_world)

async with httpx.AsyncClient(transport=transport) as client:
    response = await client.get("https://www.example.com")
    assert response.status_code == 200
    assert response.text == "Hello, world!"
```