### PR TITLE
Add missing `timeout=...` to top-level `httpx.stream()` function.

### DIFF
--- a/httpx/_api.py
+++ b/httpx/_api.py
@@ -142,7 +142,12 @@ def stream(
     [0]: /quickstart#streaming-responses
     """
     with Client(
-        cookies=cookies, proxies=proxies, cert=cert, verify=verify, trust_env=trust_env
+        cookies=cookies,
+        proxies=proxies,
+        cert=cert,
+        verify=verify,
+        timeout=timeout,
+        trust_env=trust_env,
     ) as client:
         with client.stream(
             method=method,


### PR DESCRIPTION
Refs #1611

Our refactoring to remove the `StreamContextManager` class in https://github.com/encode/httpx/pull/1577/files#diff-52ea133fd8a901d7004a1242a4db84ffa3be26864fb6b6c2c1dbd1f36e7d2027 omitted to pass through the `timeout=...` parameter in the top-level `httpx.stream(...)` function.

As a result, in 0.18.0 when using `httpx.stream(..., timeout=...)` the timeout parameter was not taking any effect, and the default timeout was instead being used.