### PR TITLE
Don't convert `data={"key": [bytes|bytearray]}` cases into strings

### DIFF
--- a/httpx/_content.py
+++ b/httpx/_content.py
@@ -104,6 +104,8 @@ def encode_urlencoded_data(
     for key, value in data.items():
         if isinstance(value, (list, tuple)):
             plain_data.extend([(key, primitive_value_to_str(item)) for item in value])
+        elif isinstance(value, (bytes, bytearray)):
+            plain_data.append((key, value))
         else:
             plain_data.append((key, primitive_value_to_str(value)))
     body = urlencode(plain_data, doseq=True).encode("utf-8")


### PR DESCRIPTION
Related to https://github.com/encode/httpx/pull/1539 

In case of a value in the `data` keyword argument is `bytes` or `bytesarray`, converting them to `str` was not the original behavior. I think it's forgotten to cover these cases in https://github.com/encode/httpx/pull/1539  so this PR covers `bytes|bytearray` cases.

To replicate the issue:

```python
import httpx

with open('path/to/some_image.png', 'rb') as file:
    image_file = file.read()
    httpx.post('http://localhost:800/some_path', data={'example': image_file})
```

*P.S. The binary data is being sent as is in the [`requests`](https://pypi.org/project/requests) package and in the versions of `httpx` before `0.18.0`.*