### PR TITLE
👷 Add Python venv cache

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -22,16 +22,15 @@ jobs:
         with:
           python-version: "${{ matrix.python-version }}"
 
-      - name: "Cache venv"
-        id: cache-venv
-        uses: actions/cache@v2.1.6
+      - uses: actions/cache@v2.1.6
+        id: cache-requirements
         with:
-          path: venv
+          path: ~/.cache/pip
           key: env-${{ matrix.python-version }}-${{ hashFiles('requirements.txt', 'setup.py') }}
 
       - name: "Install dependencies"
         run: "scripts/install"
-        if: steps.cache-venv.outputs.cache-hit != 'true'
+        if: steps.cache-requirements.outputs.cache-hit != 'true'
 
       - name: "Run linting checks"
         run: "scripts/check"

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -25,8 +25,8 @@ jobs:
       - uses: actions/cache@v2.1.6
         id: cache-requirements
         with:
-          path: ~/.cache/pip
-          key: env-${{ matrix.python-version }}-${{ hashFiles('requirements.txt', 'setup.py') }}
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.pythonLocation }}-${{ matrix.python-version }}-${{ hashFiles('requirements.txt', 'setup.py') }}
 
       - name: "Install dependencies"
         run: "scripts/install"

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -21,13 +21,26 @@ jobs:
       - uses: "actions/setup-python@v2"
         with:
           python-version: "${{ matrix.python-version }}"
+
+      - name: "Cache venv"
+        id: cache-venv
+        uses: actions/cache@v2.1.6
+        with:
+          path: venv
+          key: env-${{ matrix.python-version }}-${{ hashFiles('requirements.txt', 'setup.py') }}
+
       - name: "Install dependencies"
         run: "scripts/install"
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+
       - name: "Run linting checks"
         run: "scripts/check"
+
       - name: "Build package & docs"
         run: "scripts/build"
+
       - name: "Run tests"
         run: "scripts/test"
+
       - name: "Enforce coverage"
         run: "scripts/coverage"


### PR DESCRIPTION
This PR aims to add a cache to the Python environment. 

I also took the audacious move to indent with an empty line between each action, so let me know if you wish for it to be removed.

## Discussion on Gitter

@Kludex:
> @tomchristie how would you feel about adding a cache on the requirements installation on the test-suite github workflow? I can open a PR on all encode projects if you think it makes sense.

@tomchristie: 
> Depends. Best place to start would be probably a pull request against httpx.
The cons are the extra fiddliness etc that's being introduced, the pros are that it ought to make the builds faster
So, the smart approach is to introduce it in a pull request, and then observe what the actual difference in build times looks like.

Reference: https://gitter.im/encode/community?at=60c3235cc705e53c1c86be7e

Docs: https://github.com/actions/cache