### PR TITLE
Context managed client.send()

### DIFF
--- a/httpx/_api.py
+++ b/httpx/_api.py
@@ -1,8 +1,9 @@
 import typing
+from contextlib import contextmanager
 
-from ._client import Client, StreamContextManager
+from ._client import Client
 from ._config import DEFAULT_TIMEOUT_CONFIG
-from ._models import Request, Response
+from ._models import Response
 from ._types import (
     AuthTypes,
     CertTypes,
@@ -105,6 +106,7 @@ def request(
         )
 
 
+@contextmanager
 def stream(
     method: str,
     url: URLTypes,
@@ -123,7 +125,7 @@ def stream(
     verify: VerifyTypes = True,
     cert: CertTypes = None,
     trust_env: bool = True,
-) -> StreamContextManager:
+) -> typing.Generator[Response, None, None]:
     """
     Alternative to `httpx.request()` that streams the response body
     instead of loading it into memory at once.
@@ -134,26 +136,23 @@ def stream(
 
     [0]: /quickstart#streaming-responses
     """
-    client = Client(proxies=proxies, cert=cert, verify=verify, trust_env=trust_env)
-    request = Request(
-        method=method,
-        url=url,
-        params=params,
-        content=content,
-        data=data,
-        files=files,
-        json=json,
-        headers=headers,
-        cookies=cookies,
-    )
-    return StreamContextManager(
-        client=client,
-        request=request,
-        auth=auth,
-        timeout=timeout,
-        allow_redirects=allow_redirects,
-        close_client=True,
-    )
+    with Client(
+        proxies=proxies, cert=cert, verify=verify, timeout=timeout, trust_env=trust_env
+    ) as client:
+        with client.stream(
+            method=method,
+            url=url,
+            content=content,
+            data=data,
+            files=files,
+            json=json,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            allow_redirects=allow_redirects,
+        ) as response:
+            yield response
 
 
 def get(

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -59,7 +59,7 @@ from ._utils import (
 
 try:
     from contextlib import asynccontextmanager
-except ImportError:  # pragma: nocover
+except AttributeError:  # pragma: nocover
     from async_generator import asynccontextmanager  # type: ignore
 
 

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -58,8 +58,8 @@ from ._utils import (
 )
 
 try:
-    from contextlib import asynccontextmanager
-except AttributeError:  # pragma: nocover
+    from contextlib import asynccontextmanager  # type: ignore
+except ImportError:  # pragma: nocover
     from async_generator import asynccontextmanager  # type: ignore
 
 

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -1243,13 +1243,12 @@ class Response:
 
     def close(self) -> None:
         """
-        Close the response and release the connection.
+        Mark the response as being closed. This will ensure that the response
+        body is no longer readable.
+
         Automatically called if the response body is read to completion.
         """
-        if not self.is_closed:
-            self.is_closed = True
-            if self._on_close is not None:
-                self._on_close(self)
+        self.is_closed = True
 
     async def aread(self) -> bytes:
         """
@@ -1338,13 +1337,12 @@ class Response:
 
     async def aclose(self) -> None:
         """
-        Close the response and release the connection.
+        Mark the response as being closed. This will ensure that the response
+        body is no longer readable.
+
         Automatically called if the response body is read to completion.
         """
-        if not self.is_closed:
-            self.is_closed = True
-            if self._on_close is not None:
-                await self._on_close(self)
+        self.is_closed = True
 
 
 class Cookies(MutableMapping):

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,8 @@ setup(
         "sniffio",
         "rfc3986[idna2008]>=1.3,<2",
         "httpcore>=0.12.1,<0.13",
+        # Backport for Python 3.6...
+        "async_generator; python_version<'3.7'",
     ],
     extras_require={
         "http2": "h2==3.*",

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -45,7 +45,8 @@ def test_build_request(server):
     with httpx.Client() as client:
         request = client.build_request("GET", url)
         request.headers.update(headers)
-        response = client.send(request)
+        with client.send(request) as response:
+            response.read()
 
     assert response.status_code == 200
     assert response.url == url
@@ -60,7 +61,8 @@ def test_build_post_request(server):
     with httpx.Client() as client:
         request = client.build_request("POST", url)
         request.headers.update(headers)
-        response = client.send(request)
+        with client.send(request) as response:
+            response.read()
 
     assert response.status_code == 200
     assert response.url == url

--- a/tests/client/test_redirects.py
+++ b/tests/client/test_redirects.py
@@ -141,12 +141,14 @@ def test_redirect_303():
 def test_next_request():
     client = httpx.Client(transport=httpx.MockTransport(redirects))
     request = client.build_request("POST", "https://example.org/redirect_303")
-    response = client.send(request, allow_redirects=False)
+    with client.send(request, allow_redirects=False) as response:
+        response.read()
     assert response.status_code == httpx.codes.SEE_OTHER
     assert response.url == "https://example.org/redirect_303"
     assert response.next_request is not None
 
-    response = client.send(response.next_request, allow_redirects=False)
+    with client.send(response.next_request, allow_redirects=False) as response:
+        response.read()
     assert response.status_code == httpx.codes.OK
     assert response.url == "https://example.org/"
     assert response.next_request is None
@@ -156,12 +158,16 @@ def test_next_request():
 async def test_async_next_request():
     async with httpx.AsyncClient(transport=httpx.MockTransport(redirects)) as client:
         request = client.build_request("POST", "https://example.org/redirect_303")
-        response = await client.send(request, allow_redirects=False)
+        async with client.send(request, allow_redirects=False) as response:
+            response.read()
         assert response.status_code == httpx.codes.SEE_OTHER
         assert response.url == "https://example.org/redirect_303"
         assert response.next_request is not None
 
-        response = await client.send(response.next_request, allow_redirects=False)
+        async with client.send(
+            response.next_request, allow_redirects=False
+        ) as response:
+            response.read()
         assert response.status_code == httpx.codes.OK
         assert response.url == "https://example.org/"
         assert response.next_request is None


### PR DESCRIPTION
Reworking of #1355 in order to keep thinking a few things over.

* Client.send() changes from returning an "open" Response to being a context managed interface.
* AsyncClient.send() changes from returning an "open" Response to being a context managed interface.
* The internal StreamContextManager disappears — we don't need it anymore.
* Response(on_close) disappears - we don't need it anymore.
* Response.close() *does* still exist, but it's no longer an I/O operation, it's purely for state marking. (Hey, we're not going to let you attempt to read the stream anymore)

There's a bunch of stuff for us to discuss around 1.0 and these last bits of "should we be using a context managed interface for (1) the Transport API and (2) the send() method."

For me the important step forward is the core idea in #1515, that the Transport API should be an HTTPX interface, in the HTTPX package. The really nice thing there is that once we do that, the `httpcore` implementation and API doesn't strictly have to define what we're presenting to the end-user in httpx, which just makes everything easier, and allows use to consider each of these three separate issues *in isolation from one another*...

1. Should the Transport API be a context managed request/response interface?
2. Should the client.send() API (and httpx internals) be a context managed interface?
3. Should the httpcore API and internals use a context managed request/response interface?

I need to follow up on this one with a bit more docs & chat, but parking it here for now.