### PR TITLE
Handle default ports in WSGITransport

### DIFF
--- a/httpx/_transports/wsgi.py
+++ b/httpx/_transports/wsgi.py
@@ -87,7 +87,7 @@ class WSGITransport(httpcore.SyncHTTPTransport):
             "PATH_INFO": unquote(path.decode("ascii")),
             "QUERY_STRING": query.decode("ascii"),
             "SERVER_NAME": host.decode("ascii"),
-            "SERVER_PORT": str(port),
+            "SERVER_PORT": str(port or 80),
             "REMOTE_ADDR": self.remote_addr,
         }
         for header_key, header_value in headers:

--- a/httpx/_transports/wsgi.py
+++ b/httpx/_transports/wsgi.py
@@ -74,6 +74,9 @@ class WSGITransport(httpcore.SyncHTTPTransport):
 
         scheme, host, port, full_path = url
         path, _, query = full_path.partition(b"?")
+        if port is None:
+            port = {b"http": 80, b"https": 443}[scheme]
+
         environ = {
             "wsgi.version": (1, 0),
             "wsgi.url_scheme": scheme.decode("ascii"),
@@ -87,7 +90,7 @@ class WSGITransport(httpcore.SyncHTTPTransport):
             "PATH_INFO": unquote(path.decode("ascii")),
             "QUERY_STRING": query.decode("ascii"),
             "SERVER_NAME": host.decode("ascii"),
-            "SERVER_PORT": str(port or 80),
+            "SERVER_PORT": str(port),
             "REMOTE_ADDR": self.remote_addr,
         }
         for header_key, header_value in headers:


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-3333/#environ-variables

> SERVER_NAME, SERVER_PORT
> \---\---\---\---\---\---\---\---\---\---\---\---\---\---\---\---\---\---\---\---
> When HTTP_HOST is not set, these variables can be combined to determine a default. See the URL Reconstruction section below for more detail. SERVER_NAME and SERVER_PORT are required strings and must never be empty.

Fixed #1468