### PR TITLE
Neaten up our try...except structure for ensuring responses

### DIFF
--- a/tests/client/test_redirects.py
+++ b/tests/client/test_redirects.py
@@ -393,3 +393,10 @@ def test_redirect_custom_scheme():
     with pytest.raises(httpx.UnsupportedProtocol) as e:
         client.post("https://example.org/redirect_custom_scheme")
     assert str(e.value) == "Scheme 'market' not supported."
+
+
+@pytest.mark.usefixtures("async_environment")
+async def test_async_invalid_redirect():
+    async with httpx.AsyncClient(transport=httpx.MockTransport(redirects)) as client:
+        with pytest.raises(httpx.RemoteProtocolError):
+            await client.get("http://example.org/invalid_redirect")


### PR DESCRIPTION
More consistent structuring for ensuring we don't leave unclosed responses hanging in exception cases.

Essentially, any time we're internally calling a method that returns a response, we want to follow that with a `try...except...` block, and ensure we close the response if an exception occurs.

This pull request neatens up that behaviour, and likely closes some unseen edge cases as a result.