### PR TITLE
✏ Fix third party documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ For more advanced topics, see the [Advanced Usage](https://www.python-httpx.org/
 
 The [Developer Interface](https://www.python-httpx.org/api/) provides a comprehensive API reference.
 
-To find out about tools that integrate with HTTPX, see [Third Party Packages](https://www.python-httpx.org/third-party-packages/).
+To find out about tools that integrate with HTTPX, see [Third Party Packages](https://www.python-httpx.org/third_party_packages/).
 
 ## Contribute
 


### PR DESCRIPTION
Simple documentation typos may be raised as stand-alone pull requests.