### PR TITLE
App support

### DIFF
--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -1,5 +1,7 @@
 from .__version__ import __description__, __title__, __version__
 from ._api import delete, get, head, options, patch, post, put, request, stream
+from ._apps.routing import Route, Router
+from ._apps.wsgi import WSGIApp
 from ._auth import Auth, BasicAuth, DigestAuth
 from ._client import AsyncClient, Client
 from ._config import Limits, Proxy, Timeout, create_ssl_context
@@ -100,6 +102,8 @@ __all__ = [
     "RequestNotRead",
     "Response",
     "ResponseNotRead",
+    "Route",
+    "Router",
     "StatusCode",
     "stream",
     "StreamClosed",
@@ -114,6 +118,7 @@ __all__ = [
     "URL",
     "WriteError",
     "WriteTimeout",
+    "WSGIApp",
     "WSGITransport",
 ]
 

--- a/httpx/_apps/routing.py
+++ b/httpx/_apps/routing.py
@@ -1,0 +1,111 @@
+import re
+import typing
+
+from httpx._exceptions import UnsupportedProtocol
+from httpx._models import Request, Response
+from httpx._transports.base import (
+    AsyncBaseTransport,
+    AsyncByteStream,
+    BaseTransport,
+    SyncByteStream,
+)
+
+PARAM_REGEX = re.compile("{([a-zA-Z_][a-zA-Z0-9_]*)}")
+
+
+class Route:
+    def __init__(self, path: str, endpoint: typing.Callable) -> None:
+        self.path = path
+        self.endpoint = endpoint
+        self.regex = self._compile_regex(path)
+
+    def _compile_regex(self, path: str) -> re.Pattern:
+        regex = "^"
+        idx = 0
+
+        for match in PARAM_REGEX.finditer(path):
+            (param_name,) = match.groups()
+            regex += re.escape(path[idx : match.start()])
+            regex += f"(?P<{param_name}>[^/]+)"
+            idx = match.end()
+
+        regex += re.escape(path[idx:]) + "$"
+        return re.compile(regex)
+
+    def matches(self, request: Request) -> bool:
+        match = self.regex.match(request.url.path)
+        return bool(match)
+
+    def handle(self, request: Request) -> Response:
+        return self.endpoint(request)
+
+
+class Router(BaseTransport, AsyncBaseTransport):
+    def __init__(self, routes: typing.List[Route]):
+        self.routes = routes
+
+    def handle_request(
+        self,
+        method: bytes,
+        url: typing.Tuple[bytes, bytes, typing.Optional[int], bytes],
+        headers: typing.List[typing.Tuple[bytes, bytes]],
+        stream: SyncByteStream,
+        extensions: dict,
+    ) -> typing.Tuple[
+        int, typing.List[typing.Tuple[bytes, bytes]], SyncByteStream, dict
+    ]:
+        request = Request(
+            method=method,
+            url=url,
+            headers=headers,
+            stream=stream,
+        )
+        request.read()
+        if request.url.scheme not in ("http", "https"):
+            raise UnsupportedProtocol(f"Scheme {request.url.scheme!r} not supported.")
+        response = self.handle(request)
+        assert isinstance(response.stream, SyncByteStream)
+        return (
+            response.status_code,
+            response.headers.raw,
+            response.stream,
+            response.extensions,
+        )
+
+    async def handle_async_request(
+        self,
+        method: bytes,
+        url: typing.Tuple[bytes, bytes, typing.Optional[int], bytes],
+        headers: typing.List[typing.Tuple[bytes, bytes]],
+        stream: AsyncByteStream,
+        extensions: dict,
+    ) -> typing.Tuple[
+        int, typing.List[typing.Tuple[bytes, bytes]], AsyncByteStream, dict
+    ]:
+        request = Request(
+            method=method,
+            url=url,
+            headers=headers,
+            stream=stream,
+        )
+        await request.aread()
+        if request.url.scheme not in ("http", "https"):
+            raise UnsupportedProtocol(f"Scheme {request.url.scheme!r} not supported.")
+        response = self.handle(request)
+        assert isinstance(response.stream, AsyncByteStream)
+        return (
+            response.status_code,
+            response.headers.raw,
+            response.stream,
+            response.extensions,
+        )
+
+    def handle(self, request: Request) -> Response:
+        for route in self.routes:
+            if route.matches(request):
+                return route.handle(request)
+
+        return self.handle_not_found(request)
+
+    def handle_not_found(self, request: Request) -> Response:
+        return Response(404, text="Not found")

--- a/httpx/_apps/wsgi.py
+++ b/httpx/_apps/wsgi.py
@@ -1,0 +1,75 @@
+import typing
+from urllib.parse import quote
+
+from httpx._apps.routing import Route, Router
+from httpx._status_codes import codes
+from httpx._transports.base import BaseTransport, SyncByteStream
+
+
+class WSGIStream(SyncByteStream):
+    def __init__(self, wsgi_input: typing.Iterable[bytes]) -> None:
+        self._wsgi_input = wsgi_input
+
+    def __iter__(self) -> typing.Iterator[bytes]:
+        for chunk in self._wsgi_input:
+            yield chunk
+
+
+class WSGIApp(BaseTransport):
+    def __init__(self, routes: typing.List[Route]) -> None:
+        self.router = Router(routes)
+
+    def __call__(
+        self, environ: dict, start_response: typing.Callable
+    ) -> typing.Iterable[bytes]:
+        method = environ["REQUEST_METHOD"].encode("ascii")
+        scheme = environ["wsgi.url_scheme"].encode("ascii")
+        host = environ.get("HTTP_HOST", environ["SERVER_NAME"]).encode("ascii")
+        port = environ["SERVER_PORT"]
+        path = quote(environ.get("SCRIPT_NAME", "")).encode("ascii")
+        path += quote(environ.get("PATH_INFO", "")).encode("ascii")
+        if environ.get("QUERY_STRING"):
+            path += b"?" + environ["QUERY_STRING"].encode("ascii")
+        url = (scheme, host, port, path)
+        headers = [
+            (key.encode("ascii"), value.encode("ascii"))
+            for key, value in environ.items()
+            if key in ("CONTENT_TYPE", "CONTENT_LENGTH")
+        ]
+        headers += [
+            (key[5:].encode("ascii"), value.encode("ascii"))
+            for key, value in environ.items()
+            if key.startswith("HTTP_")
+        ]
+        stream: SyncByteStream = WSGIStream(environ["wsgi.input"])
+        extensions: dict = {}
+
+        status_code, headers, stream, extensions = self.handle_request(
+            method=method,
+            url=url,
+            headers=headers,
+            stream=stream,
+            extensions=extensions,
+        )
+
+        reason_phrase = codes.get_reason_phrase(status_code)
+        wsgi_status = f"{status_code} {reason_phrase}"
+        wsgi_headers = [
+            (key.decode("ascii"), value.decode("ascii")) for key, value in headers
+        ]
+
+        start_response(wsgi_status, wsgi_headers, exc_info=None)
+
+        return stream
+
+    def handle_request(
+        self,
+        method: bytes,
+        url: typing.Tuple[bytes, bytes, typing.Optional[int], bytes],
+        headers: typing.List[typing.Tuple[bytes, bytes]],
+        stream: SyncByteStream,
+        extensions: dict,
+    ) -> typing.Tuple[
+        int, typing.List[typing.Tuple[bytes, bytes]], SyncByteStream, dict
+    ]:
+        return self.router.handle_request(method, url, headers, stream, extensions)


### PR DESCRIPTION
This draft pull request demonstrates how we'd potentially be able to use `httpx` for server-side development.

For example:

```python
import httpx


def homepage(request):
    return httpx.Response(200, json={'hello': 'world'})

routes = [
    httpx.Route("/", endpoint=homepage),
]

app = httpx.WSGIApp(routes=routes)
```

Running the app using Gunicorn:

```shell
$ gunicorn example:app
[2021-04-23 10:23:32 +0100] [30102] [INFO] Starting gunicorn 20.1.0
[2021-04-23 10:23:32 +0100] [30102] [INFO] Listening at: http://127.0.0.1:8000 (30102)
[2021-04-23 10:23:32 +0100] [30102] [INFO] Using worker: sync
[2021-04-23 10:23:32 +0100] [30105] [INFO] Booting worker with pid: 30105
```

In the pull request I've also updated two of the test case modules to use routes and routers, rather than a single handler function.

* `tests/client/test_event_hooks.py`
* `tests/client/test_redirects.py`

I'm not pushing for us to *necessarily* go down this road, but it's an interesting starting point, and it's worth us keeping this in mind. Am glossing over a few details for now, but with relatively little effort we'd be able to support using httpx as the basis for server-side apps, with both WSGI and ASGI support.

Beware scope-creep, of course. But also, *...interesting*.