### PR TITLE
Fix extenstions typo in AsyncHTTPTransport

### DIFF
--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -264,7 +264,7 @@ class AsyncHTTPTransport(AsyncBaseTransport):
         int, typing.List[typing.Tuple[bytes, bytes]], typing.AsyncIterable[bytes], dict
     ]:
         with map_httpcore_exceptions():
-            status_code, headers, byte_stream, extenstions = await self._pool.arequest(
+            status_code, headers, byte_stream, extensions = await self._pool.arequest(
                 method=method,
                 url=url,
                 headers=headers,

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -313,3 +313,12 @@ async def test_async_mock_transport():
         response = await client.get("https://www.example.com")
         assert response.status_code == 200
         assert response.text == "Hello, world!"
+
+
+@pytest.mark.usefixtures("async_environment")
+async def test_server_extensions(server):
+    url = server.url
+    async with httpx.AsyncClient(http2=True) as client:
+        response = await client.get(url)
+    assert response.status_code == 200
+    assert response.extensions["http_version"] == b"HTTP/1.1"

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -383,3 +383,11 @@ def test_all_mounted_transport():
     response = client.get("https://www.example.com")
     assert response.status_code == 200
     assert response.json() == {"app": "mounted"}
+
+
+def test_server_extensions(server):
+    url = server.url.copy_with(path="/http_version_2")
+    with httpx.Client(http2=True) as client:
+        response = client.get(url)
+    assert response.status_code == 200
+    assert response.extensions["http_version"] == b"HTTP/1.1"


### PR DESCRIPTION
Seems like a typo sneaked by in the `AsyncHTTPTransport` 😉 

I couldn't find a better way of testing it than asserting that the `http_version` was passed from the `server` all the way up to the `resonse.extensions`.