### PR TITLE
Push httpcore exception wrapping out of client into transport

### DIFF
--- a/httpx/_decoders.py
+++ b/httpx/_decoders.py
@@ -8,6 +8,8 @@ import io
 import typing
 import zlib
 
+from ._exceptions import DecodingError
+
 try:
     import brotli
 except ImportError:  # pragma: nocover
@@ -54,13 +56,13 @@ class DeflateDecoder(ContentDecoder):
             if was_first_attempt:
                 self.decompressor = zlib.decompressobj(-zlib.MAX_WBITS)
                 return self.decode(data)
-            raise ValueError(str(exc))
+            raise DecodingError(str(exc)) from exc
 
     def flush(self) -> bytes:
         try:
             return self.decompressor.flush()
         except zlib.error as exc:  # pragma: nocover
-            raise ValueError(str(exc))
+            raise DecodingError(str(exc)) from exc
 
 
 class GZipDecoder(ContentDecoder):
@@ -77,13 +79,13 @@ class GZipDecoder(ContentDecoder):
         try:
             return self.decompressor.decompress(data)
         except zlib.error as exc:
-            raise ValueError(str(exc))
+            raise DecodingError(str(exc)) from exc
 
     def flush(self) -> bytes:
         try:
             return self.decompressor.flush()
         except zlib.error as exc:  # pragma: nocover
-            raise ValueError(str(exc))
+            raise DecodingError(str(exc)) from exc
 
 
 class BrotliDecoder(ContentDecoder):
@@ -118,7 +120,7 @@ class BrotliDecoder(ContentDecoder):
         try:
             return self._decompress(data)
         except brotli.error as exc:
-            raise ValueError(str(exc))
+            raise DecodingError(str(exc)) from exc
 
     def flush(self) -> bytes:
         if not self.seen_data:
@@ -128,7 +130,7 @@ class BrotliDecoder(ContentDecoder):
                 self.decompressor.finish()
             return b""
         except brotli.error as exc:  # pragma: nocover
-            raise ValueError(str(exc))
+            raise DecodingError(str(exc)) from exc
 
 
 class MultiDecoder(ContentDecoder):

--- a/httpx/_exceptions.py
+++ b/httpx/_exceptions.py
@@ -67,6 +67,12 @@ class RequestError(HTTPError):
 
     def __init__(self, message: str, *, request: "Request" = None) -> None:
         super().__init__(message)
+        # At the point an exception is raised we won't typically have a request
+        # instance to associate it with.
+        #
+        # The 'request_context' context manager is used within the Client and
+        # Response methods in order to ensure that any raised exceptions
+        # have a `.request` property set on them.
         self._request = request
 
     @property

--- a/httpx/_transports/base.py
+++ b/httpx/_transports/base.py
@@ -52,8 +52,8 @@ class BaseTransport:
                 try:
                     body = b''.join([part for part in stream])
                 finally:
-                    if hasattr(stream 'close'):
-                        stream.close()
+                    if 'close' in extensions:
+                        extensions['close']()
                 print(status_code, headers, body)
 
         Arguments:
@@ -86,6 +86,10 @@ class BaseTransport:
                     eg. the leading response bytes were b"HTTP/1.1 200 <CRLF>".
             http_version: The HTTP version, as a string. Eg. "HTTP/1.1".
                     When no http_version key is included, "HTTP/1.1" may be assumed.
