### PR TITLE
Added `httpx.BaseTransport` and `httpx.AsyncBaseTransport`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 0.17.1
+## Master
+
+The 0.18.x release series formalises our low-level Transport API, introducing the
+base classes `httpx.BaseTransport` and `httpx.AsyncBaseTransport`.
+
+* Transport instances now inherit from `httpx.BaseTransport` or `httpx.AsyncBaseTransport`,
+  and should implement either the `handle_request` method or `handle_async_request` method.
+* The `response.ext` property and `Response(ext=...)` argument are now named `extensions`.
+
+## 0.17.1 (March 15th, 2021)
 
 ### Fixed
 
 * Type annotation on `CertTypes` allows `keyfile` and `password` to be optional. (Pull #1503)
 * Fix httpcore pinned version. (Pull #1495)
 
-## 0.17.0
+## 0.17.0 (Februray 28th, 2021)
 
 ### Added
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1041,13 +1041,13 @@ class HelloWorldTransport(httpx.BaseTransport):
     A mock transport that always returns a JSON "Hello, world!" response.
     """
 
-    def handle_request(self, method, url, headers=None, stream=None, ext=None):
+    def handle_request(self, method, url, headers=None, stream=None, extensions=None):
         message = {"text": "Hello, world!"}
         content = json.dumps(message).encode("utf-8")
         stream = [content]
         headers = [(b"content-type", b"application/json")]
-        ext = {"http_version": "HTTP/1.1"}
-        return 200, headers, stream, ext
+        extensions = {"http_version": "HTTP/1.1"}
+        return 200, headers, stream, extensions
 ```
 
 Which we can use in the same way:
@@ -1099,7 +1099,7 @@ class HTTPSRedirectTransport(httpx.BaseTransport):
     A transport that always redirects to HTTPS.
     """
 
-    def handle_request(self, method, url, headers=None, stream=None, ext=None):
+    def handle_request(self, method, url, headers=None, stream=None, extensions=None):
         scheme, host, port, path = url
         if port is None:
             location = b"https://%s%s" % (host, path)
@@ -1107,7 +1107,7 @@ class HTTPSRedirectTransport(httpx.BaseTransport):
             location = b"https://%s:%d%s" % (host, port, path)
         stream = [b""]
         headers = [(b"location", location)]
-        ext = {"http_version": "HTTP/1.1"}
+        extensions = {"http_version": "HTTP/1.1"}
         return 303, headers, stream, ext
 
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1084,10 +1084,9 @@ which transport an outgoing request should be routed via, with [the same style
 used for specifying proxy routing](#routing).
 
 ```python
-import httpcore
 import httpx
 
-class HTTPSRedirectTransport(httpcore.SyncHTTPTransport):
+class HTTPSRedirectTransport(httpx.BaseTransport):
     """
     A transport that always redirects to HTTPS.
     """
@@ -1098,7 +1097,7 @@ class HTTPSRedirectTransport(httpcore.SyncHTTPTransport):
             location = b"https://%s%s" % (host, path)
         else:
             location = b"https://%s:%d%s" % (host, port, path)
-        stream = httpcore.PlainByteStream(b"")
+        stream = [b""]
         headers = [(b"location", location)]
         ext = {"http_version": b"HTTP/1.1"}
         return 303, headers, stream, ext

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1015,20 +1015,20 @@ This [public gist](https://gist.github.com/florimondmanca/d56764d78d748eb9f73165
 
 ### Writing custom transports
 
-A transport instance must implement the Transport API defined by
-[`httpcore`](https://www.encode.io/httpcore/api/). You
-should either subclass `httpcore.AsyncHTTPTransport` to implement a transport to
-use with `AsyncClient`, or subclass `httpcore.SyncHTTPTransport` to implement a
-transport to use with `Client`.
+A transport instance must implement the low-level Transport API, which deals
+with sending a single request, and returning a response. You should either
+subclass `httpx.BaseTransport` to implement a transport to use with `Client`,
+or subclass `httpx.AsyncBaseTransport` to implement a transport to
+use with `AsyncClient`.
 
 A complete example of a custom transport implementation would be:
 
 ```python
 import json
-import httpcore
+import httpx
 
 
-class HelloWorldTransport(httpcore.SyncHTTPTransport):
+class HelloWorldTransport(httpx.BaseTransport):
     """
     A mock transport that always returns a JSON "Hello, world!" response.
     """
@@ -1036,7 +1036,7 @@ class HelloWorldTransport(httpcore.SyncHTTPTransport):
     def request(self, method, url, headers=None, stream=None, ext=None):
         message = {"text": "Hello, world!"}
         content = json.dumps(message).encode("utf-8")
-        stream = httpcore.PlainByteStream(content)
+        stream = [content]
         headers = [(b"content-type", b"application/json")]
         ext = {"http_version": b"HTTP/1.1"}
         return 200, headers, stream, ext

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1046,7 +1046,7 @@ class HelloWorldTransport(httpx.BaseTransport):
         content = json.dumps(message).encode("utf-8")
         stream = [content]
         headers = [(b"content-type", b"application/json")]
-        extensions = {"http_version": "HTTP/1.1"}
+        extensions = {}
         return 200, headers, stream, extensions
 ```
 
@@ -1107,7 +1107,7 @@ class HTTPSRedirectTransport(httpx.BaseTransport):
             location = b"https://%s:%d%s" % (host, port, path)
         stream = [b""]
         headers = [(b"location", location)]
-        extensions = {"http_version": "HTTP/1.1"}
+        extensions = {}
         return 303, headers, stream, ext
 
 

--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -36,6 +36,7 @@ from ._exceptions import (
 from ._models import URL, Cookies, Headers, QueryParams, Request, Response
 from ._status_codes import StatusCode, codes
 from ._transports.asgi import ASGITransport
+from ._transports.base import AsyncBaseTransport, BaseTransport
 from ._transports.default import AsyncHTTPTransport, HTTPTransport
 from ._transports.mock import MockTransport
 from ._transports.wsgi import WSGITransport
@@ -45,9 +46,11 @@ __all__ = [
     "__title__",
     "__version__",
     "ASGITransport",
+    "AsyncBaseTransport",
     "AsyncClient",
     "AsyncHTTPTransport",
     "Auth",
+    "BaseTransport",
     "BasicAuth",
     "Client",
     "CloseError",

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -850,12 +850,12 @@ class Client(BaseClient):
         timer.sync_start()
 
         with map_exceptions(HTTPCORE_EXC_MAP, request=request):
-            (status_code, headers, stream, ext) = transport.request(
+            (status_code, headers, stream, extensions) = transport.handle_request(
                 request.method.encode(),
                 request.url.raw,
                 headers=request.headers.raw,
                 stream=request.stream,  # type: ignore
-                ext={"timeout": timeout.as_dict()},
+                extensions={"timeout": timeout.as_dict()},
             )
 
         def on_close(response: Response) -> None:
@@ -867,7 +867,7 @@ class Client(BaseClient):
             status_code,
             headers=headers,
             stream=stream,  # type: ignore
-            ext=ext,
+            extensions=extensions,
             request=request,
             on_close=on_close,
         )
@@ -1484,12 +1484,17 @@ class AsyncClient(BaseClient):
         await timer.async_start()
 
         with map_exceptions(HTTPCORE_EXC_MAP, request=request):
-            (status_code, headers, stream, ext) = await transport.arequest(
+            (
+                status_code,
+                headers,
+                stream,
+                extensions,
+            ) = await transport.handle_async_request(
                 request.method.encode(),
                 request.url.raw,
                 headers=request.headers.raw,
                 stream=request.stream,  # type: ignore
-                ext={"timeout": timeout.as_dict()},
+                extensions={"timeout": timeout.as_dict()},
             )
 
         async def on_close(response: Response) -> None:
@@ -1502,7 +1507,7 @@ class AsyncClient(BaseClient):
             status_code,
             headers=headers,
             stream=stream,  # type: ignore
-            ext=ext,
+            extensions=extensions,
             request=request,
             on_close=on_close,
         )

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -902,7 +902,7 @@ class Response:
         json: typing.Any = None,
         stream: ByteStream = None,
         request: Request = None,
-        ext: dict = None,
+        extensions: dict = None,
         history: typing.List["Response"] = None,
         on_close: typing.Callable = None,
     ):
@@ -917,7 +917,7 @@ class Response:
 
         self.call_next: typing.Optional[typing.Callable] = None
 
-        self.ext = {} if ext is None else ext
+        self.extensions = {} if extensions is None else extensions
         self.history = [] if history is None else list(history)
         self._on_close = on_close
 
@@ -988,11 +988,11 @@ class Response:
 
     @property
     def http_version(self) -> str:
-        return self.ext.get("http_version", "HTTP/1.1")
+        return self.extensions.get("http_version", "HTTP/1.1")
 
     @property
     def reason_phrase(self) -> str:
-        return self.ext.get("reason", codes.get_reason_phrase(self.status_code))
+        return self.extensions.get("reason", codes.get_reason_phrase(self.status_code))
 
     @property
     def url(self) -> typing.Optional[URL]:

--- a/httpx/_transports/asgi.py
+++ b/httpx/_transports/asgi.py
@@ -70,13 +70,13 @@ class ASGITransport(AsyncBaseTransport):
         self.root_path = root_path
         self.client = client
 
-    async def arequest(
+    async def handle_async_request(
         self,
         method: bytes,
         url: Tuple[bytes, bytes, Optional[int], bytes],
         headers: List[Tuple[bytes, bytes]] = None,
         stream: typing.AsyncIterator[bytes] = None,
-        ext: dict = None,
+        extensions: dict = None,
     ) -> Tuple[int, List[Tuple[bytes, bytes]], typing.AsyncIterator[bytes], dict]:
         headers = [] if headers is None else headers
 
@@ -163,6 +163,6 @@ class ASGITransport(AsyncBaseTransport):
         async def response_stream() -> typing.AsyncIterator[bytes]:
             yield b"".join(body_parts)
 
-        ext = {}
+        extensions = {}
 
-        return (status_code, response_headers, response_stream(), ext)
+        return (status_code, response_headers, response_stream(), extensions)

--- a/httpx/_transports/base.py
+++ b/httpx/_transports/base.py
@@ -21,9 +21,9 @@ class BaseTransport:
         self,
         method: bytes,
         url: typing.Tuple[bytes, bytes, typing.Optional[int], bytes],
-        headers: typing.List[typing.Tuple[bytes, bytes]] = None,
-        stream: typing.Iterator[bytes] = None,
-        extensions: dict = None,
+        headers: typing.List[typing.Tuple[bytes, bytes]],
+        stream: typing.Iterator[bytes],
+        extensions: dict,
     ) -> typing.Tuple[
         int, typing.List[typing.Tuple[bytes, bytes]], typing.Iterator[bytes], dict
     ]:
@@ -111,9 +111,9 @@ class AsyncBaseTransport:
         self,
         method: bytes,
         url: typing.Tuple[bytes, bytes, typing.Optional[int], bytes],
-        headers: typing.List[typing.Tuple[bytes, bytes]] = None,
-        stream: typing.AsyncIterator[bytes] = None,
-        extensions: dict = None,
+        headers: typing.List[typing.Tuple[bytes, bytes]],
+        stream: typing.AsyncIterator[bytes],
+        extensions: dict,
     ) -> typing.Tuple[
         int, typing.List[typing.Tuple[bytes, bytes]], typing.AsyncIterator[bytes], dict
     ]:

--- a/httpx/_transports/base.py
+++ b/httpx/_transports/base.py
@@ -55,10 +55,10 @@ class BaseTransport:
         stream: The response body as a bytes iterator.
         extensions: An open ended dictionary, including optional extensions to the
                     core request/response API. Keys are plain strings, and may include:
-            reason: The textual portion of the status code, as a string. Eg 'OK'.
+            reason: The reason-phrase of the HTTP response, as bytes. Eg 'OK'.
                     HTTP/2 onwards does not include a reason phrase on the wire.
-                    When no reason key is included, a default based on the status code
-                    may be used. An empty-string reason phrase should not be substituted
+                    When no key is included, a default based on the status code may
+                    be used. An empty-string reason phrase should not be substituted
                     for a default, as it indicates the server left the portion blank
                     eg. the leading response bytes were b"HTTP/1.1 200 <CRLF>".
             http_version: The HTTP version, as a string. Eg. "HTTP/1.1".

--- a/httpx/_transports/base.py
+++ b/httpx/_transports/base.py
@@ -35,6 +35,29 @@ class BaseTransport:
         of cut-off provides a clear design seperation between the HTTPX API,
         and the low-level network handling.
 
+        Developers shouldn't typically ever need to call into this API directly,
+        since the Client class provides all the higher level user-facing API
+        niceties.
+
+        Example usage:
+
+            with httpx.HTTPTransport() as transport:
+                status_code, headers, stream, extensions = transport.handle_request(
+                    method=b'GET',
+                    url=(b'https', b'www.example.com', 443, b'/'),
+                    headers=[(b'Host', b'www.example.com')],
+                    stream=[],
+                    extensions={}
+                )
+                try:
+                    body = b''.join([part for part in stream])
+                finally:
+                    if hasattr(stream 'close'):
+                        stream.close()
+                print(status_code, headers, body)
+
+        Arguments:
+
         method: The request method as bytes. Eg. b'GET'.
         url: The components of the request URL, as a tuple of `(scheme, host, port, target)`.
              The target will usually be the URL path, but also allows for alternative

--- a/httpx/_transports/base.py
+++ b/httpx/_transports/base.py
@@ -15,7 +15,7 @@ class BaseTransport:
         exc_value: BaseException = None,
         traceback: TracebackType = None,
     ) -> None:
-        pass
+        self.close()
 
     def request(
         self,
@@ -27,7 +27,9 @@ class BaseTransport:
     ) -> typing.Tuple[
         int, typing.List[typing.Tuple[bytes, bytes]], typing.Iterator[bytes], dict
     ]:
-        pass
+        raise NotImplementedError(
+            "The 'request' method must be implemented."
+        )  # pragma: nocover
 
     def close(self) -> None:
         pass
@@ -43,7 +45,7 @@ class AsyncBaseTransport:
         exc_value: BaseException = None,
         traceback: TracebackType = None,
     ) -> None:
-        pass
+        await self.aclose()
 
     async def arequest(
         self,
@@ -55,7 +57,9 @@ class AsyncBaseTransport:
     ) -> typing.Tuple[
         int, typing.List[typing.Tuple[bytes, bytes]], typing.AsyncIterator[bytes], dict
     ]:
-        pass
+        raise NotImplementedError(
+            "The 'arequest' method must be implemented."
+        )  # pragma: nocover
 
     async def aclose(self) -> None:
         pass

--- a/httpx/_transports/base.py
+++ b/httpx/_transports/base.py
@@ -1,0 +1,61 @@
+import typing
+from types import TracebackType
+
+T = typing.TypeVar("T", bound="BaseTransport")
+A = typing.TypeVar("A", bound="AsyncBaseTransport")
+
+
+class BaseTransport:
+    def __enter__(self: T) -> T:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: typing.Type[BaseException] = None,
+        exc_value: BaseException = None,
+        traceback: TracebackType = None,
+    ) -> None:
+        pass
+
+    def request(
+        self,
+        method: bytes,
+        url: typing.Tuple[bytes, bytes, typing.Optional[int], bytes],
+        headers: typing.List[typing.Tuple[bytes, bytes]] = None,
+        stream: typing.Iterator[bytes] = None,
+        ext: dict = None,
+    ) -> typing.Tuple[
+        int, typing.List[typing.Tuple[bytes, bytes]], typing.Iterator[bytes], dict
+    ]:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+class AsyncBaseTransport:
+    async def __aenter__(self: A) -> A:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: typing.Type[BaseException] = None,
+        exc_value: BaseException = None,
+        traceback: TracebackType = None,
+    ) -> None:
+        pass
+
+    async def arequest(
+        self,
+        method: bytes,
+        url: typing.Tuple[bytes, bytes, typing.Optional[int], bytes],
+        headers: typing.List[typing.Tuple[bytes, bytes]] = None,
+        stream: typing.AsyncIterator[bytes] = None,
+        ext: dict = None,
+    ) -> typing.Tuple[
+        int, typing.List[typing.Tuple[bytes, bytes]], typing.AsyncIterator[bytes], dict
+    ]:
+        pass
+
+    async def aclose(self) -> None:
+        pass

--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -94,9 +94,9 @@ class HTTPTransport(BaseTransport):
         self,
         method: bytes,
         url: typing.Tuple[bytes, bytes, typing.Optional[int], bytes],
-        headers: typing.List[typing.Tuple[bytes, bytes]] = None,
-        stream: typing.Iterator[bytes] = None,
-        extensions: dict = None,
+        headers: typing.List[typing.Tuple[bytes, bytes]],
+        stream: typing.Iterator[bytes],
+        extensions: dict,
     ) -> typing.Tuple[
         int, typing.List[typing.Tuple[bytes, bytes]], typing.Iterator[bytes], dict
     ]:
@@ -163,9 +163,9 @@ class AsyncHTTPTransport(AsyncBaseTransport):
         self,
         method: bytes,
         url: typing.Tuple[bytes, bytes, typing.Optional[int], bytes],
-        headers: typing.List[typing.Tuple[bytes, bytes]] = None,
-        stream: typing.AsyncIterator[bytes] = None,
-        extensions: dict = None,
+        headers: typing.List[typing.Tuple[bytes, bytes]],
+        stream: typing.AsyncIterator[bytes],
+        extensions: dict,
     ) -> typing.Tuple[
         int, typing.List[typing.Tuple[bytes, bytes]], typing.AsyncIterator[bytes], dict
     ]:

--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -31,6 +31,7 @@ import httpcore
 
 from .._config import DEFAULT_LIMITS, Limits, Proxy, create_ssl_context
 from .._types import CertTypes, VerifyTypes
+from .base import AsyncBaseTransport, BaseTransport
 
 T = typing.TypeVar("T", bound="HTTPTransport")
 A = typing.TypeVar("A", bound="AsyncHTTPTransport")
@@ -38,7 +39,7 @@ Headers = typing.List[typing.Tuple[bytes, bytes]]
 URL = typing.Tuple[bytes, bytes, typing.Optional[int], bytes]
 
 
-class HTTPTransport(httpcore.SyncHTTPTransport):
+class HTTPTransport(BaseTransport):
     def __init__(
         self,
         verify: VerifyTypes = True,
@@ -96,16 +97,16 @@ class HTTPTransport(httpcore.SyncHTTPTransport):
         method: bytes,
         url: URL,
         headers: Headers = None,
-        stream: httpcore.SyncByteStream = None,
+        stream: typing.Iterator[bytes] = None,
         ext: dict = None,
-    ) -> typing.Tuple[int, Headers, httpcore.SyncByteStream, dict]:
-        return self._pool.request(method, url, headers=headers, stream=stream, ext=ext)
+    ) -> typing.Tuple[int, Headers, typing.Iterator[bytes], dict]:
+        return self._pool.request(method, url, headers=headers, stream=stream, ext=ext)  # type: ignore
 
     def close(self) -> None:
         self._pool.close()
 
 
-class AsyncHTTPTransport(httpcore.AsyncHTTPTransport):
+class AsyncHTTPTransport(AsyncBaseTransport):
     def __init__(
         self,
         verify: VerifyTypes = True,
@@ -163,11 +164,11 @@ class AsyncHTTPTransport(httpcore.AsyncHTTPTransport):
         method: bytes,
         url: URL,
         headers: Headers = None,
-        stream: httpcore.AsyncByteStream = None,
+        stream: typing.AsyncIterator[bytes] = None,
         ext: dict = None,
-    ) -> typing.Tuple[int, Headers, httpcore.AsyncByteStream, dict]:
-        return await self._pool.arequest(
-            method, url, headers=headers, stream=stream, ext=ext
+    ) -> typing.Tuple[int, Headers, typing.AsyncIterator[bytes], dict]:
+        return await self._pool.arequest(  # type: ignore
+            method, url, headers=headers, stream=stream, ext=ext  # type: ignore
         )
 
     async def aclose(self) -> None:

--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -35,8 +35,6 @@ from .base import AsyncBaseTransport, BaseTransport
 
 T = typing.TypeVar("T", bound="HTTPTransport")
 A = typing.TypeVar("A", bound="AsyncHTTPTransport")
-Headers = typing.List[typing.Tuple[bytes, bytes]]
-URL = typing.Tuple[bytes, bytes, typing.Optional[int], bytes]
 
 
 class HTTPTransport(BaseTransport):
@@ -92,15 +90,17 @@ class HTTPTransport(BaseTransport):
     ) -> None:
         self._pool.__exit__(exc_type, exc_value, traceback)
 
-    def request(
+    def handle_request(
         self,
         method: bytes,
-        url: URL,
-        headers: Headers = None,
+        url: typing.Tuple[bytes, bytes, typing.Optional[int], bytes],
+        headers: typing.List[typing.Tuple[bytes, bytes]] = None,
         stream: typing.Iterator[bytes] = None,
-        ext: dict = None,
-    ) -> typing.Tuple[int, Headers, typing.Iterator[bytes], dict]:
-        return self._pool.request(method, url, headers=headers, stream=stream, ext=ext)  # type: ignore
+        extensions: dict = None,
+    ) -> typing.Tuple[
+        int, typing.List[typing.Tuple[bytes, bytes]], typing.Iterator[bytes], dict
+    ]:
+        return self._pool.request(method, url, headers=headers, stream=stream, ext=extensions)  # type: ignore
 
     def close(self) -> None:
         self._pool.close()
@@ -159,16 +159,18 @@ class AsyncHTTPTransport(AsyncBaseTransport):
     ) -> None:
         await self._pool.__aexit__(exc_type, exc_value, traceback)
 
-    async def arequest(
+    async def handle_async_request(
         self,
         method: bytes,
-        url: URL,
-        headers: Headers = None,
+        url: typing.Tuple[bytes, bytes, typing.Optional[int], bytes],
+        headers: typing.List[typing.Tuple[bytes, bytes]] = None,
         stream: typing.AsyncIterator[bytes] = None,
-        ext: dict = None,
-    ) -> typing.Tuple[int, Headers, typing.AsyncIterator[bytes], dict]:
+        extensions: dict = None,
+    ) -> typing.Tuple[
+        int, typing.List[typing.Tuple[bytes, bytes]], typing.AsyncIterator[bytes], dict
+    ]:
         return await self._pool.arequest(  # type: ignore
-            method, url, headers=headers, stream=stream, ext=ext  # type: ignore
+            method, url, headers=headers, stream=stream, ext=extensions  # type: ignore
         )
 
     async def aclose(self) -> None:

--- a/httpx/_transports/mock.py
+++ b/httpx/_transports/mock.py
@@ -10,13 +10,13 @@ class MockTransport(AsyncBaseTransport, BaseTransport):
     def __init__(self, handler: Callable) -> None:
         self.handler = handler
 
-    def request(
+    def handle_request(
         self,
         method: bytes,
         url: Tuple[bytes, bytes, Optional[int], bytes],
         headers: List[Tuple[bytes, bytes]] = None,
         stream: typing.Iterator[bytes] = None,
-        ext: dict = None,
+        extensions: dict = None,
     ) -> Tuple[int, List[Tuple[bytes, bytes]], typing.Iterator[bytes], dict]:
         request = Request(
             method=method,
@@ -30,16 +30,16 @@ class MockTransport(AsyncBaseTransport, BaseTransport):
             response.status_code,
             response.headers.raw,
             response.stream,
-            response.ext,
+            response.extensions,
         )
 
-    async def arequest(
+    async def handle_async_request(
         self,
         method: bytes,
         url: Tuple[bytes, bytes, Optional[int], bytes],
         headers: List[Tuple[bytes, bytes]] = None,
         stream: typing.AsyncIterator[bytes] = None,
-        ext: dict = None,
+        extensions: dict = None,
     ) -> Tuple[int, List[Tuple[bytes, bytes]], typing.AsyncIterator[bytes], dict]:
         request = Request(
             method=method,
@@ -63,5 +63,5 @@ class MockTransport(AsyncBaseTransport, BaseTransport):
             response.status_code,
             response.headers.raw,
             response.stream,
-            response.ext,
+            response.extensions,
         )

--- a/httpx/_transports/mock.py
+++ b/httpx/_transports/mock.py
@@ -1,12 +1,12 @@
 import asyncio
+import typing
 from typing import Callable, List, Optional, Tuple
 
-import httpcore
-
 from .._models import Request
+from .base import AsyncBaseTransport, BaseTransport
 
 
-class MockTransport(httpcore.SyncHTTPTransport, httpcore.AsyncHTTPTransport):
+class MockTransport(AsyncBaseTransport, BaseTransport):
     def __init__(self, handler: Callable) -> None:
         self.handler = handler
 
@@ -15,9 +15,9 @@ class MockTransport(httpcore.SyncHTTPTransport, httpcore.AsyncHTTPTransport):
         method: bytes,
         url: Tuple[bytes, bytes, Optional[int], bytes],
         headers: List[Tuple[bytes, bytes]] = None,
-        stream: httpcore.SyncByteStream = None,
+        stream: typing.Iterator[bytes] = None,
         ext: dict = None,
-    ) -> Tuple[int, List[Tuple[bytes, bytes]], httpcore.SyncByteStream, dict]:
+    ) -> Tuple[int, List[Tuple[bytes, bytes]], typing.Iterator[bytes], dict]:
         request = Request(
             method=method,
             url=url,
@@ -38,9 +38,9 @@ class MockTransport(httpcore.SyncHTTPTransport, httpcore.AsyncHTTPTransport):
         method: bytes,
         url: Tuple[bytes, bytes, Optional[int], bytes],
         headers: List[Tuple[bytes, bytes]] = None,
-        stream: httpcore.AsyncByteStream = None,
+        stream: typing.AsyncIterator[bytes] = None,
         ext: dict = None,
-    ) -> Tuple[int, List[Tuple[bytes, bytes]], httpcore.AsyncByteStream, dict]:
+    ) -> Tuple[int, List[Tuple[bytes, bytes]], typing.AsyncIterator[bytes], dict]:
         request = Request(
             method=method,
             url=url,

--- a/httpx/_transports/mock.py
+++ b/httpx/_transports/mock.py
@@ -14,9 +14,9 @@ class MockTransport(AsyncBaseTransport, BaseTransport):
         self,
         method: bytes,
         url: Tuple[bytes, bytes, Optional[int], bytes],
-        headers: List[Tuple[bytes, bytes]] = None,
-        stream: typing.Iterator[bytes] = None,
-        extensions: dict = None,
+        headers: List[Tuple[bytes, bytes]],
+        stream: typing.Iterator[bytes],
+        extensions: dict,
     ) -> Tuple[int, List[Tuple[bytes, bytes]], typing.Iterator[bytes], dict]:
         request = Request(
             method=method,
@@ -37,9 +37,9 @@ class MockTransport(AsyncBaseTransport, BaseTransport):
         self,
         method: bytes,
         url: Tuple[bytes, bytes, Optional[int], bytes],
-        headers: List[Tuple[bytes, bytes]] = None,
-        stream: typing.AsyncIterator[bytes] = None,
-        extensions: dict = None,
+        headers: List[Tuple[bytes, bytes]],
+        stream: typing.AsyncIterator[bytes],
+        extensions: dict,
     ) -> Tuple[int, List[Tuple[bytes, bytes]], typing.AsyncIterator[bytes], dict]:
         request = Request(
             method=method,

--- a/httpx/_transports/wsgi.py
+++ b/httpx/_transports/wsgi.py
@@ -63,14 +63,13 @@ class WSGITransport(BaseTransport):
         self,
         method: bytes,
         url: typing.Tuple[bytes, bytes, typing.Optional[int], bytes],
-        headers: typing.List[typing.Tuple[bytes, bytes]] = None,
-        stream: typing.Iterator[bytes] = None,
-        extensions: dict = None,
+        headers: typing.List[typing.Tuple[bytes, bytes]],
+        stream: typing.Iterator[bytes],
+        extensions: dict,
     ) -> typing.Tuple[
         int, typing.List[typing.Tuple[bytes, bytes]], typing.Iterator[bytes], dict
     ]:
-        headers = [] if headers is None else headers
-        wsgi_input = io.BytesIO() if stream is None else io.BytesIO(b"".join(stream))
+        wsgi_input = io.BytesIO(b"".join(stream))
 
         scheme, host, port, full_path = url
         path, _, query = full_path.partition(b"?")

--- a/httpx/_transports/wsgi.py
+++ b/httpx/_transports/wsgi.py
@@ -59,13 +59,13 @@ class WSGITransport(BaseTransport):
         self.script_name = script_name
         self.remote_addr = remote_addr
 
-    def request(
+    def handle_request(
         self,
         method: bytes,
         url: typing.Tuple[bytes, bytes, typing.Optional[int], bytes],
         headers: typing.List[typing.Tuple[bytes, bytes]] = None,
         stream: typing.Iterator[bytes] = None,
-        ext: dict = None,
+        extensions: dict = None,
     ) -> typing.Tuple[
         int, typing.List[typing.Tuple[bytes, bytes]], typing.Iterator[bytes], dict
     ]:
@@ -126,6 +126,6 @@ class WSGITransport(BaseTransport):
             (key.encode("ascii"), value.encode("ascii"))
             for key, value in seen_response_headers
         ]
-        ext = {}
+        extensions = {}
 
-        return (status_code, headers, result, ext)
+        return (status_code, headers, result, extensions)

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -169,12 +169,12 @@ async def test_100_continue(server):
 
 @pytest.mark.usefixtures("async_environment")
 async def test_context_managed_transport():
-    class Transport(httpcore.AsyncHTTPTransport):
+    class Transport(httpx.AsyncBaseTransport):
         def __init__(self):
             self.events = []
 
         async def aclose(self):
-            # The base implementation of httpcore.AsyncHTTPTransport just
+            # The base implementation of httpx.AsyncBaseTransport just
             # calls into `.aclose`, so simple transport cases can just override
             # this method for any cleanup, where more complex cases
             # might want to additionally override `__aenter__`/`__aexit__`.
@@ -201,13 +201,13 @@ async def test_context_managed_transport():
 
 @pytest.mark.usefixtures("async_environment")
 async def test_context_managed_transport_and_mount():
-    class Transport(httpcore.AsyncHTTPTransport):
+    class Transport(httpx.AsyncBaseTransport):
         def __init__(self, name: str):
             self.name: str = name
             self.events: typing.List[str] = []
 
         async def aclose(self):
-            # The base implementation of httpcore.AsyncHTTPTransport just
+            # The base implementation of httpx.AsyncBaseTransport just
             # calls into `.aclose`, so simple transport cases can just override
             # this method for any cleanup, where more complex cases
             # might want to additionally override `__aenter__`/`__aexit__`.

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1,7 +1,6 @@
 import typing
 from datetime import timedelta
 
-import httpcore
 import pytest
 
 import httpx
@@ -218,12 +217,12 @@ def test_pool_limits_deprecated():
 
 
 def test_context_managed_transport():
-    class Transport(httpcore.SyncHTTPTransport):
+    class Transport(httpx.BaseTransport):
         def __init__(self):
             self.events = []
 
         def close(self):
-            # The base implementation of httpcore.SyncHTTPTransport just
+            # The base implementation of httpx.BaseTransport just
             # calls into `.close`, so simple transport cases can just override
             # this method for any cleanup, where more complex cases
             # might want to additionally override `__enter__`/`__exit__`.
@@ -249,13 +248,13 @@ def test_context_managed_transport():
 
 
 def test_context_managed_transport_and_mount():
-    class Transport(httpcore.SyncHTTPTransport):
+    class Transport(httpx.BaseTransport):
         def __init__(self, name: str):
             self.name: str = name
             self.events: typing.List[str] = []
 
         def close(self):
-            # The base implementation of httpcore.SyncHTTPTransport just
+            # The base implementation of httpx.BaseTransport just
             # calls into `.close`, so simple transport cases can just override
             # this method for any cleanup, where more complex cases
             # might want to additionally override `__enter__`/`__exit__`.

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -71,6 +71,30 @@ async def raise_exc_after_response(scope, receive, send):
 
 
 @pytest.mark.usefixtures("async_environment")
+async def test_asgi_transport():
+    async with httpx.ASGITransport(app=hello_world) as transport:
+        status_code, headers, stream, ext = await transport.arequest(
+            b"GET", (b"http", b"www.example.org", 80, b"/")
+        )
+        body = b"".join([part async for part in stream])
+
+        assert status_code == 200
+        assert body == b"Hello, World!"
+
+
+@pytest.mark.usefixtures("async_environment")
+async def test_asgi_transport_no_body():
+    async with httpx.ASGITransport(app=echo_body) as transport:
+        status_code, headers, stream, ext = await transport.arequest(
+            b"GET", (b"http", b"www.example.org", 80, b"/")
+        )
+        body = b"".join([part async for part in stream])
+
+        assert status_code == 200
+        assert body == b""
+
+
+@pytest.mark.usefixtures("async_environment")
 async def test_asgi():
     async with httpx.AsyncClient(app=hello_world) as client:
         response = await client.get("http://www.example.org/")

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -73,7 +73,7 @@ async def raise_exc_after_response(scope, receive, send):
 @pytest.mark.usefixtures("async_environment")
 async def test_asgi_transport():
     async with httpx.ASGITransport(app=hello_world) as transport:
-        status_code, headers, stream, ext = await transport.arequest(
+        status_code, headers, stream, ext = await transport.handle_async_request(
             b"GET", (b"http", b"www.example.org", 80, b"/")
         )
         body = b"".join([part async for part in stream])
@@ -85,7 +85,7 @@ async def test_asgi_transport():
 @pytest.mark.usefixtures("async_environment")
 async def test_asgi_transport_no_body():
     async with httpx.ASGITransport(app=echo_body) as transport:
-        status_code, headers, stream, ext = await transport.arequest(
+        status_code, headers, stream, ext = await transport.handle_async_request(
             b"GET", (b"http", b"www.example.org", 80, b"/")
         )
         body = b"".join([part async for part in stream])

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -70,11 +70,19 @@ async def raise_exc_after_response(scope, receive, send):
     raise RuntimeError()
 
 
+async def empty_stream():
+    yield b""
+
+
 @pytest.mark.usefixtures("async_environment")
 async def test_asgi_transport():
     async with httpx.ASGITransport(app=hello_world) as transport:
         status_code, headers, stream, ext = await transport.handle_async_request(
-            b"GET", (b"http", b"www.example.org", 80, b"/")
+            method=b"GET",
+            url=(b"http", b"www.example.org", 80, b"/"),
+            headers=[(b"Host", b"www.example.org")],
+            stream=empty_stream(),
+            extensions={},
         )
         body = b"".join([part async for part in stream])
 
@@ -86,7 +94,11 @@ async def test_asgi_transport():
 async def test_asgi_transport_no_body():
     async with httpx.ASGITransport(app=echo_body) as transport:
         status_code, headers, stream, ext = await transport.handle_async_request(
-            b"GET", (b"http", b"www.example.org", 80, b"/")
+            method=b"GET",
+            url=(b"http", b"www.example.org", 80, b"/"),
+            headers=[(b"Host", b"www.example.org")],
+            stream=empty_stream(),
+            extensions={},
         )
         body = b"".join([part async for part in stream])
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -42,7 +42,7 @@ def test_httpcore_exception_mapping(server) -> None:
 
     # Make sure it also works with custom transports.
     class MockTransport(httpx.BaseTransport):
-        def request(self, *args: Any, **kwargs: Any) -> Any:
+        def handle_request(self, *args: Any, **kwargs: Any) -> Any:
             raise httpcore.ProtocolError()
 
     client = httpx.Client(transport=MockTransport())

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -41,7 +41,7 @@ def test_httpcore_exception_mapping(server) -> None:
             stream.read()
 
     # Make sure it also works with custom transports.
-    class MockTransport(httpcore.SyncHTTPTransport):
+    class MockTransport(httpx.BaseTransport):
         def request(self, *args: Any, **kwargs: Any) -> Any:
             raise httpcore.ProtocolError()
 


### PR DESCRIPTION
We have a little niggle in our API. Almost all the way through `httpcore` is treated as an implementation detail, that just happens to be used by the default transport implementation, `httpx.HTTPTransport`.

The one place where this isn't the case is in our "Transport API". In that case we're explicitly documenting "subclass httpcore.SyncHTTPTransport and implement it's API".

To make this clearer, here's how the "custom transports" docs look after this change...

---

### Writing custom transports

A transport instance must implement the low-level Transport API, which deals
with sending a single request, and returning a response. You should either
subclass `httpx.BaseTransport` to implement a transport to use with `Client`,
or subclass `httpx.AsyncBaseTransport` to implement a transport to
use with `AsyncClient`.

A complete example of a custom transport implementation would be:

```python
import json
import httpx


class HelloWorldTransport(httpx.BaseTransport):
    """
    A mock transport that always returns a JSON "Hello, world!" response.
    """

    def request(self, method, url, headers=None, stream=None, ext=None):
        message = {"text": "Hello, world!"}
        content = json.dumps(message).encode("utf-8")
        stream = [content]
        headers = [(b"content-type", b"application/json")]
        ext = {"http_version": b"HTTP/1.1"}
        return 200, headers, stream, ext
```

Which we can use in the same way:

```pycon
>>> import httpx
>>> client = httpx.Client(transport=HelloWorldTransport())
>>> response = client.get("https://example.org/")
>>> response.json()
{"text": "Hello, world!"}
```

---

I do have some further thoughts on progressing on from this point, but from a review perspective we *probably* want to treat this in isolation.

Nonetheless, I think the potential follow through points are worth talking through...

* We currently have a slightly awkward byte stream API, that includes a `.close()` method at the `httpcore` level, but which makes for an awkward base `.request()` signature. A neater alternative would be to switch to having `close` be an optional key on the returned `ext` dict. Then request and response streams are just plain old byte iterables. Yay. (There's a couple of type: ignores in this PR that sweep this under the table.)
* We *might* want to have the low-level method that is overridden be something like `handle_request(...)` instead of `request(...)`. Why? Because then we could implement a couple of convenience methods on the base classes, allowing for easy usage of sending a single request with a transport. Eg...
 
```python
t = httpx.HTTPTransport()
r = t.request("GET", "https://www.example.com")
```

This kinda gives us the best of both worlds, of having a strict low-level point in the API where all the request/response models drop away to plain primitives, while also being able to use transports directly. (Which for the purposes of debugging, narrowing down issues etc. is actually super useful. Especially if we start doing a really good job in `__repr__` of showing exactly which transports are mounted on a client, and exactly what configuration each transport has setup.)
* With a little tweaking we could drop the `HTTPCORE_EXC_MAP` out of the client, and strictly inside the `httpx.HTTPTransport` implementation, which is nice from the perspective of getting any reference to httpcore entirely out of `httpx`, except in the sole case of the concrete `httpx.HTTPTransport` implementation. Not worth discussing the details of that tweak here.
* Annnnddddd... kinda related to all this, although not *absolutely* a necessity... I think we *probably* look at considering dropping our context-managed Transport API into the heap of "interesting idea, but actually not necessarily worth the complexity trade-offs". We've been held up on getting to a neat 1.0 for a while largely because of that one, and I think it might well be worth us nope'ing on it. Wouldn't absolutely preclude us from choosing that route in a 2.x series at some point, but also I'm just not convinced it looks like a graceful road for us, from a user-perspective. Now... that's a potentially loaded decision to make, *but* I don't think a final decision on that needs to hold us up from progressing with an `httpx.BaseTransport` API *in either case*, because I think this way around feels more user-centred regardless of if we had a close-callback or a context-managed API. (Tho would need to take another look at the streaming case for `ASGITransport`?)

Either ways. This particular PR rubs out one of our last sets of API niggles, and necessarily put us on path for a 0.18.x series, which I think would be the last prior to a 1.0 release.