### PR TITLE
Do not require typing_extensions on Python 3.8+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ pytest-trio
 trio
 trio-typing
 trustme
+typing_extensions; python_version < "3.8"
 uvicorn
 
 attrs>=19.3.0  # See: https://github.com/encode/httpx/pull/566#issuecomment-559862665

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+import sys
 import threading
 import time
 import typing
@@ -14,9 +15,15 @@ from cryptography.hazmat.primitives.serialization import (
     PrivateFormat,
     load_pem_private_key,
 )
-from typing_extensions import Literal
 from uvicorn.config import Config
 from uvicorn.main import Server
+
+# `typing.Literal` exists from Python 3.8 onwards.
+# For <=3.7 we require the `typing_extensions` package for a backported version.
+if sys.version_info >= (3, 8):  # pragma: no cover
+    from typing import Literal
+else:  # pragma: no cover
+    from typing_extensions import Literal
 
 from httpx import URL
 from tests.concurrency import sleep


### PR DESCRIPTION
typing.Literal is part of Python's stdlib since Python 3.8, so require
the typing_extensions backport only on older Python versions.