### PR TITLE
Immutable QueryParams

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -386,7 +386,7 @@ class BaseClient:
         """
         if params or self.params:
             merged_queryparams = QueryParams(self.params)
-            merged_queryparams.update(params)
+            merged_queryparams = merged_queryparams.merge(params)
             return merged_queryparams
         return params
 

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -1,5 +1,4 @@
 import codecs
-import collections
 import logging
 import mimetypes
 import netrc
@@ -368,31 +367,6 @@ def peek_filelike_length(stream: typing.IO) -> int:
     else:
         # Yup, seems to be an actual file.
         return os.fstat(fd).st_size
-
-
-def flatten_queryparams(
-    queryparams: typing.Mapping[
-        str, typing.Union["PrimitiveData", typing.Sequence["PrimitiveData"]]
-    ]
-) -> typing.List[typing.Tuple[str, "PrimitiveData"]]:
-    """
-    Convert a mapping of query params into a flat list of two-tuples
-    representing each item.
-
-    Example:
-    >>> flatten_queryparams_values({"q": "httpx", "tag": ["python", "dev"]})
-    [("q", "httpx), ("tag", "python"), ("tag", "dev")]
-    """
-    items = []
-
-    for k, v in queryparams.items():
-        if isinstance(v, collections.abc.Sequence) and not isinstance(v, (str, bytes)):
-            for u in v:
-                items.append((k, u))
-        else:
-            items.append((k, typing.cast("PrimitiveData", v)))
-
-    return items
 
 
 class Timer:

--- a/tests/models/test_queryparams.py
+++ b/tests/models/test_queryparams.py
@@ -76,19 +76,50 @@ def test_queryparam_types():
     assert str(q) == "a=1&a=2"
 
 
-def test_queryparam_setters():
-    q = httpx.QueryParams({"a": 1})
-    q.update([])
+def test_queryparam_update_is_hard_deprecated():
+    q = httpx.QueryParams("a=123")
+    with pytest.raises(RuntimeError):
+        q.update({"a": "456"})
 
-    assert str(q) == "a=1"
 
-    q = httpx.QueryParams([("a", 1), ("a", 2)])
-    q["a"] = "3"
-    assert str(q) == "a=3"
+def test_queryparam_setter_is_hard_deprecated():
+    q = httpx.QueryParams("a=123")
+    with pytest.raises(RuntimeError):
+        q["a"] = "456"
 
-    q = httpx.QueryParams([("a", 1), ("b", 1)])
-    u = httpx.QueryParams([("b", 2), ("b", 3)])
-    q.update(u)
 
-    assert str(q) == "a=1&b=2&b=3"
-    assert q["b"] == u["b"]
+def test_queryparam_set():
+    q = httpx.QueryParams("a=123")
+    q = q.set("a", "456")
+    assert q == httpx.QueryParams("a=456")
+
+
+def test_queryparam_add():
+    q = httpx.QueryParams("a=123")
+    q = q.add("a", "456")
+    assert q == httpx.QueryParams("a=123&a=456")
+
+
+def test_queryparam_remove():
+    q = httpx.QueryParams("a=123")
+    q = q.remove("a")
+    assert q == httpx.QueryParams("")
+
+
+def test_queryparam_merge():
+    q = httpx.QueryParams("a=123")
+    q = q.merge({"b": "456"})
+    assert q == httpx.QueryParams("a=123&b=456")
+    q = q.merge({"a": "000", "c": "789"})
+    assert q == httpx.QueryParams("a=000&b=456&c=789")
+
+
+def test_queryparams_are_hashable():
+    params = (
+        httpx.QueryParams("a=123"),
+        httpx.QueryParams({"a": 123}),
+        httpx.QueryParams("b=456"),
+        httpx.QueryParams({"b": 456}),
+    )
+
+    assert len(set(params)) == 2

--- a/tests/models/test_queryparams.py
+++ b/tests/models/test_queryparams.py
@@ -18,17 +18,17 @@ def test_queryparams(source):
     assert "a" in q
     assert "A" not in q
     assert "c" not in q
-    assert q["a"] == "456"
-    assert q.get("a") == "456"
+    assert q["a"] == "123"
+    assert q.get("a") == "123"
     assert q.get("nope", default=None) is None
     assert q.get_list("a") == ["123", "456"]
 
     assert list(q.keys()) == ["a", "b"]
-    assert list(q.values()) == ["456", "789"]
-    assert list(q.items()) == [("a", "456"), ("b", "789")]
+    assert list(q.values()) == ["123", "789"]
+    assert list(q.items()) == [("a", "123"), ("b", "789")]
     assert len(q) == 2
     assert list(q) == ["a", "b"]
-    assert dict(q) == {"a": "456", "b": "789"}
+    assert dict(q) == {"a": "123", "b": "789"}
     assert str(q) == "a=123&a=456&b=789"
     assert repr(q) == "QueryParams('a=123&a=456&b=789')"
     assert httpx.QueryParams({"a": "123", "b": "456"}) == httpx.QueryParams(


### PR DESCRIPTION
As outlined in #1599.
Refs #1275.

Drop support for `QueryParams.__setitem__` and `QueryParams.update()` in favour of an immutable-only interface, in line with our `URL` design. All manipulation methods now return new QueryParams instances:

```python
q = httpx.QueryParams()

q = q.set("a", "123")
assert q == httpx.QueryParams("a=123")

q = q.add("a", "456")
assert q == httpx.QueryParams("a=123&a=456")

q = q.remove("a")
assert q == httpx.QueryParams("")

q = q.merge({"b": "789"})
assert q == httpx.QueryParams("b=789")
```

I've opted for a hard deprecation here, with `.update()` raising a RuntimeError, because immutability vs. mutability isn't something we ought to go "we're halfway there" on.