### PR TITLE
Tweak QueryParams implementation

### DIFF
--- a/tests/models/test_queryparams.py
+++ b/tests/models/test_queryparams.py
@@ -18,17 +18,17 @@ def test_queryparams(source):
     assert "a" in q
     assert "A" not in q
     assert "c" not in q
-    assert q["a"] == "456"
-    assert q.get("a") == "456"
+    assert q["a"] == "123"
+    assert q.get("a") == "123"
     assert q.get("nope", default=None) is None
     assert q.get_list("a") == ["123", "456"]
 
     assert list(q.keys()) == ["a", "b"]
-    assert list(q.values()) == ["456", "789"]
-    assert list(q.items()) == [("a", "456"), ("b", "789")]
+    assert list(q.values()) == ["123", "789"]
+    assert list(q.items()) == [("a", "123"), ("b", "789")]
     assert len(q) == 2
     assert list(q) == ["a", "b"]
-    assert dict(q) == {"a": "456", "b": "789"}
+    assert dict(q) == {"a": "123", "b": "789"}
     assert str(q) == "a=123&a=456&b=789"
     assert repr(q) == "QueryParams('a=123&a=456&b=789')"
     assert httpx.QueryParams({"a": "123", "b": "456"}) == httpx.QueryParams(


### PR DESCRIPTION
Tweak QueryParams implementation internally, so that we're just using a single data-structure.

`._dict = {k: [v1, v2, v3]}`

Instead of a pair of data structures...

`._dict = {k: v1}`
`._list= [(k, v1), (k, v2), (k, v3)]`

Note that this also resolves a minor minor buglette:

The `QueryParams.get()` docstring states *"Get a value from the query param for a given key. If the key occurs more than once, then only the first value is returned."*

However, prior to this change, for cases with multiple values, the *last* value was being returned.