### PR TITLE
Update `verify` parameter description

### DIFF
--- a/httpx/_api.py
+++ b/httpx/_api.py
@@ -68,7 +68,8 @@ def request(
     * **allow_redirects** - *(optional)* Enables or disables HTTP redirects.
     * **verify** - *(optional)* SSL certificates (a.k.a CA bundle) used to
     verify the identity of requested hosts. Either `True` (default CA bundle),
-    a path to an SSL certificate file, or `False` (disable verification).
+    a path to an SSL certificate file, an `ssl.SSLContext`, or `False`
+    (which will disable verification).
     * **cert** - *(optional)* An SSL certificate used by the requested host
     to authenticate the client. Either a path to an SSL certificate file, or
     two-tuple of (certificate file, key file), or a three-tuple of (certificate

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -546,7 +546,8 @@ class Client(BaseClient):
     sending requests.
     * **verify** - *(optional)* SSL certificates (a.k.a CA bundle) used to
     verify the identity of requested hosts. Either `True` (default CA bundle),
-    a path to an SSL certificate file, or `False` (disable verification).
+    a path to an SSL certificate file, an `ssl.SSLContext`, or `False`
+    (which will disable verification).
     * **cert** - *(optional)* An SSL certificate used by the requested host
     to authenticate the client. Either a path to an SSL certificate file, or
     two-tuple of (certificate file, key file), or a three-tuple of (certificate


### PR DESCRIPTION
Added to documentation to show that `verify` can be an `ssl.SSLContext`, as this is not immediately obvious from the developer interface documentation due to the lack of type hints on the signature that is rendered.

![image](https://user-images.githubusercontent.com/73482956/114899125-9a44e500-9e0a-11eb-9082-000c679ea9f2.png)

