### PR TITLE
map_exceptions in request.aclose()

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -1500,7 +1500,8 @@ class AsyncClient(BaseClient):
         async def on_close(response: Response) -> None:
             response.elapsed = datetime.timedelta(seconds=await timer.async_elapsed())
             if hasattr(stream, "aclose"):
-                await stream.aclose()
+                with map_exceptions(HTTPCORE_EXC_MAP, request=request):
+                    await stream.aclose()
 
         response = Response(
             status_code,

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -338,17 +338,15 @@ async def test_response_aclose_map_exceptions():
     import asyncio
 
     server = await asyncio.start_server(respond_then_die, "127.0.0.1")
-    assert server.sockets is not None
-    addr = server.sockets[0].getsockname()
-    host, port = addr
-
-    serving = asyncio.ensure_future(server.serve_forever())  # py3.6
     try:
+        assert server.sockets is not None
+        addr = server.sockets[0].getsockname()
+        host, port = addr
+
         async with httpx.AsyncClient() as client:
             async with client.stream("GET", f"http://{host}:{port}") as response:
                 with pytest.raises(httpx.CloseError):
                     await response.aclose()
     finally:
-        serving.cancel()
         server.close()
         await server.wait_closed()

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -338,15 +338,17 @@ async def test_response_aclose_map_exceptions():
     import asyncio
 
     server = await asyncio.start_server(respond_then_die, "127.0.0.1")
-    await server.start_serving()  # py3.6
+    assert server.sockets is not None
+    addr = server.sockets[0].getsockname()
+    host, port = addr
+
+    serving = asyncio.ensure_future(server.serve_forever())  # py3.6
     try:
-        assert server.sockets is not None
-        addr = server.sockets[0].getsockname()
-        host, port = addr
         async with httpx.AsyncClient() as client:
             async with client.stream("GET", f"http://{host}:{port}") as response:
                 with pytest.raises(httpx.CloseError):
                     await response.aclose()
     finally:
+        serving.cancel()
         server.close()
         await server.wait_closed()

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -307,7 +307,8 @@ async def test_mounted_transport():
 async def test_response_aclose_map_exceptions():
     class BrokenStream:
         async def __aiter__(self):
-            pass
+            # so we're an AsyncIterator
+            pass  # pragma: nocover
 
         async def aclose(self):
             raise httpcore.CloseError(OSError(104, "Connection reset by peer"))

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -307,7 +307,7 @@ async def test_mounted_transport():
 async def test_response_aclose_map_exceptions():
     class BrokenStream:
         async def __aiter__(self):
-            yield b""
+            pass
 
         async def aclose(self):
             raise httpcore.CloseError(OSError(104, "Connection reset by peer"))


### PR DESCRIPTION
Now, clients can catch an exception that occurs during close.

[closes #1463]