### PR TITLE
📌 Pin development requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,5 +27,3 @@ trio==0.19.0
 trio-typing==0.5.0
 trustme==0.8.0
 uvicorn==0.14.0
-
-attrs==21.2.0  # See: https://github.com/encode/httpx/pull/566#issuecomment-559862665

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
+# We're pinning our tooling, because it's an environment we can strictly control.
+# On the other hand, we're not pinning package dependencies, because our tests
+# needs to pass with the latest version of the packages.
+# Reference: https://github.com/encode/httpx/pull/1721#discussion_r661241588
 -e .[http2,brotli]
 
 # Documentation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,31 +1,31 @@
 -e .[http2,brotli]
 
 # Documentation
-mkdocs
-mkautodoc
-mkdocs-material
+mkdocs==1.2.1
+mkautodoc==0.1.0
+mkdocs-material==7.1.8
 
 # Packaging
-twine
-wheel
+twine==3.4.1
+wheel==0.36.2
 
 # Tests & Linting
-autoflake
+autoflake==1.4
 black==20.8b1
 coverage==5.3
-cryptography
-flake8
-flake8-bugbear
-flake8-pie==0.5.*
-isort==5.*
-mypy
-types-certifi
-pytest==6.*
-pytest-asyncio
-pytest-trio
-trio
-trio-typing
-trustme
-uvicorn
+cryptography==3.4.7
+flake8==3.9.2
+flake8-bugbear==21.4.3
+flake8-pie==0.5.0
+isort==5.9.1
+mypy==0.910
+types-certifi==0.1.4
+pytest==6.2.4
+pytest-asyncio==0.15.1
+pytest-trio==0.7.0
+trio==0.19.0
+trio-typing==0.5.0
+trustme==0.8.0
+uvicorn==0.14.0
 
-attrs>=19.3.0  # See: https://github.com/encode/httpx/pull/566#issuecomment-559862665
+attrs==21.2.0  # See: https://github.com/encode/httpx/pull/566#issuecomment-559862665


### PR DESCRIPTION
Idea raised on #1680:

> Should we make sure that we have more strictly pinned dependancies before pulling this in?
> 
> Eg... https://github.com/encode/httpcore/pull/184/files
> 
> _Originally posted by @tomchristie in https://github.com/encode/httpx/issues/1680#issuecomment-862320582_