### PR TITLE
".ok" property added to the Response object

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -1404,6 +1404,20 @@ class Response:
             message = message.format(self, error_type="Server Error")
             raise HTTPStatusError(message, request=request, response=self)
 
+    @property
+    def ok(self):
+        """Returns True if :attr:`status_code` is less than 400, False if not.
+        This attribute checks if the status code of the response is between
+        400 and 600 to see if there was a client error or a server error. If
+        the status code is between 200 and 400, this will return True. This
+        is **not** a check to see if the response code is ``200 OK``.
+        """
+        try:
+            self.raise_for_status()
+        except HTTPStatusError:
+            return False
+        return True
+
     def json(self, **kwargs: typing.Any) -> typing.Any:
         if self.charset_encoding is None and self.content and len(self.content) > 3:
             encoding = guess_json_utf(self.content)


### PR DESCRIPTION
In the requests API we have the ".ok" attribute that returns `False` only if the status code if greather than or equal 400. I think it would be interesting to have this property in the response model as it is more convenient in some cases where we want to know if the request was not completed successfully but we do not want to handle the `HTTPStatusError`.