### PR TITLE
Extensions reason_phrase and http_version as bytes

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -985,11 +985,17 @@ class Response:
 
     @property
     def http_version(self) -> str:
-        return self.extensions.get("http_version", "HTTP/1.1")
+        try:
+            return self.extensions["http_version"].decode("ascii", errors="ignore")
+        except KeyError:
+            return "HTTP/1.1"
 
     @property
     def reason_phrase(self) -> str:
-        return self.extensions.get("reason", codes.get_reason_phrase(self.status_code))
+        try:
+            return self.extensions["reason_phrase"].decode("ascii", errors="ignore")
+        except KeyError:
+            return codes.get_reason_phrase(self.status_code)
 
     @property
     def url(self) -> typing.Optional[URL]:

--- a/httpx/_transports/base.py
+++ b/httpx/_transports/base.py
@@ -78,14 +78,14 @@ class BaseTransport:
         stream: The response body as a bytes iterator.
         extensions: An open ended dictionary, including optional extensions to the
                     core request/response API. Keys are plain strings, and may include:
-            reason: The reason-phrase of the HTTP response, as bytes. Eg 'OK'.
+            reason_phrase: The reason-phrase of the HTTP response, as bytes. Eg b'OK'.
                     HTTP/2 onwards does not include a reason phrase on the wire.
                     When no key is included, a default based on the status code may
                     be used. An empty-string reason phrase should not be substituted
                     for a default, as it indicates the server left the portion blank
                     eg. the leading response bytes were b"HTTP/1.1 200 <CRLF>".
-            http_version: The HTTP version, as a string. Eg. "HTTP/1.1".
-                    When no http_version key is included, "HTTP/1.1" may be assumed.
+            http_version: The HTTP version, as bytes. Eg. b"HTTP/1.1".
+                    When no http_version key is included, HTTP/1.1 may be assumed.
             close:  A callback which should be invoked to release any network
                     resources.
             aclose: An async callback which should be invoked to release any


### PR DESCRIPTION
The Transport API extensions `reason_phrase` and `http_version` are now mandated as being bytes.