### PR TITLE
For non-streaming cases, populate `request.content` automatically.

### DIFF
--- a/httpx/_exceptions.py
+++ b/httpx/_exceptions.py
@@ -294,25 +294,23 @@ class StreamConsumed(StreamError):
 
 class ResponseNotRead(StreamError):
     """
-    Attempted to access response content, without having called `read()`
-    after a streaming response.
+    Attempted to access streaming response content, without having called `read()`.
     """
 
     def __init__(self) -> None:
         message = (
-            "Attempted to access response content, without having called `read()` "
-            "after a streaming response."
+            "Attempted to access streaming response content, without having called `read()`."
         )
         super().__init__(message)
 
 
 class RequestNotRead(StreamError):
     """
-    Attempted to access request content, without having called `read()`.
+    Attempted to access streaming request content, without having called `read()`.
     """
 
     def __init__(self) -> None:
-        message = "Attempted to access request content, without having called `read()`."
+        message = "Attempted to access streaming request content, without having called `read()`."
         super().__init__(message)
 
 

--- a/httpx/_exceptions.py
+++ b/httpx/_exceptions.py
@@ -298,9 +298,7 @@ class ResponseNotRead(StreamError):
     """
 
     def __init__(self) -> None:
-        message = (
-            "Attempted to access streaming response content, without having called `read()`."
-        )
+        message = "Attempted to access streaming response content, without having called `read()`."
         super().__init__(message)
 
 

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -829,6 +829,9 @@ class Request:
             headers, stream = encode_request(content, data, files, json)
             self._prepare(headers)
             self.stream = stream
+            # Load the request body, except for streaming content.
+            if isinstance(stream, ByteStream):
+                self.read()
 
     def _prepare(self, default_headers: typing.Dict[str, str]) -> None:
         for key, value in default_headers.items():
@@ -869,10 +872,11 @@ class Request:
         if not hasattr(self, "_content"):
             assert isinstance(self.stream, typing.Iterable)
             self._content = b"".join(self.stream)
-            # If a streaming request has been read entirely into memory, then
-            # we can replace the stream with a raw bytes implementation,
-            # to ensure that any non-replayable streams can still be used.
-            self.stream = ByteStream(self._content)
+            if not isinstance(self.stream, ByteStream):
+                # If a streaming request has been read entirely into memory, then
+                # we can replace the stream with a raw bytes implementation,
+                # to ensure that any non-replayable streams can still be used.
+                self.stream = ByteStream(self._content)
         return self._content
 
     async def aread(self) -> bytes:
@@ -882,10 +886,11 @@ class Request:
         if not hasattr(self, "_content"):
             assert isinstance(self.stream, typing.AsyncIterable)
             self._content = b"".join([part async for part in self.stream])
-            # If a streaming request has been read entirely into memory, then
-            # we can replace the stream with a raw bytes implementation,
-            # to ensure that any non-replayable streams can still be used.
-            self.stream = ByteStream(self._content)
+            if not isinstance(self.stream, ByteStream):
+                # If a streaming request has been read entirely into memory, then
+                # we can replace the stream with a raw bytes implementation,
+                # to ensure that any non-replayable streams can still be used.
+                self.stream = ByteStream(self._content)
         return self._content
 
     def __repr__(self) -> str:
@@ -941,7 +946,7 @@ class Response:
             headers, stream = encode_response(content, text, html, json)
             self._prepare(headers)
             self.stream = stream
-            if content is None or isinstance(content, (bytes, str)):
+            if isinstance(stream, ByteStream):
                 # Load the response body, except for streaming content.
                 self.read()
 

--- a/tests/models/test_requests.py
+++ b/tests/models/test_requests.py
@@ -97,11 +97,12 @@ async def test_aread_and_stream_data():
     assert content == request.content
 
 
-@pytest.mark.asyncio
-async def test_cannot_access_content_without_read():
-    # Ensure a request may still be streamed if it has been read.
-    # Needed for cases such as authentication classes that read the request body.
-    request = httpx.Request("POST", "http://example.org", json={"test": 123})
+def test_cannot_access_streaming_content_without_read():
+    # Ensure that streaming requests
+    def streaming_body():  # pragma: nocover
+        yield ""
+
+    request = httpx.Request("POST", "http://example.org", content=streaming_body())
     with pytest.raises(httpx.RequestNotRead):
         request.content
 


### PR DESCRIPTION
Minor user-experience & consistency tweak.

For non-streaming cases we should pre-load `request.content`.

This leads to neater consistency between requests/responses, and ensures that the request content is readily accessible to introspection.

```pycon
>>> r = httpx.Request("POST", "https://www.example.com", content=b'...')
>>> r.content  # Previously this would raise 'httpx.RequestNotRead'
b'...'
```

```pycon
>>> r = httpx.Request("POST", "https://www.example.com", json={"example": "payload"})
>>> r.content  # Previously this would raise 'httpx.RequestNotRead'
b'{"example": "payload"}'
```

```pycon
>>> r = httpx.Request("POST", "https://www.example.com", content=[b'.' for i in range(3)])
>>> r.content
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/tomchristie/GitHub/encode/httpx/httpx/_models.py", line 865, in content
    raise RequestNotRead()
httpx.RequestNotRead: Attempted to access streaming request content, without having called `read()`.
```

Or, eg...

**Previously**...

```pycon
>>> import httpx
>>> r = httpx.get("https://www.example.com")
>>> r.request.content
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/tomchristie/GitHub/encode/httpx/httpx/_models.py", line 862, in content
    raise RequestNotRead()
httpx.RequestNotRead: Attempted to access request content, without having called `read()`  # Eh?
````

**Now**...

```pycon
>>> import httpx
>>> r = httpx.get("https://www.example.com")
>>> r.request.content
b''
```