### PR TITLE
Make redirect strategy on HEAD complied with the doc

### DIFF
--- a/httpx/_api.py
+++ b/httpx/_api.py
@@ -240,7 +240,7 @@ def head(
     cookies: CookieTypes = None,
     auth: AuthTypes = None,
     proxies: ProxiesTypes = None,
-    allow_redirects: bool = True,
+    allow_redirects: bool = False,  # NOTE: Differs to usual default.
     cert: CertTypes = None,
     verify: VerifyTypes = True,
     timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -945,7 +945,7 @@ class Client(BaseClient):
         headers: HeaderTypes = None,
         cookies: CookieTypes = None,
         auth: typing.Union[AuthTypes, UnsetType] = UNSET,
-        allow_redirects: bool = True,
+        allow_redirects: bool = False,  # NOTE: Differs to usual default.
         timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
     ) -> Response:
         """
@@ -1582,7 +1582,7 @@ class AsyncClient(BaseClient):
         headers: HeaderTypes = None,
         cookies: CookieTypes = None,
         auth: typing.Union[AuthTypes, UnsetType] = UNSET,
-        allow_redirects: bool = True,
+        allow_redirects: bool = False,  # NOTE: Differs to usual default.
         timeout: typing.Union[TimeoutTypes, UnsetType] = UNSET,
     ) -> Response:
         """


### PR DESCRIPTION
`httpx` follows the redirect strategy of `requests` that all APIs follow redirections by default **except** `HEAD`. This PR prevents `HEAD` following redirections when `allow_redirects` param is not set.

https://www.python-httpx.org/quickstart/#redirection-and-history