### PR TITLE
Add a network pytest mark for tests that use the network

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ combine_as_imports = True
 addopts = -rxXs
 markers =
   copied_from(source, changes=None): mark test as copied from somewhere else, along with a description of changes made to accodomate e.g. our test setup
+  network: marks tests which require network connection
 
 [coverage:run]
 omit = venv/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ combine_as_imports = True
 addopts = -rxXs
 markers =
   copied_from(source, changes=None): mark test as copied from somewhere else, along with a description of changes made to accodomate e.g. our test setup
-  network: marks tests which require network connection
+  network: marks tests which require network connection. Used in 3rd-party build environments that have network disabled.
 
 [coverage:run]
 omit = venv/*

--- a/tests/client/test_proxies.py
+++ b/tests/client/test_proxies.py
@@ -122,6 +122,7 @@ def test_transport_for_request(url, proxies, expected):
 
 
 @pytest.mark.asyncio
+@pytest.mark.network
 async def test_async_proxy_close():
     try:
         client = httpx.AsyncClient(proxies={"https://": PROXY_URL})
@@ -130,6 +131,7 @@ async def test_async_proxy_close():
         await client.aclose()
 
 
+@pytest.mark.network
 def test_sync_proxy_close():
     try:
         client = httpx.Client(proxies={"https://": PROXY_URL})

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -23,6 +23,7 @@ async def test_write_timeout(server):
 
 
 @pytest.mark.usefixtures("async_environment")
+@pytest.mark.network
 async def test_connect_timeout(server):
     timeout = httpx.Timeout(None, connect=1e-6)
 


### PR DESCRIPTION
Sometimes it's useful to have the tests that use the network
marked so they can be skipped easily when we know the network
is not available.

This is useful for example on SUSE and openSUSE's build servers.
When building the httpx packages (actually, any package in the
distribution) the network is disabled so we can assure
reproducible builds (among other benefits). With this mark, it's
easier to skip tests that can not succeed.
