### PR TITLE
Fix: proxy http2 prior to knowledge support

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -580,6 +580,10 @@ class Client(BaseClient):
     to authenticate the client. Either a path to an SSL certificate file, or
     two-tuple of (certificate file, key file), or a three-tuple of (certificate
     file, key file, password).
+    * **http1** - *(optional)* A boolean indicating if HTTP/1 support should be
+    enabled. Defaults to `True`.
+    * **http2** - *(optional)* A boolean indicating if HTTP/2 support should be
+    enabled. Default to `False`.
     * **proxies** - *(optional)* A dictionary mapping proxy keys to proxy
     URLs.
     * **timeout** - *(optional)* The timeout configuration to use when sending
@@ -1277,6 +1281,8 @@ class AsyncClient(BaseClient):
     to authenticate the client. Either a path to an SSL certificate file, or
     two-tuple of (certificate file, key file), or a three-tuple of (certificate
     file, key file, password).
+    * **http1** - *(optional)* A boolean indicating if HTTP/1 support should be
+    enabled. Defaults to `True`.
     * **http2** - *(optional)* A boolean indicating if HTTP/2 support should be
     enabled. Defaults to `False`.
     * **proxies** - *(optional)* A dictionary mapping HTTP protocols to proxy
@@ -1412,6 +1418,7 @@ class AsyncClient(BaseClient):
         return AsyncHTTPTransport(
             verify=verify,
             cert=cert,
+            http1=http1,
             http2=http2,
             limits=limits,
             trust_env=trust_env,

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -319,7 +319,8 @@ class Limits:
 
 class Proxy:
     def __init__(
-        self, url: URLTypes, *, headers: HeaderTypes = None, mode: str = "DEFAULT"
+        self, url: URLTypes, *, headers: HeaderTypes = None, mode: str = "DEFAULT",
+        http1_override: typing.Optional[bool] = None, http2_override: typing.Optional[bool] = None
     ):
         url = URL(url)
         headers = Headers(headers)
@@ -341,6 +342,18 @@ class Proxy:
         self.url = url
         self.headers = headers
         self.mode = mode
+        self._http1_override = http1_override
+        self._http2_override = http2_override
+
+    def http1_support(self, default: bool) -> bool:
+        if self._http1_override is not None:
+            return self._http1_override
+        return default
+
+    def http2_support(self, default: bool) -> bool:
+        if self._http2_override is not None:
+            return self._http2_override
+        return default
 
     def _build_auth_header(self, username: str, password: str) -> str:
         userpass = (username.encode("utf-8"), password.encode("utf-8"))

--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -150,6 +150,7 @@ class HTTPTransport(BaseTransport):
                 max_connections=limits.max_connections,
                 max_keepalive_connections=limits.max_keepalive_connections,
                 keepalive_expiry=limits.keepalive_expiry,
+                http1=http1,
                 http2=http2,
                 backend=backend,
             )
@@ -247,6 +248,7 @@ class AsyncHTTPTransport(AsyncBaseTransport):
                 max_connections=limits.max_connections,
                 max_keepalive_connections=limits.max_keepalive_connections,
                 keepalive_expiry=limits.keepalive_expiry,
+                http1=http1,
                 http2=http2,
                 backend=backend,
             )

--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -150,8 +150,8 @@ class HTTPTransport(BaseTransport):
                 max_connections=limits.max_connections,
                 max_keepalive_connections=limits.max_keepalive_connections,
                 keepalive_expiry=limits.keepalive_expiry,
-                http1=http1,
-                http2=http2,
+                http1=proxy.http1_support(http1),
+                http2=proxy.http2_support(http2),
                 backend=backend,
             )
 
@@ -248,8 +248,8 @@ class AsyncHTTPTransport(AsyncBaseTransport):
                 max_connections=limits.max_connections,
                 max_keepalive_connections=limits.max_keepalive_connections,
                 keepalive_expiry=limits.keepalive_expiry,
-                http1=http1,
-                http2=http2,
+                http1=proxy.http1_support(http1),
+                http2=proxy.http2_support(http2),
                 backend=backend,
             )
 


### PR DESCRIPTION
Hi, 

This PR is related to https://github.com/encode/httpx/pull/1624 and required the following PR at httpcore side:  https://github.com/encode/httpcore/pull/342
It fix the HTTP2  prior of knowledge support for HTTP proxies.
- https://github.com/encode/httpx/commit/5a34fdd47a722b987d5da29c657323051a6884b2 propagate client `http1` support to the configured proxies
- https://github.com/encode/httpx/commit/9825d69155abad1f88da7c87cc4df69ac256832e introduce new configurations on the Proxy object to override the client http capabilities: `http1_override`, `http2_override`

```
proxies = {
    # Route all traffic through a proxy by default, inherit http1,http2 capabilities from client
    "all://": "http://localhost:8030",
    # But don't use proxies for HTTPS requests to "domain.io"...
    "https://domain.io": None,
    # And use another proxy for requests to "example.com" and its subdomains, only support http1
    "all://*example.com": httpx.Proxy(url="http://localhost:8031", http1_override=True, http2_override=False),
    # And yet another proxy if HTTP is used,
    # and the "internal" subdomain on port 5550 is requested, only support http2 -- prior to knowlegdge
    "http://internal.example.com:5550": httpx.Proxy(url="http://localhost:8032", http1_override=False, http2_override=True),
}
```

BR,

- [ ] Initially raised as discussion #None
