### PR TITLE
use context.minimum_version in py3.7+ where available

### DIFF
--- a/httpx/_compat.py
+++ b/httpx/_compat.py
@@ -20,6 +20,8 @@ if sys.version_info >= (3, 10) or (
     # 'SSLContext.minimum_version' from Python 3.7 onwards, however
     # this attribute is not available unless the ssl module is compiled
     # with OpenSSL 1.1.0g or newer.
+    # https://docs.python.org/3.10/library/ssl.html#ssl.SSLContext.minimum_version
+    # https://docs.python.org/3.7/library/ssl.html#ssl.SSLContext.minimum_version
     def set_minimum_tls_version_1_2(context: ssl.SSLContext) -> None:
         context.minimum_version = ssl.TLSVersion.TLSv1_2
 

--- a/httpx/_compat.py
+++ b/httpx/_compat.py
@@ -13,22 +13,18 @@ except ImportError:
     from async_generator import asynccontextmanager  # type: ignore # noqa
 
 
-if sys.version_info >= (3, 10) or (
-    sys.version_info >= (3, 7) and ssl.OPENSSL_VERSION_INFO >= (1, 1, 0, 7)
-):
-    # The OP_NO_SSL* and OP_NO_TLS* become deprecated in favor of
-    # 'SSLContext.minimum_version' from Python 3.7 onwards, however
-    # this attribute is not available unless the ssl module is compiled
-    # with OpenSSL 1.1.0g or newer.
-    # https://docs.python.org/3.10/library/ssl.html#ssl.SSLContext.minimum_version
-    # https://docs.python.org/3.7/library/ssl.html#ssl.SSLContext.minimum_version
-    def set_minimum_tls_version_1_2(context: ssl.SSLContext) -> None:
+def set_minimum_tls_version_1_2(context: ssl.SSLContext) -> None:
+    if sys.version_info >= (3, 10) or (
+        sys.version_info >= (3, 7) and ssl.OPENSSL_VERSION_INFO >= (1, 1, 0, 7)
+    ):
+        # The OP_NO_SSL* and OP_NO_TLS* become deprecated in favor of
+        # 'SSLContext.minimum_version' from Python 3.7 onwards, however
+        # this attribute is not available unless the ssl module is compiled
+        # with OpenSSL 1.1.0g or newer.
+        # https://docs.python.org/3.10/library/ssl.html#ssl.SSLContext.minimum_version
+        # https://docs.python.org/3.7/library/ssl.html#ssl.SSLContext.minimum_version
         context.minimum_version = ssl.TLSVersion.TLSv1_2
-
-
-else:
-
-    def set_minimum_tls_version_1_2(context: ssl.SSLContext) -> None:
+    else:
         context.options |= ssl.OP_NO_SSLv2
         context.options |= ssl.OP_NO_SSLv3
         context.options |= ssl.OP_NO_TLSv1

--- a/httpx/_compat.py
+++ b/httpx/_compat.py
@@ -27,6 +27,7 @@ if sys.version_info >= (3, 10) or (
 else:
 
     def set_minimum_tls_version_1_2(context: ssl.SSLContext) -> None:
-        context.options |= (
-            ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3 | ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
-        )
+        context.options |= ssl.OP_NO_SSLv2
+        context.options |= ssl.OP_NO_SSLv3
+        context.options |= ssl.OP_NO_TLSv1
+        context.options |= ssl.OP_NO_TLSv1_1

--- a/httpx/_compat.py
+++ b/httpx/_compat.py
@@ -25,6 +25,8 @@ def set_minimum_tls_version_1_2(context: ssl.SSLContext) -> None:
         # https://docs.python.org/3.7/library/ssl.html#ssl.SSLContext.minimum_version
         context.minimum_version = ssl.TLSVersion.TLSv1_2
     else:
+        # If 'minimum_version' isn't available, we configure these options with
+        # the older deprecated variants.
         context.options |= ssl.OP_NO_SSLv2
         context.options |= ssl.OP_NO_SSLv3
         context.options |= ssl.OP_NO_TLSv1


### PR DESCRIPTION
ssl.OP_NO_TLSv1
ssl.OP_NO_TLSv1_1

are deprecated in py3.7+ and using these options prevents
downstream users of httpx.create_ssl_context using
minimum_version
