### PR TITLE
Version 0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-* Pass through `timeout=...`` in top-level httpx.stream() function. (Pull #1613)
+* Pass through `timeout=...` in top-level httpx.stream() function. (Pull #1613)
 * Map httpcore transport close exceptions to httpx exceptions. (Pull #1606)
 
 ## 0.18.0 (27th April, 2021)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.18.1 (29th April, 2021)
+
+### Changed
+
+* Update brotli support to use the `brotlicffi` package (Pull #1605)
+* Ensure that `Request(..., stream=...)` does not auto-generate any headers on the request instance. (Pull #1607)
+
+### Fixed
+
+* Pass through `timeout=...`` in top-level httpx.stream() function. (Pull #1613)
+* Map httpcore transport close exceptions to httpx exceptions. (Pull #1606)
+
 ## 0.18.0 (27th April, 2021)
 
 The 0.18.x release series formalises our low-level Transport API, introducing the base classes `httpx.BaseTransport` and `httpx.AsyncBaseTransport`.

--- a/httpx/__version__.py
+++ b/httpx/__version__.py
@@ -1,3 +1,3 @@
 __title__ = "httpx"
 __description__ = "A next generation HTTP client, for Python 3."
-__version__ = "0.18.0"
+__version__ = "0.18.1"


### PR DESCRIPTION
## 0.18.1 (29th April, 2021)

### Changed

* Update brotli support to use the `brotlicffi` package (Pull #1605)
* Ensure that `Request(..., stream=...)` does not auto-generate any headers on the request instance. (Pull #1607)

### Fixed

* Pass through `timeout=...` in top-level httpx.stream() function. (Pull #1613)
* Map httpcore transport close exceptions to httpx exceptions. (Pull #1606)