### PR TITLE
Drop Response.call_next

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -918,8 +918,6 @@ class Response:
         # the client will set `response.next_request`.
         self.next_request: typing.Optional[Request] = None
 
-        self.call_next: typing.Optional[typing.Callable] = None
-
         self.extensions = {} if extensions is None else extensions
         self.history = [] if history is None else list(history)
 


### PR DESCRIPTION
Had a look at the attributes of `Response` while thinking about https://github.com/encode/httpx/discussions/1562. Looks like `call_next` is not used for anything.