### PR TITLE
Deprecate per-request cookies

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -37,6 +37,26 @@ HTTPX uses `utf-8` for encoding `str` request bodies. For example, when using `c
 
 For response bodies, assuming the server didn't send an explicit encoding then HTTPX will do its best to figure out an appropriate encoding. Unlike Requests which uses the `chardet` library, HTTPX relies on a plainer fallback strategy (basically attempting UTF-8, or using Windows-1252 as a fallback). This strategy should be robust enough to handle the vast majority of use cases.
 
+## Cookies
+
+If using a client instance, then cookies should always be set on the client rather than on a per-request basis.
+
+This usage is supported...
+
+```python
+client = httpx.Client(cookies=...)
+client.post(...)
+```
+
+This usage is deprecated...
+
+```python
+client = httpx.Client()
+client.post(..., cookies=...)
+```
+
+We prefer enforcing a stricter API here because it provides clearer expectations around cookie persistence, particularly when redirects occur.
+
 ## Status Codes
 
 In our documentation we prefer the uppercased versions, such as `codes.NOT_FOUND`, but also provide lower-cased versions for API compatibility with `requests`.
@@ -147,6 +167,6 @@ while request is not None:
 
 `requests` allows event hooks to mutate `Request` and `Response` objects. See [examples](https://requests.readthedocs.io/en/master/user/advanced/#event-hooks) given in the documentation for `requests`.
 
-In HTTPX, event hooks may access properties of requests and responses, but event hook callbacks cannot mutate the original request/response. 
+In HTTPX, event hooks may access properties of requests and responses, but event hook callbacks cannot mutate the original request/response.
 
 If you are looking for more control, consider checking out [Custom Transports](advanced.md#custom-transports).

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -46,6 +46,9 @@ This usage is supported:
 ```python
 client = httpx.Client(cookies=...)
 client.post(...)
+```
+
+This usage is **not** supported:
 
 ```python
 client = httpx.Client()

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -41,14 +41,11 @@ For response bodies, assuming the server didn't send an explicit encoding then H
 
 If using a client instance, then cookies should always be set on the client rather than on a per-request basis.
 
-This usage is supported...
+This usage is supported:
 
 ```python
 client = httpx.Client(cookies=...)
 client.post(...)
-```
-
-This usage is deprecated...
 
 ```python
 client = httpx.Client()

--- a/httpx/_api.py
+++ b/httpx/_api.py
@@ -88,7 +88,12 @@ def request(
     ```
     """
     with Client(
-        proxies=proxies, cert=cert, verify=verify, timeout=timeout, trust_env=trust_env
+        cookies=cookies,
+        proxies=proxies,
+        cert=cert,
+        verify=verify,
+        timeout=timeout,
+        trust_env=trust_env,
     ) as client:
         return client.request(
             method=method,
@@ -99,7 +104,6 @@ def request(
             json=json,
             params=params,
             headers=headers,
-            cookies=cookies,
             auth=auth,
             allow_redirects=allow_redirects,
         )
@@ -134,7 +138,9 @@ def stream(
 
     [0]: /quickstart#streaming-responses
     """
-    client = Client(proxies=proxies, cert=cert, verify=verify, trust_env=trust_env)
+    client = Client(
+        cookies=cookies, proxies=proxies, cert=cert, verify=verify, trust_env=trust_env
+    )
     request = Request(
         method=method,
         url=url,
@@ -144,7 +150,6 @@ def stream(
         files=files,
         json=json,
         headers=headers,
-        cookies=cookies,
     )
     return StreamContextManager(
         client=client,

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -733,7 +733,7 @@ class Client(BaseClient):
         """
         if cookies is not None:
             message = (
-                "Setting per-request cookies=... is being deprecated, because "
+                "Setting per-request cookies=<...> is being deprecated, because "
                 "the expected behaviour on cookie persistence is ambiguous. Set "
                 "cookies directly on the client instance instead."
             )

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -731,6 +731,14 @@ class Client(BaseClient):
 
         [0]: /advanced/#merging-of-configuration
         """
+        if cookies is not None:
+            message = (
+                "Setting per-request cookies=... is being deprecated, because "
+                "the expected behaviour on cookie persistence is ambiguous. Set "
+                "cookies directly on the client instance instead."
+            )
+            warnings.warn(message, DeprecationWarning)
+
         request = self.build_request(
             method=method,
             url=url,


### PR DESCRIPTION
Closes #1404

Documentation here is as follows...

---

## Cookies

If using a client instance, then cookies should always be set on the client rather than on a per-request basis.

This usage is supported...

```python
client = httpx.Client(cookies=...)
client.post(...)
```

This usage is deprecated...

```python
client = httpx.Client()
client.post(..., cookies=...)
```

We prefer enforcing a stricter API here because it provides clearer expectations around cookie persistence, particularly when redirects occur.