### PR TITLE
Stream interface

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1044,7 +1044,7 @@ class HelloWorldTransport(httpx.BaseTransport):
     def handle_request(self, method, url, headers, stream, extensions):
         message = {"text": "Hello, world!"}
         content = json.dumps(message).encode("utf-8")
-        stream = [content]
+        stream = httpx.ByteStream(content)
         headers = [(b"content-type", b"application/json")]
         extensions = {}
         return 200, headers, stream, extensions
@@ -1105,7 +1105,7 @@ class HTTPSRedirectTransport(httpx.BaseTransport):
             location = b"https://%s%s" % (host, path)
         else:
             location = b"https://%s:%d%s" % (host, port, path)
-        stream = [b""]
+        stream = httpx.ByteStream(b"")
         headers = [(b"location", location)]
         extensions = {}
         return 303, headers, stream, extensions

--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -3,6 +3,7 @@ from ._api import delete, get, head, options, patch, post, put, request, stream
 from ._auth import Auth, BasicAuth, DigestAuth
 from ._client import AsyncClient, Client
 from ._config import Limits, Proxy, Timeout, create_ssl_context
+from ._content import ByteStream
 from ._exceptions import (
     CloseError,
     ConnectError,
@@ -36,7 +37,12 @@ from ._exceptions import (
 from ._models import URL, Cookies, Headers, QueryParams, Request, Response
 from ._status_codes import StatusCode, codes
 from ._transports.asgi import ASGITransport
-from ._transports.base import AsyncBaseTransport, BaseTransport
+from ._transports.base import (
+    AsyncBaseTransport,
+    AsyncByteStream,
+    BaseTransport,
+    SyncByteStream,
+)
 from ._transports.default import AsyncHTTPTransport, HTTPTransport
 from ._transports.mock import MockTransport
 from ._transports.wsgi import WSGITransport
@@ -47,11 +53,13 @@ __all__ = [
     "__version__",
     "ASGITransport",
     "AsyncBaseTransport",
+    "AsyncByteStream",
     "AsyncClient",
     "AsyncHTTPTransport",
     "Auth",
     "BaseTransport",
     "BasicAuth",
+    "ByteStream",
     "Client",
     "CloseError",
     "codes",
@@ -97,6 +105,7 @@ __all__ = [
     "stream",
     "StreamConsumed",
     "StreamError",
+    "SyncByteStream",
     "Timeout",
     "TimeoutException",
     "TooManyRedirects",

--- a/httpx/_multipart.py
+++ b/httpx/_multipart.py
@@ -3,6 +3,7 @@ import os
 import typing
 from pathlib import Path
 
+from ._transports.base import AsyncByteStream, SyncByteStream
 from ._types import FileContent, FileTypes, RequestFiles
 from ._utils import (
     format_form_param,
@@ -141,7 +142,7 @@ class FileField:
         yield from self.render_data()
 
 
-class MultipartStream:
+class MultipartStream(SyncByteStream, AsyncByteStream):
     """
     Request content as streaming multipart encoded form data.
     """

--- a/httpx/_transports/asgi.py
+++ b/httpx/_transports/asgi.py
@@ -24,6 +24,14 @@ def create_event() -> "Event":
         return asyncio.Event()
 
 
+class ASGIResponseStream(AsyncByteStream):
+    def __init__(self, body: typing.List[bytes]) -> None:
+        self._body = body
+
+    async def __aiter__(self) -> typing.AsyncIterator[bytes]:
+        yield b"".join(self._body)
+
+
 class ASGITransport(AsyncBaseTransport):
     """
     A custom AsyncTransport that handles sending requests directly to an ASGI app.
@@ -154,13 +162,6 @@ class ASGITransport(AsyncBaseTransport):
         assert response_complete.is_set()
         assert status_code is not None
         assert response_headers is not None
-
-        class ASGIResponseStream(AsyncByteStream):
-            def __init__(self, body: typing.List[bytes]) -> None:
-                self._body = body
-
-            async def __aiter__(self) -> typing.AsyncIterator[bytes]:
-                yield b"".join(self._body)
 
         stream = ASGIResponseStream(body_parts)
         extensions = {}

--- a/httpx/_transports/asgi.py
+++ b/httpx/_transports/asgi.py
@@ -3,7 +3,7 @@ from urllib.parse import unquote
 
 import sniffio
 
-from .base import AsyncBaseTransport
+from .base import AsyncBaseTransport, AsyncByteStream
 
 if typing.TYPE_CHECKING:  # pragma: no cover
     import asyncio
@@ -74,10 +74,10 @@ class ASGITransport(AsyncBaseTransport):
         method: bytes,
         url: typing.Tuple[bytes, bytes, typing.Optional[int], bytes],
         headers: typing.List[typing.Tuple[bytes, bytes]],
-        stream: typing.AsyncIterable[bytes],
+        stream: AsyncByteStream,
         extensions: dict,
     ) -> typing.Tuple[
-        int, typing.List[typing.Tuple[bytes, bytes]], typing.AsyncIterable[bytes], dict
+        int, typing.List[typing.Tuple[bytes, bytes]], AsyncByteStream, dict
     ]:
         # ASGI scope.
         scheme, host, port, full_path = url
@@ -155,9 +155,14 @@ class ASGITransport(AsyncBaseTransport):
         assert status_code is not None
         assert response_headers is not None
 
-        async def response_stream() -> typing.AsyncIterator[bytes]:
-            yield b"".join(body_parts)
+        class ASGIResponseStream(AsyncByteStream):
+            def __init__(self, body: typing.List[bytes]) -> None:
+                self._body = body
 
+            async def __aiter__(self) -> typing.AsyncIterator[bytes]:
+                yield b"".join(self._body)
+
+        stream = ASGIResponseStream(body_parts)
         extensions = {}
 
-        return (status_code, response_headers, response_stream(), extensions)
+        return (status_code, response_headers, stream, extensions)

--- a/httpx/_transports/base.py
+++ b/httpx/_transports/base.py
@@ -5,6 +5,22 @@ T = typing.TypeVar("T", bound="BaseTransport")
 A = typing.TypeVar("A", bound="AsyncBaseTransport")
 
 
+class SyncByteStream:
+    def __iter__(self) -> typing.Iterator[bytes]:
+        raise NotImplementedError(
+            "The '__iter__' method must be implemented."
+        )  # pragma: nocover
+        yield b""  # pragma: nocover
+
+
+class AsyncByteStream:
+    async def __aiter__(self) -> typing.AsyncIterator[bytes]:
+        raise NotImplementedError(
+            "The '__aiter__' method must be implemented."
+        )  # pragma: nocover
+        yield b""  # pragma: nocover
+
+
 class BaseTransport:
     def __enter__(self: T) -> T:
         return self
@@ -22,10 +38,10 @@ class BaseTransport:
         method: bytes,
         url: typing.Tuple[bytes, bytes, typing.Optional[int], bytes],
         headers: typing.List[typing.Tuple[bytes, bytes]],
-        stream: typing.Iterable[bytes],
+        stream: SyncByteStream,
         extensions: dict,
     ) -> typing.Tuple[
-        int, typing.List[typing.Tuple[bytes, bytes]], typing.Iterable[bytes], dict
+        int, typing.List[typing.Tuple[bytes, bytes]], SyncByteStream, dict
     ]:
         """
         Send a single HTTP request and return a response.
@@ -116,10 +132,10 @@ class AsyncBaseTransport:
         method: bytes,
         url: typing.Tuple[bytes, bytes, typing.Optional[int], bytes],
         headers: typing.List[typing.Tuple[bytes, bytes]],
-        stream: typing.AsyncIterable[bytes],
+        stream: AsyncByteStream,
         extensions: dict,
     ) -> typing.Tuple[
-        int, typing.List[typing.Tuple[bytes, bytes]], typing.AsyncIterable[bytes], dict
+        int, typing.List[typing.Tuple[bytes, bytes]], AsyncByteStream, dict
     ]:
         raise NotImplementedError(
             "The 'handle_async_request' method must be implemented."

--- a/httpx/_transports/base.py
+++ b/httpx/_transports/base.py
@@ -17,7 +17,7 @@ class SyncByteStream:
         Subclasses can override this method to release any network resources
         after a request/response cycle is complete.
 
-        Streaming cases should call use a `try...finally` block to ensure that
+        Streaming cases should use a `try...finally` block to ensure that
         the stream `close()` method is always called.
 
         Example:

--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -191,12 +191,11 @@ class HTTPTransport(BaseTransport):
                     for part in self._httpcore_stream:
                         yield part
 
-        def close() -> None:
-            with map_httpcore_exceptions():
-                byte_stream.close()
+            def close(self) -> None:
+                with map_httpcore_exceptions():
+                    self._httpcore_stream.close()
 
         ensure_http_version_reason_phrase_as_bytes(extensions)
-        extensions["close"] = close
         stream = ResponseStream(byte_stream)
 
         return status_code, headers, stream, extensions
@@ -286,12 +285,11 @@ class AsyncHTTPTransport(AsyncBaseTransport):
                     async for part in self._httpcore_stream:
                         yield part
 
-        async def aclose() -> None:
-            with map_httpcore_exceptions():
-                await byte_stream.aclose()
+            async def aclose(self) -> None:
+                with map_httpcore_exceptions():
+                    await byte_stream.aclose()
 
         ensure_http_version_reason_phrase_as_bytes(extensions)
-        extensions["aclose"] = aclose
         stream = ResponseStream(byte_stream)
 
         return status_code, headers, stream, extensions

--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -287,7 +287,7 @@ class AsyncHTTPTransport(AsyncBaseTransport):
 
             async def aclose(self) -> None:
                 with map_httpcore_exceptions():
-                    await byte_stream.aclose()
+                    await self._httpcore_stream.aclose()
 
         ensure_http_version_reason_phrase_as_bytes(extensions)
         stream = ResponseStream(byte_stream)

--- a/httpx/_transports/mock.py
+++ b/httpx/_transports/mock.py
@@ -2,7 +2,7 @@ import asyncio
 import typing
 
 from .._models import Request
-from .base import AsyncBaseTransport, BaseTransport
+from .base import AsyncBaseTransport, AsyncByteStream, BaseTransport, SyncByteStream
 
 
 class MockTransport(AsyncBaseTransport, BaseTransport):
@@ -14,10 +14,10 @@ class MockTransport(AsyncBaseTransport, BaseTransport):
         method: bytes,
         url: typing.Tuple[bytes, bytes, typing.Optional[int], bytes],
         headers: typing.List[typing.Tuple[bytes, bytes]],
-        stream: typing.Iterable[bytes],
+        stream: SyncByteStream,
         extensions: dict,
     ) -> typing.Tuple[
-        int, typing.List[typing.Tuple[bytes, bytes]], typing.Iterable[bytes], dict
+        int, typing.List[typing.Tuple[bytes, bytes]], SyncByteStream, dict
     ]:
         request = Request(
             method=method,
@@ -39,10 +39,10 @@ class MockTransport(AsyncBaseTransport, BaseTransport):
         method: bytes,
         url: typing.Tuple[bytes, bytes, typing.Optional[int], bytes],
         headers: typing.List[typing.Tuple[bytes, bytes]],
-        stream: typing.AsyncIterable[bytes],
+        stream: AsyncByteStream,
         extensions: dict,
     ) -> typing.Tuple[
-        int, typing.List[typing.Tuple[bytes, bytes]], typing.AsyncIterable[bytes], dict
+        int, typing.List[typing.Tuple[bytes, bytes]], AsyncByteStream, dict
     ]:
         request = Request(
             method=method,

--- a/httpx/_transports/wsgi.py
+++ b/httpx/_transports/wsgi.py
@@ -14,6 +14,15 @@ def _skip_leading_empty_chunks(body: typing.Iterable) -> typing.Iterable:
     return []
 
 
+class WSGIByteStream(SyncByteStream):
+    def __init__(self, result: typing.Iterable[bytes]) -> None:
+        self._result = _skip_leading_empty_chunks(result)
+
+    def __iter__(self) -> typing.Iterator[bytes]:
+        for part in self._result:
+            yield part
+
+
 class WSGITransport(BaseTransport):
     """
     A custom transport that handles sending requests directly to an WSGI app.
@@ -111,14 +120,6 @@ class WSGITransport(BaseTransport):
             seen_exc_info = exc_info
 
         result = self.app(environ, start_response)
-
-        class WSGIByteStream(SyncByteStream):
-            def __init__(self, result: typing.Iterable[bytes]) -> None:
-                self._result = _skip_leading_empty_chunks(result)
-
-            def __iter__(self) -> typing.Iterator[bytes]:
-                for part in self._result:
-                    yield part
 
         stream = WSGIByteStream(result)
 

--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -74,9 +74,8 @@ AuthTypes = Union[
     None,
 ]
 
-ByteStream = Union[Iterable[bytes], AsyncIterable[bytes]]
-RequestContent = Union[str, bytes, ByteStream]
-ResponseContent = Union[str, bytes, ByteStream]
+RequestContent = Union[str, bytes, Iterable[bytes], AsyncIterable[bytes]]
+ResponseContent = Union[str, bytes, Iterable[bytes], AsyncIterable[bytes]]
 
 RequestData = dict
 

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -3,18 +3,18 @@ import typing
 
 import pytest
 
-from httpx import StreamConsumed
+import httpx
 from httpx._content import encode_request, encode_response
 
 
 @pytest.mark.asyncio
 async def test_empty_content():
     headers, stream = encode_request()
-    assert isinstance(stream, typing.Iterable)
-    assert isinstance(stream, typing.AsyncIterable)
+    assert isinstance(stream, httpx.SyncByteStream)
+    assert isinstance(stream, httpx.AsyncByteStream)
 
-    sync_content = b"".join([part for part in stream])
-    async_content = b"".join([part async for part in stream])
+    sync_content = stream.read()
+    async_content = await stream.aread()
 
     assert headers == {}
     assert sync_content == b""
@@ -62,7 +62,7 @@ async def test_iterator_content():
     assert headers == {"Transfer-Encoding": "chunked"}
     assert content == b"Hello, world!"
 
-    with pytest.raises(StreamConsumed):
+    with pytest.raises(httpx.StreamConsumed):
         [part for part in stream]
 
     # Support 'data' for compat with requests.
@@ -91,7 +91,7 @@ async def test_aiterator_content():
     assert headers == {"Transfer-Encoding": "chunked"}
     assert content == b"Hello, world!"
 
-    with pytest.raises(StreamConsumed):
+    with pytest.raises(httpx.StreamConsumed):
         [part async for part in stream]
 
     # Support 'data' for compat with requests.
@@ -382,7 +382,7 @@ async def test_response_iterator_content():
     assert headers == {"Transfer-Encoding": "chunked"}
     assert content == b"Hello, world!"
 
-    with pytest.raises(StreamConsumed):
+    with pytest.raises(httpx.StreamConsumed):
         [part for part in stream]
 
 
@@ -401,7 +401,7 @@ async def test_response_aiterator_content():
     assert headers == {"Transfer-Encoding": "chunked"}
     assert content == b"Hello, world!"
 
-    with pytest.raises(StreamConsumed):
+    with pytest.raises(httpx.StreamConsumed):
         [part async for part in stream]
 
 


### PR DESCRIPTION
This pull request allows us to compare the following two alternatives...

* The HTTPX Transport API, using `stream` as a plain primitive `Iterable[bytes]`/`AsyncIterable[bytes]`, with `close`/`aclose` extensions for handling close callbacks. 
* The HTTPX Transport API, using simple `httpx.SyncByteStream`/`httpx.AsyncByteStream` interfaces for streams.

Note that the `request.stream` and `response.stream` interfaces also change as a result of this.

The pros of this approach are that the Transport API presents a more natural interface...

**Before:**

```python
with httpx.HTTPTransport() as transport:
    status_code, headers, stream, extensions = transport.handle_request(
        method=b'GET',
        url=(b'https', b'www.example.com', 443, b'/'),
        headers=[(b'Host', b'www.example.com')],
        stream=[],
        extensions={}
    )
    try:
        body = [part for part in stream]
    finally:
        if "close" in extensions:
            extensions["close"]()
```

**After:**

Standard case:

```python
with httpx.HTTPTransport() as transport:
    status_code, headers, stream, extensions = transport.handle_request(
        method=b'GET',
        url=(b'https', b'www.example.com', 443, b'/'),
        headers=[(b'Host', b'www.example.com')],
        stream=httpx.ByteStream(b""),
        extensions={}
    )
    body = stream.read()
```

Streaming case:

```python
with httpx.HTTPTransport() as transport:
    status_code, headers, stream, extensions = transport.handle_request(
        method=b'GET',
        url=(b'https', b'www.example.com', 443, b'/'),
        headers=[(b'Host', b'www.example.com')],
        stream=httpx.ByteStream(b""),
        extensions={}
    )
    try:
        body = [part for part in stream]
    finally:
        stream.close()
```

The cons of this approach are that we're adding `httpx.SyncByteStream` and `httpx.AsyncByteStream` instead of the "`handle_request` is just plain datatypes everywhere". We're also adding the `httpx.ByteStream()` class for the simple concrete bytes-only case.

Having had a bunch of time to think over the three possible cases...

* A stream interface
* A plain bytes interface, with `close`/`aclose` extensions to handle resource closing.
* A plain bytes interface, with context management to handle resource closing.

My feel is that this one probably hits the sweet spot of "nice low-level interface" while still being neatly usable and obvious from a usability perspective.

It's also lower impact if we want to update httpcore with an equivalent interface, since https://github.com/encode/httpcore/pull/296 in it's current state already matches up with this. (But gets more complex if we start adding in `close`/`aclose` extensions.)