### PR TITLE
Add Changelog link to PyPI page

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
     version=get_version("httpx"),
     url="https://github.com/encode/httpx",
     project_urls={
+        "Changelog": "https://github.com/encode/httpx/blob/master/CHANGELOG.md",
         "Documentation": "https://www.python-httpx.org",
         "Source": "https://github.com/encode/httpx",
     },


### PR DESCRIPTION
Makes it easy to find out about changes, and it gets a little "present" icon, for example https://pypi.org/project/django-linear-migrations/