### PR TITLE
Wildcard versions to ranges

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,11 +59,11 @@ setup(
         "certifi",
         "sniffio",
         "rfc3986[idna2008]>=1.3,<2",
-        "httpcore==0.12.*",
+        "httpcore>=0.12,<0.13",
     ],
     extras_require={
-        "http2": "h2==3.*",
-        "brotli": "brotlipy==0.7.*",
+        "http2": "h2>=3,<4",
+        "brotli": "brotlipy>=0.7,<0.8*",
     },
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     ],
     extras_require={
         "http2": "h2>=3,<4",
-        "brotli": "brotlipy>=0.7,<0.8*",
+        "brotli": "brotlipy>=0.7,<0.8",
     },
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Using wildcards causes `pip` to retrieve all versions that match that pattern, then compare all dependencies against each of those versions.

When there are multiple dependencies doing that, it becomes a multiplicative comparison.

Example I just ran into:
- 3 versions of `httpcore` matching `0.12.*`
- 8 versions of `h11` matching `0.*` pulled in as secondaries
- 4 versions of `h2` matching `3.*` pulled in as secondaries

This produces `3 * 8 * 4 = 96` sets of dependencies to check for compatibility. Pip actually came up with this warning:
```log
INFO: pip is looking at multiple versions of httpcore to determine which version is compatible with other requirements. This could take a while.
INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. If you want to abort this run, you can press Ctrl + C to do so. To improve how pip performs, tell us what happened here: https://pip.pypa.io/surveys/backtracking
```

This patch changes from wildcard to range, which `pip` will treat as `use the latest that works, try older if it doesn't`