### PR TITLE
Incompatible with httpcore 0.12.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         "certifi",
         "sniffio",
         "rfc3986[idna2008]>=1.3,<2",
-        "httpcore==0.12.*",
+        "httpcore>=0.12.1,<0.13",
     ],
     extras_require={
         "http2": "h2==3.*",


### PR DESCRIPTION
The version 0.12.0 of httpcore is not compatible. When this version is installed, all the tests using `httpx.Client()` will fail with the following error

`AttributeError: 'Client' object has no attribute '_transport'`