### PR TITLE
Explain SSL_CERT_DIR specific format

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -122,11 +122,9 @@ SSL_CERT_FILE=/path/to/ca-certs/ca-bundle.crt python -c "import httpx; httpx.get
 
 ## `SSL_CERT_DIR`
 
-Valid values: a directory
+Valid values: a directory following an [OpenSSL specific layout](https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html).
 
-If this environment variable is set then HTTPX will load
-CA certificates from the specified location instead of the default
-location.
+If this environment variable is set and the directory follows an [OpenSSL specific layout](https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html) (ie. you ran `c_rehash`) then HTTPX will load CA certificates from this directory instead of the default location.
 
 Example:
 


### PR DESCRIPTION
It's easy to believe that any .pem files there will get picked up automatically, but that's not the case. I've reused the link that the Python docs use in https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_verify_locations.

Quoting a coworker: "weird thing is that we tried to use `SSL_CERT_DIR` and it didn't work, but `SSL_CERT_FILE` did".