### PR TITLE
Inline SERVER_SCOPE and remove typing_extensions requirement

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,6 @@ from cryptography.hazmat.primitives.serialization import (
     PrivateFormat,
     load_pem_private_key,
 )
-from typing_extensions import Literal
 from uvicorn.config import Config
 from uvicorn.main import Server
 
@@ -165,38 +164,35 @@ async def redirect_301(scope, receive, send):
     await send({"type": "http.response.body"})
 
 
-SERVER_SCOPE: Literal["session"] = "session"
-
-
-@pytest.fixture(scope=SERVER_SCOPE)
+@pytest.fixture(scope="session")
 def cert_authority():
     return trustme.CA()
 
 
-@pytest.fixture(scope=SERVER_SCOPE)
+@pytest.fixture(scope="session")
 def ca_cert_pem_file(cert_authority):
     with cert_authority.cert_pem.tempfile() as tmp:
         yield tmp
 
 
-@pytest.fixture(scope=SERVER_SCOPE)
+@pytest.fixture(scope="session")
 def localhost_cert(cert_authority):
     return cert_authority.issue_cert("localhost")
 
 
-@pytest.fixture(scope=SERVER_SCOPE)
+@pytest.fixture(scope="session")
 def cert_pem_file(localhost_cert):
     with localhost_cert.cert_chain_pems[0].tempfile() as tmp:
         yield tmp
 
 
-@pytest.fixture(scope=SERVER_SCOPE)
+@pytest.fixture(scope="session")
 def cert_private_key_file(localhost_cert):
     with localhost_cert.private_key_pem.tempfile() as tmp:
         yield tmp
 
 
-@pytest.fixture(scope=SERVER_SCOPE)
+@pytest.fixture(scope="session")
 def cert_encrypted_private_key_file(localhost_cert):
     # Deserialize the private key and then reserialize with a password
     private_key = load_pem_private_key(
@@ -272,14 +268,14 @@ def serve_in_thread(server: Server):
         thread.join()
 
 
-@pytest.fixture(scope=SERVER_SCOPE)
+@pytest.fixture(scope="session")
 def server():
     config = Config(app=app, lifespan="off", loop="asyncio")
     server = TestServer(config=config)
     yield from serve_in_thread(server)
 
 
-@pytest.fixture(scope=SERVER_SCOPE)
+@pytest.fixture(scope="session")
 def https_server(cert_pem_file, cert_private_key_file):
     config = Config(
         app=app,


### PR DESCRIPTION
Inline the confusing SERVER_SCOPE literal as suggested in #1771,
and effectively remove the Literal import bringing typing_extensions
requirement.