+            close:  A callback which should be invoked to release any network
+                    resources.
+            aclose: An async callback which should be invoked to release any
+                    network resources.
         """
         raise NotImplementedError(
             "The 'handle_request' method must be implemented."

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -1,7 +1,6 @@
 import typing
 from datetime import timedelta
 
-import httpcore
 import pytest
 
 import httpx
@@ -301,25 +300,6 @@ async def test_mounted_transport():
         response = await client.get("custom://www.example.com")
         assert response.status_code == 200
         assert response.json() == {"app": "mounted"}
-
-
-@pytest.mark.usefixtures("async_environment")
-async def test_response_aclose_map_exceptions():
-    class BrokenStream:
-        async def __aiter__(self):
-            # so we're an AsyncIterator
-            pass  # pragma: nocover
-
-        async def aclose(self):
-            raise httpcore.CloseError(OSError(104, "Connection reset by peer"))
-
-    def handle(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, stream=BrokenStream())
-
-    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as client:
-        async with client.stream("GET", "http://example.com") as response:
-            with pytest.raises(httpx.CloseError):
-                await response.aclose()
 
 
 @pytest.mark.usefixtures("async_environment")

--- a/tests/client/test_redirects.py
+++ b/tests/client/test_redirects.py
@@ -1,4 +1,3 @@
-import httpcore
 import pytest
 
 import httpx
@@ -6,9 +5,7 @@ import httpx
 
 def redirects(request: httpx.Request) -> httpx.Response:
     if request.url.scheme not in ("http", "https"):
-        raise httpcore.UnsupportedProtocol(
-            f"Scheme {request.url.scheme!r} not supported."
-        )
+        raise httpx.UnsupportedProtocol(f"Scheme {request.url.scheme!r} not supported.")
 
     if request.url.path == "/redirect_301":
         status_code = httpx.codes.MOVED_PERMANENTLY

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,8 +76,6 @@ async def app(scope, receive, send):
     assert scope["type"] == "http"
     if scope["path"].startswith("/slow_response"):
         await slow_response(scope, receive, send)
-    elif scope["path"].startswith("/slow_stream_response"):
-        await slow_stream_response(scope, receive, send)
     elif scope["path"].startswith("/status"):
         await status_code(scope, receive, send)
     elif scope["path"].startswith("/echo_body"):
@@ -111,19 +109,6 @@ async def slow_response(scope, receive, send):
         }
     )
     await send({"type": "http.response.body", "body": b"Hello, world!"})
-
-
-async def slow_stream_response(scope, receive, send):
-    await send(
-        {
-            "type": "http.response.start",
-            "status": 200,
-            "headers": [[b"content-type", b"text/plain"]],
-        }
-    )
-
-    await sleep(1)
-    await send({"type": "http.response.body", "body": b"", "more_body": False})
 
 
 async def status_code(scope, receive, send):

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -733,7 +733,7 @@ def test_json_without_specified_encoding_value_error():
     # force incorrect guess from `guess_json_utf` to trigger error
     with mock.patch("httpx._models.guess_json_utf", return_value="utf-32"):
         response = httpx.Response(200, content=content, headers=headers)
-        with pytest.raises(ValueError):
+        with pytest.raises(json.decoder.JSONDecodeError):
             response.json()
 
 
@@ -767,7 +767,7 @@ def test_decode_error_with_request(header_value):
     headers = [(b"Content-Encoding", header_value)]
     body = b"test 123"
     compressed_body = brotli.compress(body)[3:]
-    with pytest.raises(ValueError):
+    with pytest.raises(httpx.DecodingError):
         httpx.Response(
             200,
             headers=headers,
@@ -788,7 +788,7 @@ def test_value_error_without_request(header_value):
     headers = [(b"Content-Encoding", header_value)]
     body = b"test 123"
     compressed_body = brotli.compress(body)[3:]
-    with pytest.raises(ValueError):
+    with pytest.raises(httpx.DecodingError):
         httpx.Response(200, headers=headers, content=compressed_body)
 
 

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -170,7 +170,7 @@ def test_decoding_errors(header_value):
         request = httpx.Request("GET", "https://example.org")
         httpx.Response(200, headers=headers, content=compressed_body, request=request)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(httpx.DecodingError):
         httpx.Response(200, headers=headers, content=compressed_body)
 
 


### PR DESCRIPTION
Follow-on to #1522

Transports should now raise `httpx` exception classes, rather than `httpcore` exception classes.

* The httpcore -> httpx exception mapping now *only* occurs within the `HTTPTransport()` class, which uses the  `httpcore` library.
* The `RequestError` exceptions no longer require a request argument at the point of instantiation. The client class ensures that any `RequestError` raised by a transport will have a `request` attribute attached to it.
* Transports now use plain byte iterables, with `extensions['close']`/`extensions['aclose']` for any optional close callback.