### PR TITLE
Fix redirect description about HEAD

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -124,8 +124,11 @@ On the other hand, HTTPX uses [HTTPCore](https://github.com/encode/httpcore) as 
 
 `requests` omits `params` whose values are `None` (e.g. `requests.get(..., params={"foo": None})`). This is not supported by HTTPX.
 
-## Determining the next redirect request
+## HEAD redirection
+In `requests`, all top-level API follow redirects by default except `HEAD`.
+In consideration of consistency, we make `HEAD` follow redirects by default in HTTPX.
 
+## Determining the next redirect request
 When using `allow_redirects=False`, the `requests` library exposes an attribute `response.next`, which can be used to obtain the next redirect request.
 
 In HTTPX, this attribute is instead named `response.next_request`. For example:

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -125,10 +125,12 @@ On the other hand, HTTPX uses [HTTPCore](https://github.com/encode/httpcore) as 
 `requests` omits `params` whose values are `None` (e.g. `requests.get(..., params={"foo": None})`). This is not supported by HTTPX.
 
 ## HEAD redirection
+
 In `requests`, all top-level API follow redirects by default except `HEAD`.
 In consideration of consistency, we make `HEAD` follow redirects by default in HTTPX.
 
 ## Determining the next redirect request
+
 When using `allow_redirects=False`, the `requests` library exposes an attribute `response.next`, which can be used to obtain the next redirect request.
 
 In HTTPX, this attribute is instead named `response.next_request`. For example:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -410,9 +410,6 @@ with additional API for accessing cookies by their domain or path.
 
 By default, HTTPX will follow redirects for all HTTP methods.
 
-!!! warning
-    For anyone comes from Requests, you may be familar that `HEAD` in Requests 
-    doesn't follow redirects by default. But that is not the case in HTTPX.
 
 The `history` property of the response can be used to inspect any followed redirects.
 It contains a list of any redirect responses that were followed, in the order

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -408,7 +408,11 @@ with additional API for accessing cookies by their domain or path.
 
 ## Redirection and History
 
-By default, HTTPX will follow redirects for anything except `HEAD` requests.
+By default, HTTPX will follow redirects for all HTTP methods.
+
+!!! warning
+    For anyone comes from Requests, you may be familar that `HEAD` in Requests 
+    doesn't follow redirects by default. But that is not the case in HTTPX.
 
 The `history` property of the response can be used to inspect any followed redirects.
 It contains a list of any redirect responses that were followed, in the order
@@ -434,16 +438,6 @@ You can modify the default redirection handling with the allow_redirects paramet
 301
 >>> r.history
 []
-```
-
-If you’re making a `HEAD` request, you can use this to enable redirection:
-
-```pycon
->>> r = httpx.head('http://github.com/', allow_redirects=True)
->>> r.url
-'https://github.com/'
->>> r.history
-[<Response [301 Moved Permanently]>]
 ```
 
 ## Timeouts


### PR DESCRIPTION
`HEAD` is changed to follow redirects by default in GH-1183. Update the corresponding description in the doc.