### PR TITLE
Improve header byte pairs decoding in WSGITransport

### DIFF
--- a/httpx/_transports/wsgi.py
+++ b/httpx/_transports/wsgi.py
@@ -5,6 +5,8 @@ from urllib.parse import unquote
 
 import httpcore
 
+from .._models import Headers
+
 
 def _skip_leading_empty_chunks(body: typing.Iterable) -> typing.Iterable:
     body = iter(body)
@@ -93,11 +95,12 @@ class WSGITransport(httpcore.SyncHTTPTransport):
             "SERVER_PORT": str(port),
             "REMOTE_ADDR": self.remote_addr,
         }
-        for header_key, header_value in headers:
-            key = header_key.decode("ascii").upper().replace("-", "_")
+        # Piggyback encoding detecting strategy in Headers
+        for header_key, header_value in Headers(headers).multi_items():
+            key = header_key.upper().replace("-", "_")
             if key not in ("CONTENT_TYPE", "CONTENT_LENGTH"):
                 key = "HTTP_" + key
-            environ[key] = header_value.decode("ascii")
+            environ[key] = header_value
 
         seen_status = None
         seen_response_headers = None


### PR DESCRIPTION
According to `Headers.encoding()`, it's supported to decode header byte pairs encoded with utf-8 or latin-1 except ascii. Cause the header byte pairs received from httpcore connection may be non-ascii encoded.

On the other hand, it's also possible to send `Request` with non-ascii encoded `Headers`, 

```python
import httpx

headers = httpx.Headers({"foobar": "甲乙"}, encoding="utf-8")
url = "https://httpbin.org/anything"

r = httpx.get(url, headers=headers)
```

Non-ascii encoded `Headers` in `Request` is not a problem for `HTTPTransport`, `AsyncHTTPTransport` and `ASGITransport`. In these transports, the headers are sent as bytes. But for `WSGITransport`, we need to decode header byte pairs and put them into a `environ` dict.

In the current implementation of `WSGITransport`, we assume the header byte pairs in `Request` are only "ascii" encoded. This PR extends the header encoding support in `WSGITransport`, by piggybacking the encoding detect strategy of property `Headers.encoding()`.

