### PR TITLE
Fix docs syntax highlighting

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,7 +25,8 @@ nav:
 
 markdown_extensions:
   - admonition
-  - codehilite
+  - codehilite:
+      css_class: highlight
   - mkautodoc
 
 extra_css:


### PR DESCRIPTION
Right now our docs is broken wrt syntax highlighting: code blocks render as "plain text".

Turns out a fair bit has changed in the world `mkdocs-material` and Markdown extensions since we last deployed docs. MkDocs-Material went from 5.* to 7.*, and circa 6.2.* it seems to have migrated from `codehilite` to [Highlight](https://facelessuser.github.io/pymdown-extensions/extensions/highlight/) as their primary syntax highlighting engine. As a result the CSS class changed from `.codehilite` to `.highlight` — hence the fix in this PR to get code blocks highlighting back. :-)