### PR TITLE
Escalate the distinction between `data=...` and `content=...` to be stricter.

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -28,8 +28,8 @@ And using `data=...` to send form data:
 httpx.post(..., data={"message": "Hello, world"})
 ```
 
-If you're using a type checking tool such as `mypy`, you'll see warnings issues if using test/byte content with the `data` argument.
-However, for compatibility reasons with `requests`, we do still handle the case where `data=...` is used with raw binary and text contents.
+Using the `data=<text/byte content>` will raise a deprecation warning,
+and is expected to be fully removed with the HTTPX 1.0 release.
 
 ## Content encoding
 
@@ -147,6 +147,6 @@ while request is not None:
 
 `requests` allows event hooks to mutate `Request` and `Response` objects. See [examples](https://requests.readthedocs.io/en/master/user/advanced/#event-hooks) given in the documentation for `requests`.
 
-In HTTPX, event hooks may access properties of requests and responses, but event hook callbacks cannot mutate the original request/response. 
+In HTTPX, event hooks may access properties of requests and responses, but event hook callbacks cannot mutate the original request/response.
 
 If you are looking for more control, consider checking out [Custom Transports](advanced.md#custom-transports).

--- a/httpx/_content.py
+++ b/httpx/_content.py
@@ -1,4 +1,5 @@
 import inspect
+import warnings
 from json import dumps as json_dumps
 from typing import (
     Any,
@@ -148,6 +149,8 @@ def encode_request(
         # However for compat with requests, we *do* still support
         # `data=<bytes...>` usages. We deal with that case here, treating it
         # as if `content=<...>` had been supplied instead.
+        message = "Use 'content=<...>' to upload raw bytes/text content."
+        warnings.warn(message, DeprecationWarning)
         return encode_content(data)
 
     if content is not None:

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -630,7 +630,7 @@ async def test_digest_auth_unavailable_streaming_body():
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(app)) as client:
         with pytest.raises(httpx.StreamConsumed):
-            await client.post(url, data=streaming_body(), auth=auth)
+            await client.post(url, content=streaming_body(), auth=auth)
 
 
 @pytest.mark.asyncio

--- a/tests/models/test_requests.py
+++ b/tests/models/test_requests.py
@@ -112,7 +112,7 @@ def test_transfer_encoding_header():
 
     data = streaming_body(b"test 123")
 
-    request = httpx.Request("POST", "http://example.org", data=data)
+    request = httpx.Request("POST", "http://example.org", content=data)
     assert "Content-Length" not in request.headers
     assert request.headers["Transfer-Encoding"] == "chunked"
 
@@ -129,7 +129,7 @@ def test_ignore_transfer_encoding_header_if_content_length_exists():
     data = streaming_body(b"abcd")
 
     headers = {"Content-Length": "4"}
-    request = httpx.Request("POST", "http://example.org", data=data, headers=headers)
+    request = httpx.Request("POST", "http://example.org", content=data, headers=headers)
     assert "Transfer-Encoding" not in request.headers
     assert request.headers["Content-Length"] == "4"
 
@@ -155,7 +155,7 @@ def test_override_content_length_header():
     data = streaming_body(b"test 123")
     headers = {"Content-Length": "8"}
 
-    request = httpx.Request("POST", "http://example.org", data=data, headers=headers)
+    request = httpx.Request("POST", "http://example.org", content=data, headers=headers)
     assert request.headers["Content-Length"] == "8"
 
 

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -35,7 +35,8 @@ async def test_bytes_content():
     assert async_content == b"Hello, world!"
 
     # Support 'data' for compat with requests.
-    headers, stream = encode_request(data=b"Hello, world!")  # type: ignore
+    with pytest.warns(DeprecationWarning):
+        headers, stream = encode_request(data=b"Hello, world!")  # type: ignore
     assert isinstance(stream, typing.Iterable)
     assert isinstance(stream, typing.AsyncIterable)
 
@@ -66,7 +67,8 @@ async def test_iterator_content():
         [part for part in stream]
 
     # Support 'data' for compat with requests.
-    headers, stream = encode_request(data=hello_world())  # type: ignore
+    with pytest.warns(DeprecationWarning):
+        headers, stream = encode_request(data=hello_world())  # type: ignore
     assert isinstance(stream, typing.Iterable)
     assert not isinstance(stream, typing.AsyncIterable)
 
@@ -95,7 +97,8 @@ async def test_aiterator_content():
         [part async for part in stream]
 
     # Support 'data' for compat with requests.
-    headers, stream = encode_request(data=hello_world())  # type: ignore
+    with pytest.warns(DeprecationWarning):
+        headers, stream = encode_request(data=hello_world())  # type: ignore
     assert not isinstance(stream, typing.Iterable)
     assert isinstance(stream, typing.AsyncIterable)
 


### PR DESCRIPTION
Currently we're supporting `data=<bytes|text|bytes-iter|async-byte-iter>` for requests compatibility,
although we're recommending against it.

I think we ought to escalate this into a more formal deprecation warning, and then remove it entirely.

Having a stricter, more consistent API here feels like a clear improvement to me vs `requests`.