### PR TITLE
Escalate 0.17 deprecation warnings to becoming fully deprecated.

### DIFF
--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -35,7 +35,7 @@ from ._exceptions import (
     WriteTimeout,
 )
 from ._models import URL, Cookies, Headers, QueryParams, Request, Response
-from ._status_codes import StatusCode, codes
+from ._status_codes import codes
 from ._transports.asgi import ASGITransport
 from ._transports.base import (
     AsyncBaseTransport,
@@ -100,7 +100,6 @@ __all__ = [
     "RequestNotRead",
     "Response",
     "ResponseNotRead",
-    "StatusCode",
     "stream",
     "StreamClosed",
     "StreamConsumed",

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -57,7 +57,6 @@ from ._utils import (
     get_environment_proxies,
     get_logger,
     same_origin,
-    warn_deprecated,
 )
 
 # The type annotation for @classmethod and context managers here follows PEP 484
@@ -586,7 +585,6 @@ class Client(BaseClient):
         mounts: typing.Mapping[str, BaseTransport] = None,
         timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
         limits: Limits = DEFAULT_LIMITS,
-        pool_limits: Limits = None,
         max_redirects: int = DEFAULT_MAX_REDIRECTS,
         event_hooks: typing.Mapping[str, typing.List[typing.Callable]] = None,
         base_url: URLTypes = "",
@@ -614,13 +612,6 @@ class Client(BaseClient):
                     "Using http2=True, but the 'h2' package is not installed. "
                     "Make sure to install httpx using `pip install httpx[http2]`."
                 ) from None
-
-        if pool_limits is not None:
-            warn_deprecated(
-                "Client(..., pool_limits=...) is deprecated and will raise "
-                "errors in the future. Use Client(..., limits=...) instead."
-            )
-            limits = pool_limits
 
         allow_env_proxies = trust_env and app is None and transport is None
         proxy_map = self._get_proxy_map(proxies, allow_env_proxies)
@@ -1280,7 +1271,6 @@ class AsyncClient(BaseClient):
         mounts: typing.Mapping[str, AsyncBaseTransport] = None,
         timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
         limits: Limits = DEFAULT_LIMITS,
-        pool_limits: Limits = None,
         max_redirects: int = DEFAULT_MAX_REDIRECTS,
         event_hooks: typing.Mapping[str, typing.List[typing.Callable]] = None,
         base_url: URLTypes = "",
@@ -1308,13 +1298,6 @@ class AsyncClient(BaseClient):
                     "Using http2=True, but the 'h2' package is not installed. "
                     "Make sure to install httpx using `pip install httpx[http2]`."
                 ) from None
-
-        if pool_limits is not None:
-            warn_deprecated(
-                "AsyncClient(..., pool_limits=...) is deprecated and will raise "
-                "errors in the future. Use AsyncClient(..., limits=...) instead."
-            )
-            limits = pool_limits
 
         allow_env_proxies = trust_env and app is None and transport is None
         proxy_map = self._get_proxy_map(proxies, allow_env_proxies)

--- a/httpx/_status_codes.py
+++ b/httpx/_status_codes.py
@@ -1,4 +1,3 @@
-import warnings
 from enum import IntEnum
 
 
@@ -142,23 +141,3 @@ class codes(IntEnum):
 # Include lower-case styles for `requests` compatibility.
 for code in codes:
     setattr(codes, code._name_.lower(), int(code))
-
-
-class StatusCodeCompat:
-    def __call__(self, *args, **kwargs):  # type: ignore
-        message = "`httpx.StatusCode` is deprecated. Use `httpx.codes` instead."
-        warnings.warn(message, DeprecationWarning)
-        return codes(*args, **kwargs)
-
-    def __getattr__(self, attr):  # type: ignore
-        message = "`httpx.StatusCode` is deprecated. Use `httpx.codes` instead."
-        warnings.warn(message, DeprecationWarning)
-        return getattr(codes, attr)
-
-    def __getitem__(self, item):  # type: ignore
-        message = "`httpx.StatusCode` is deprecated. Use `httpx.codes` instead."
-        warnings.warn(message, DeprecationWarning)
-        return codes[item]
-
-
-StatusCode = StatusCodeCompat()

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -8,7 +8,6 @@ import re
 import sys
 import time
 import typing
