### PR TITLE
introduce http2_prior_knowledge option in httpx Client

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -559,6 +559,7 @@ class Client(BaseClient):
         verify: VerifyTypes = True,
         cert: CertTypes = None,
         http2: bool = False,
+        http2_prior_knowledge: bool = False,
         proxies: ProxiesTypes = None,
         mounts: typing.Mapping[str, httpcore.SyncHTTPTransport] = None,
         timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
@@ -582,6 +583,9 @@ class Client(BaseClient):
             base_url=base_url,
             trust_env=trust_env,
         )
+
+        if http2_prior_knowledge:
+            http2 = True
 
         if http2:
             try:
@@ -1192,6 +1196,7 @@ class AsyncClient(BaseClient):
         verify: VerifyTypes = True,
         cert: CertTypes = None,
         http2: bool = False,
+        http2_prior_knowledge: bool = False,
         proxies: ProxiesTypes = None,
         mounts: typing.Mapping[str, httpcore.AsyncHTTPTransport] = None,
         timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
@@ -1216,6 +1221,9 @@ class AsyncClient(BaseClient):
             trust_env=trust_env,
         )
 
+        if http2_prior_knowledge:
+            http2 = True
+
         if http2:
             try:
                 import h2  # noqa
@@ -1239,6 +1247,7 @@ class AsyncClient(BaseClient):
             verify=verify,
             cert=cert,
             http2=http2,
+            http2_prior_knowledge=http2_prior_knowledge,
             limits=limits,
             transport=transport,
             app=app,
@@ -1255,6 +1264,7 @@ class AsyncClient(BaseClient):
                 verify=verify,
                 cert=cert,
                 http2=http2,
+                http2_prior_knowledge=http2_prior_knowledge,
                 limits=limits,
                 trust_env=trust_env,
             )
@@ -1271,6 +1281,7 @@ class AsyncClient(BaseClient):
         verify: VerifyTypes = True,
         cert: CertTypes = None,
         http2: bool = False,
+        http2_prior_knowledge: bool = False,
         limits: Limits = DEFAULT_LIMITS,
         transport: httpcore.AsyncHTTPTransport = None,
         app: typing.Callable = None,
@@ -1283,7 +1294,7 @@ class AsyncClient(BaseClient):
             return ASGITransport(app=app)
 
         return AsyncHTTPTransport(
-            verify=verify, cert=cert, http2=http2, limits=limits, trust_env=trust_env
+            verify=verify, cert=cert, http2=http2, http2_prior_knowledge=http2_prior_knowledge, limits=limits, trust_env=trust_env
         )
 
     def _init_proxy_transport(
@@ -1292,6 +1303,7 @@ class AsyncClient(BaseClient):
         verify: VerifyTypes = True,
         cert: CertTypes = None,
         http2: bool = False,
+        http2_prior_knowledge: bool = False,
         limits: Limits = DEFAULT_LIMITS,
         trust_env: bool = True,
     ) -> httpcore.AsyncHTTPTransport:
@@ -1299,6 +1311,7 @@ class AsyncClient(BaseClient):
             verify=verify,
             cert=cert,
             http2=http2,
+            http2_prior_knowledge=http2_prior_knowledge,
             limits=limits,
             trust_env=trust_env,
             proxy=proxy,

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -1294,7 +1294,12 @@ class AsyncClient(BaseClient):
             return ASGITransport(app=app)
 
         return AsyncHTTPTransport(
-            verify=verify, cert=cert, http2=http2, http2_prior_knowledge=http2_prior_knowledge, limits=limits, trust_env=trust_env
+            verify=verify,
+            cert=cert,
+            http2=http2,
+            http2_prior_knowledge=http2_prior_knowledge,
+            limits=limits,
+            trust_env=trust_env,
         )
 
     def _init_proxy_transport(

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -48,7 +48,11 @@ def create_ssl_context(
     http2_prior_knowledge: bool = False,
 ) -> ssl.SSLContext:
     return SSLConfig(
-        cert=cert, verify=verify, trust_env=trust_env, http2=http2, http2_prior_knowledge=http2_prior_knowledge,
+        cert=cert,
+        verify=verify,
+        trust_env=trust_env,
+        http2=http2,
+        http2_prior_knowledge=http2_prior_knowledge,
     ).ssl_context
 
 

--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -120,7 +120,13 @@ class AsyncHTTPTransport(httpcore.AsyncHTTPTransport):
         retries: int = 0,
         backend: str = "auto",
     ) -> None:
-        ssl_context = create_ssl_context(verify=verify, cert=cert, trust_env=trust_env, http2=http2, http2_prior_knowledge=http2_prior_knowledge)
+        ssl_context = create_ssl_context(
+            verify=verify,
+            cert=cert,
+            trust_env=trust_env,
+            http2=http2,
+            http2_prior_knowledge=http2_prior_knowledge,
+        )
 
         if proxy is None:
             self._pool = httpcore.AsyncConnectionPool(

--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -111,6 +111,7 @@ class AsyncHTTPTransport(httpcore.AsyncHTTPTransport):
         verify: VerifyTypes = True,
         cert: CertTypes = None,
         http2: bool = False,
+        http2_prior_knowledge: bool = False,
         limits: Limits = DEFAULT_LIMITS,
         trust_env: bool = True,
         proxy: Proxy = None,
@@ -119,7 +120,7 @@ class AsyncHTTPTransport(httpcore.AsyncHTTPTransport):
         retries: int = 0,
         backend: str = "auto",
     ) -> None:
-        ssl_context = create_ssl_context(verify=verify, cert=cert, trust_env=trust_env)
+        ssl_context = create_ssl_context(verify=verify, cert=cert, trust_env=trust_env, http2=http2, http2_prior_knowledge=http2_prior_knowledge)
 
         if proxy is None:
             self._pool = httpcore.AsyncConnectionPool(
@@ -128,6 +129,7 @@ class AsyncHTTPTransport(httpcore.AsyncHTTPTransport):
                 max_keepalive_connections=limits.max_keepalive_connections,
                 keepalive_expiry=limits.keepalive_expiry,
                 http2=http2,
+                http2_prior_knowledge=http2_prior_knowledge,
                 uds=uds,
                 local_address=local_address,
                 retries=retries,


### PR DESCRIPTION
This PR is to be used in conjuction with [this httpcore PR](https://github.com/encode/httpcore/pull/269).

It passes the `http2_prior_knowledge` option to the httpx client, which passes it to the httpcore `AsyncConnectionPool` instanciation.

I also added it to the http config model, to make sure that the alpn selected protocols only contains `"h2"` if the http2_prior_knowledge option is set to True.