### PR TITLE
Adding netrc environment variable into the documentation

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -370,7 +370,7 @@ password example-password
 ...
 ```
 
-When using `Client` instances, `trust_env` should be set on the client itself, rather that on the request methods:
+When using `Client` instances, `trust_env` should be set on the client itself, rather than on the request methods:
 
 ```python
 client = httpx.Client(trust_env=False)

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -132,6 +132,25 @@ Example:
 SSL_CERT_DIR=/path/to/ca-certs/ python -c "import httpx; httpx.get('https://example.com')"
 ```
 
+## `.NETRCFILE`
+
+Valid values: a filename
+
+If this environment variable is set and auth parameter is not defined, HTTPX will add auth information stored in
+.netrc file into request's header. If you do not provide NETRC environment, HTTPX will use default files. (~/.netrc
+, ~/_netrc)
+
+Example:
+
+```python
+# test_script.py
+import httpx
+import os
+os.environ["NETRC"] = "my_default_folder/.my_netrc"
+with httpx.Client(trust_env=False) as client:
+    r = client.get("https://example.org/")
+```
+
 ## Proxies
 
 The environment variables documented below are used as a convention by various HTTP tooling, including:
@@ -175,3 +194,5 @@ python -c "import httpx; httpx.get('http://example.com')"
 python -c "import httpx; httpx.get('http://127.0.0.1:5000/my-api')"
 python -c "import httpx; httpx.get('https://www.python-httpx.org')"
 ```
+
+

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -136,12 +136,12 @@ SSL_CERT_DIR=/path/to/ca-certs/ python -c "import httpx; httpx.get('https://exam
 
 Valid values: a filename
 
-If this environment variable is set and auth parameter is not defined, HTTPX will add auth information stored in .netrc file into request's header. If you do not provide NETRC environment, HTTPX will use default files. (~/.netrc, ~/_netrc)
+If this environment variable is set but auth parameter is not defined, HTTPX will add auth information stored in the .netrc file into the request's header. If you do not provide NETRC environment either, HTTPX will use default files. (~/.netrc, ~/_netrc)
 
 Example:
 
 ```console
-NETRCFILE=/path/to/netrcfile/my_netrc python -c "import httpx; httpx.get('https://example.com')"
+NETRCFILE=/path/to/netrcfile/.my_netrc python -c "import httpx; httpx.get('https://example.com')"
 ```
 
 ## Proxies

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -132,7 +132,7 @@ Example:
 SSL_CERT_DIR=/path/to/ca-certs/ python -c "import httpx; httpx.get('https://example.com')"
 ```
 
-## `.NETRCFILE`
+## `.NETRC`
 
 Valid values: a filename
 

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -136,19 +136,12 @@ SSL_CERT_DIR=/path/to/ca-certs/ python -c "import httpx; httpx.get('https://exam
 
 Valid values: A filename
 
-If this environment variable is set and auth parameter is not defined, HTTPX will add auth information stored in
-.netrc file into request's header. If you do not provide NETRC environment, HTTPX will use default files. (~/.netrc
-, ~/_netrc)
+If this environment variable is set and auth parameter is not defined, HTTPX will add auth information stored in .netrc file into request's header. If you do not provide NETRC environment, HTTPX will use default files. (~/.netrc, ~/_netrc)
 
 Example:
 
-```python
-# test_script.py
-import httpx
-import os
-os.environ["NETRC"] = "my_default_folder/.my_netrc"
-with httpx.Client(trust_env=False) as client:
-    r = client.get("https://example.org/")
+```console
+NETRCFILE=/path/to/netrcfile/my_netrc python -c "import httpx; httpx.get('https://example.com')"
 ```
 
 ## Proxies

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -134,7 +134,7 @@ SSL_CERT_DIR=/path/to/ca-certs/ python -c "import httpx; httpx.get('https://exam
 
 ## `.NETRCFILE`
 
-Valid values: A filename
+Valid values: a filename
 
 If this environment variable is set and auth parameter is not defined, HTTPX will add auth information stored in .netrc file into request's header. If you do not provide NETRC environment, HTTPX will use default files. (~/.netrc, ~/_netrc)
 

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -141,7 +141,7 @@ If this environment variable is set but auth parameter is not defined, HTTPX wil
 Example:
 
 ```console
-NETRCFILE=/path/to/netrcfile/.my_netrc python -c "import httpx; httpx.get('https://example.com')"
+NETRC=/path/to/netrcfile/.my_netrc python -c "import httpx; httpx.get('https://example.com')"
 ```
 
 ## Proxies

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -134,7 +134,7 @@ SSL_CERT_DIR=/path/to/ca-certs/ python -c "import httpx; httpx.get('https://exam
 
 ## `.NETRCFILE`
 
-Valid values: a filename
+Valid values: A filename
 
 If this environment variable is set and auth parameter is not defined, HTTPX will add auth information stored in
 .netrc file into request's header. If you do not provide NETRC environment, HTTPX will use default files. (~/.netrc
@@ -194,5 +194,4 @@ python -c "import httpx; httpx.get('http://example.com')"
 python -c "import httpx; httpx.get('http://127.0.0.1:5000/my-api')"
 python -c "import httpx; httpx.get('https://www.python-httpx.org')"
 ```
-
 

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -132,7 +132,7 @@ Example:
 SSL_CERT_DIR=/path/to/ca-certs/ python -c "import httpx; httpx.get('https://example.com')"
 ```
 
-## `.NETRC`
+## `NETRC`
 
 Valid values: a filename
 


### PR DESCRIPTION
The starting point for contributions should usually be [a discussion](https://github.com/encode/httpx/discussions)

Simple documentation typos may be raised as stand-alone pull requests, but otherwise
please ensure you've discussed the your proposal prior to issuing a pull request.

This will help us direct work appropriately, and ensure that any suggested changes
have been okayed by the maintainers.

- [ ] Initially raised as discussion #...