-import warnings
 from pathlib import Path
 from urllib.request import getproxies
 
@@ -472,12 +471,11 @@ class URLPattern:
         from ._models import URL
 
         if pattern and ":" not in pattern:
-            warn_deprecated(
+            raise ValueError(
                 f"Proxy keys should use proper URL forms rather "
                 f"than plain scheme strings. "
                 f'Instead of "{pattern}", use "{pattern}://"'
             )
-            pattern += "://"
 
         url = URL(pattern)
         self.pattern = pattern
@@ -535,7 +533,3 @@ class URLPattern:
 
     def __eq__(self, other: typing.Any) -> bool:
         return isinstance(other, URLPattern) and self.pattern == other.pattern
-
-
-def warn_deprecated(message: str) -> None:  # pragma: nocover
-    warnings.warn(message, DeprecationWarning, stacklevel=2)

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -222,16 +222,6 @@ def test_merge_relative_url_with_encoded_slashes():
     assert request.url == "https://www.example.com/base%2Fpath/testing"
 
 
-def test_pool_limits_deprecated():
-    limits = httpx.Limits()
-
-    with pytest.warns(DeprecationWarning):
-        httpx.Client(pool_limits=limits)
-
-    with pytest.warns(DeprecationWarning):
-        httpx.AsyncClient(pool_limits=limits)
-
-
 def test_context_managed_transport():
     class Transport(httpx.BaseTransport):
         def __init__(self):

--- a/tests/client/test_proxies.py
+++ b/tests/client/test_proxies.py
@@ -256,17 +256,19 @@ def test_proxies_environ(monkeypatch, client_class, url, env, expected):
 
 
 @pytest.mark.parametrize(
-    ["proxies", "expected_scheme"],
+    ["proxies", "is_valid"],
     [
-        ({"http": "http://127.0.0.1"}, "http://"),
-        ({"https": "http://127.0.0.1"}, "https://"),
-        ({"all": "http://127.0.0.1"}, "all://"),
+        ({"http": "http://127.0.0.1"}, False),
+        ({"https": "http://127.0.0.1"}, False),
+        ({"all": "http://127.0.0.1"}, False),
+        ({"http://": "http://127.0.0.1"}, True),
+        ({"https://": "http://127.0.0.1"}, True),
+        ({"all://": "http://127.0.0.1"}, True),
     ],
 )
-def test_for_deprecated_proxy_params(proxies, expected_scheme):
-    with pytest.deprecated_call() as block:
+def test_for_deprecated_proxy_params(proxies, is_valid):
+    if not is_valid:
+        with pytest.raises(ValueError):
+            httpx.Client(proxies=proxies)
+    else:
         httpx.Client(proxies=proxies)
-
-    warning_message = str(block.pop(DeprecationWarning))
-
-    assert expected_scheme in warning_message

--- a/tests/test_status_codes.py
+++ b/tests/test_status_codes.py
@@ -1,5 +1,3 @@
-import pytest
-
 import httpx
 
 
@@ -26,14 +24,3 @@ def test_reason_phrase_for_status_code():
 
 def test_reason_phrase_for_unknown_status_code():
     assert httpx.codes.get_reason_phrase(499) == ""
-
-
-def test_deprecated_status_code_class():
-    with pytest.warns(DeprecationWarning):
-        assert httpx.StatusCode.NOT_FOUND == 404
-
-    with pytest.warns(DeprecationWarning):
-        assert httpx.StatusCode(404) == 404
-
-    with pytest.warns(DeprecationWarning):
-        assert httpx.StatusCode["NOT_FOUND"] == 404


### PR DESCRIPTION
The following API changes have been issuing deprecation warnings since 0.17.0 onwards, and are now fully deprecated...

* You should now use `httpx.codes` consistently instead of `httpx.StatusCodes`.
* Use `limits=...` instead of `pool_limits=...`.
* Use `proxies={"http://": ...}` instead of `proxies={"http": ...}` for scheme-specific mounting.