### PR TITLE
Expand URL interface

### DIFF
--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -100,11 +100,13 @@ def test_url_eq_str():
 def test_url_params():
     url = httpx.URL("https://example.org:123/path/to/somewhere", params={"a": "123"})
     assert str(url) == "https://example.org:123/path/to/somewhere?a=123"
+    assert url.params == httpx.QueryParams({"a": "123"})
 
     url = httpx.URL(
         "https://example.org:123/path/to/somewhere?b=456", params={"a": "123"}
     )
-    assert str(url) == "https://example.org:123/path/to/somewhere?b=456&a=123"
+    assert str(url) == "https://example.org:123/path/to/somewhere?a=123"
+    assert url.params == httpx.QueryParams({"a": "123"})
 
 
 def test_url_join():

--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -124,6 +124,38 @@ def test_url_join():
     assert url.join("../../somewhere-else") == "https://example.org:123/somewhere-else"
 
 
+def test_url_set_param_manipulation():
+    """
+    Some basic URL query parameter manipulation.
+    """
+    url = httpx.URL("https://example.org:123/?a=123")
+    assert url.copy_set_param("a", "456") == "https://example.org:123/?a=456"
+
+
+def test_url_add_param_manipulation():
+    """
+    Some basic URL query parameter manipulation.
+    """
+    url = httpx.URL("https://example.org:123/?a=123")
+    assert url.copy_add_param("a", "456") == "https://example.org:123/?a=123&a=456"
+
+
+def test_url_remove_param_manipulation():
+    """
+    Some basic URL query parameter manipulation.
+    """
+    url = httpx.URL("https://example.org:123/?a=123")
+    assert url.copy_remove_param("a") == "https://example.org:123/"
+
+
+def test_url_merge_params_manipulation():
+    """
+    Some basic URL query parameter manipulation.
+    """
+    url = httpx.URL("https://example.org:123/?a=123")
+    assert url.copy_merge_params({"b": "456"}) == "https://example.org:123/?a=123&b=456"
+
+
 def test_relative_url_join():
     url = httpx.URL("/path/to/somewhere")
     assert url.join("/somewhere-else") == "/somewhere-else"


### PR DESCRIPTION
Neaten out the URL interface as follows:

* Support `httpx.URL(**kwargs)`
* Support `url.copy_with(params=...)`
* Support `url.params`
* Support `url.copy_set_param()`, `url.copy_add_param()`, `url.copy_remove_param()`, `url.copy_merge_params()`

For instance:

```python
u = httpx.URL("https://www.example.com/", username="tom@gmail.com", password="123 456")
assert u == "https://tom%40gmail.com:123%20456@www.example.com/"

u = httpx.URL(scheme="https", host="www.example.com", path="/')
assert u == "https://www.example.com/"

u = httpx.URL("https://www.example.com/")
u = u.copy_with(params={"search": "is green a colour?"}
assert u == "https://www.example.com/?search=is+green+a+colour%3F"

u = httpx.URL("https://www.example.com/?a=123")
assert u.params == httpx.QueryParams({"a": "123"})

u = httpx.URL("https://www.example.com/?a=123")
u = u.copy_set_param("a", "456")
assert u == "https://www.example.com/?a=456"

u = httpx.URL("https://www.example.com/?a=123")
u = u.copy_add_param("a", "456")
assert u == "https://www.example.com/?a=123&a=456"

u = httpx.URL("https://www.example.com/?a=123")
u = u.copy_remove_param("a")
assert u == "https://www.example.com/"

u = httpx.URL("https://www.example.com/?a=123")
u = u.copy_merge_params({"b": "456"})
assert u == "https://www.example.com/?a=123&b=456"
```

There's one edge case bit of necessary straightening out here, which is the behaviour of:

```python
u = httpx.URL("https://www.example.com/?a=123", params={"b": "456"})
```

Which now *replaces* the params, rather than merging them. Because that's the consistent thing to do if `params` is just one of many possible keyword arguments there, and should get consistent behaviour.

Note however that I've continued to ensure that #652 remains resolved. So:

```python
httpx.get("https://www.example.com/?a=123", params={"b": "456"})  # Outgoing request uses "?a=123&b=456" here.

# Is equivalent to...
url = httpx.URL("https://www.example.com/?a=123")
url = url.copy_merge_params({"b": "456"}
httpx.get(url)
```