### PR TITLE
Add support for response context manager interface

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -870,7 +870,7 @@ class Client(BaseClient):
             )
             try:
                 (status_code, headers, stream, ext) = raw_response
-            except ValueError:
+            except ValueError:  # pragma: no cover
                 response_ctx = cast_context_manager(raw_response)
                 (status_code, headers, stream, ext) = exit_stack.enter_context(
                     response_ctx
@@ -1522,7 +1522,7 @@ class AsyncClient(BaseClient):
             )
             try:
                 (status_code, headers, stream, ext) = await raw_response
-            except ValueError:
+            except ValueError:  # pragma: no cover
                 response_ctx = cast_async_context_manager(raw_response)
                 (
                     status_code,

--- a/httpx/_compat.py
+++ b/httpx/_compat.py
@@ -1,0 +1,9 @@
+try:
+    from contextlib import AsyncExitStack  # type: ignore  # Py3.6
+except ImportError:  # pragma: no cover
+    # Python 3.6
+    from async_exit_stack import AsyncExitstack  # type: ignore  # noqa: F401
+
+__all__ = [
+    "AsyncExitStack",
+]

--- a/httpx/_compat.py
+++ b/httpx/_compat.py
@@ -2,7 +2,7 @@ try:
     from contextlib import AsyncExitStack  # type: ignore  # Py3.6
 except ImportError:  # pragma: no cover
     # Python 3.6
-    from async_exit_stack import AsyncExitstack  # type: ignore  # noqa: F401
+    from async_exit_stack import AsyncExitStack  # type: ignore  # noqa: F401
 
 __all__ = [
     "AsyncExitStack",

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -19,6 +19,8 @@ from ._types import PrimitiveData
 if typing.TYPE_CHECKING:  # pragma: no cover
     from ._models import URL
 
+T = typing.TypeVar("T")
+
 
 _HTML5_FORM_ENCODING_REPLACEMENTS = {'"': "%22", "\\": "\\\\"}
 _HTML5_FORM_ENCODING_REPLACEMENTS.update(
@@ -539,3 +541,13 @@ class URLPattern:
 
 def warn_deprecated(message: str) -> None:  # pragma: nocover
     warnings.warn(message, DeprecationWarning, stacklevel=2)
+
+
+def cast_context_manager(value: T) -> typing.ContextManager[T]:
+    return value  # type: ignore
+
+
+def cast_async_context_manager(
+    value: typing.Awaitable[T],
+) -> typing.AsyncContextManager[T]:
+    return value  # type: ignore

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -543,11 +543,11 @@ def warn_deprecated(message: str) -> None:  # pragma: nocover
     warnings.warn(message, DeprecationWarning, stacklevel=2)
 
 
-def cast_context_manager(value: T) -> typing.ContextManager[T]:
+def cast_context_manager(value: T) -> typing.ContextManager[T]:  # pragma: no cover
     return value  # type: ignore
 
 
 def cast_async_context_manager(
     value: typing.Awaitable[T],
-) -> typing.AsyncContextManager[T]:
+) -> typing.AsyncContextManager[T]:  # pragma: no cover
     return value  # type: ignore

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,8 @@ setup(
         "sniffio",
         "rfc3986[idna2008]>=1.3,<2",
         "httpcore==0.12.*",
+        # Backports.
+        "async_exit_stack; python_version<'3.7'",
     ],
     extras_require={
         "http2": "h2==3.*",


### PR DESCRIPTION
Prompted by https://github.com/encode/httpx/pull/1355#issuecomment-787878698

This PR is now a plain refactor that adds support for HTTPCore returning context-managed responses, should we choose to move forward with https://github.com/encode/httpcore/pull/206.

This ends up basically being a re-issuing of #1341.

I know we discussed "let's just switch to context managers throughout the stack" (https://github.com/encode/httpx/pull/1341#issuecomment-704368692), but eventually all the changes in #1355 didn't seem to be worth the hassle to me. If all we want is to make the Transport API more resource-leak-safe, then it shouldn't change anything to HTTPX's API since we already handle resource closure properly here.

We could look at reorganizing things to use the context-managed interface more thoroughly _internally_ (to simplify a bunch of `try/except/finally` code around `close()` and `aclose()`), but all I'm saying is that it doesn't matter as far as compatibility with https://github.com/encode/httpcore/pull/206 is concerned.