### PR TITLE
Prefer `Content-Length` over `Transfer-Encoding: chunked` for `content=<file-like>` cases.

### DIFF
--- a/httpx/_multipart.py
+++ b/httpx/_multipart.py
@@ -93,9 +93,8 @@ class FileField:
             return len(headers) + len(to_bytes(self.file))
 
         # Let's do our best not to read `file` into memory.
-        try:
-            file_length = peek_filelike_length(self.file)
-        except OSError:
+        file_length = peek_filelike_length(self.file)
+        if file_length is None:
             # As a last resort, read file and cache contents for later.
             assert not hasattr(self, "_data")
             self._data = to_bytes(self.file.read())

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -342,7 +342,7 @@ def guess_content_type(filename: typing.Optional[str]) -> typing.Optional[str]:
     return None
 
 
-def peek_filelike_length(stream: typing.IO) -> typing.Optional[int]:
+def peek_filelike_length(stream: typing.Any) -> typing.Optional[int]:
     """
     Given a file-like stream object, return its length in number of bytes
     without reading it into memory.
@@ -350,7 +350,9 @@ def peek_filelike_length(stream: typing.IO) -> typing.Optional[int]:
     try:
         # Is it an actual file?
         fd = stream.fileno()
-    except OSError:
+        # Yup, seems to be an actual file.
+        length = os.fstat(fd).st_size
+    except (AttributeError, OSError):
         # No... Maybe it's something that supports random access, like `io.BytesIO`?
         try:
             # Assuming so, go to end of stream to figure out its length,
@@ -358,14 +360,11 @@ def peek_filelike_length(stream: typing.IO) -> typing.Optional[int]:
             offset = stream.tell()
             length = stream.seek(0, os.SEEK_END)
             stream.seek(offset)
-        except OSError:
+        except (AttributeError, OSError):
             # Not even that? Sorry, we're doomed...
             return None
-        else:
-            return length
-    else:
-        # Yup, seems to be an actual file.
-        return os.fstat(fd).st_size
+
+    return length
 
 
 class Timer:

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -342,7 +342,7 @@ def guess_content_type(filename: typing.Optional[str]) -> typing.Optional[str]:
     return None
 
 
-def peek_filelike_length(stream: typing.IO) -> int:
+def peek_filelike_length(stream: typing.IO) -> typing.Optional[int]:
     """
     Given a file-like stream object, return its length in number of bytes
     without reading it into memory.
@@ -360,7 +360,7 @@ def peek_filelike_length(stream: typing.IO) -> int:
             stream.seek(offset)
         except OSError:
             # Not even that? Sorry, we're doomed...
-            raise
+            return None
         else:
             return length
     else:

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -49,6 +49,18 @@ async def test_bytes_content():
 
 
 @pytest.mark.asyncio
+async def test_bytesio_content():
+    headers, stream = encode_request(content=io.BytesIO(b"Hello, world!"))
+    assert isinstance(stream, typing.Iterable)
+    assert not isinstance(stream, typing.AsyncIterable)
+
+    content = b"".join([part for part in stream])
+
+    assert headers == {"Content-Length": "13"}
+    assert content == b"Hello, world!"
+
+
+@pytest.mark.asyncio
 async def test_iterator_content():
     def hello_world():
         yield b"Hello, "


### PR DESCRIPTION
Closes #1490

Step 1: Add failing test case for `content=io.BytesIO(...)`:

```python
def test_bytesio_content():
    headers, stream = encode_request(content=io.BytesIO(b"Hello, world!"))
    assert isinstance(stream, typing.Iterable)
    assert not isinstance(stream, typing.AsyncIterable)

    content = b"".join([part for part in stream])

    assert headers == {"Content-Length": "13"}  # Currently returns {'Transfer-Encoding': 'chunked'}
    assert content == b"Hello, world!"
```

Step 2: Refactor `peek_filelike_length` to return `Optional[int]`, rather than raising an exception when the length cannot be determined.

Step 3: Use `peek_filelike_length` in the `elif isinstance(content, Iterable):` case of `encode_content(...) -> (headers, stream)`, switching between either `Content-Length: <length>` or `Transfer-Encoding: chunked`