### PR TITLE
Fix typo in docs to match `max_keepalive` default

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -667,7 +667,7 @@ You can control the connection pool size using the `limits` keyword
 argument on the client. It takes instances of `httpx.Limits` which define:
 
 - `max_keepalive`, number of allowable keep-alive connections, or `None` to always
-allow. (Defaults 10)
+allow. (Defaults 20)
 - `max_connections`, maximum number of allowable connections, or` None` for no limits.
 (Default 100)
 


### PR DESCRIPTION
[Simple docs typo PR]

Update the docs to match default value of `max_keepalive` as given in the variable `DEFAULT_LIMITS` in `_config` at https://github.com/encode/httpx/blob/master/httpx/_config.py#L359