### PR TITLE
Fix JSON wrong encoding tests on big endian platforms

### DIFF
--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -735,7 +735,7 @@ def test_json_without_specified_encoding_decode_error():
     content = json.dumps(data).encode("utf-32-be")
     headers = {"Content-Type": "application/json"}
     # force incorrect guess from `guess_json_utf` to trigger error
-    with mock.patch("httpx._models.guess_json_utf", return_value="utf-32"):
+    with mock.patch("httpx._models.guess_json_utf", return_value="utf-32-le"):
         response = httpx.Response(
             200,
             content=content,
@@ -750,7 +750,7 @@ def test_json_without_specified_encoding_value_error():
     content = json.dumps(data).encode("utf-32-be")
     headers = {"Content-Type": "application/json"}
     # force incorrect guess from `guess_json_utf` to trigger error
-    with mock.patch("httpx._models.guess_json_utf", return_value="utf-32"):
+    with mock.patch("httpx._models.guess_json_utf", return_value="utf-32-le"):
         response = httpx.Response(200, content=content, headers=headers)
         with pytest.raises(json.decoder.JSONDecodeError):
             response.json()


### PR DESCRIPTION
Fix test_json_without_specified_encoding_*_error tests on big endian
platforms.  The tests wrongly assume that data encoded as "utf-32-be"
can not be decoded as "utf-32".  This is true on little endian platforms
but on big endian platforms "utf-32" is equivalent to "utf-32-be".
To avoid the problem, explicitly decode as "utf-32-le", as this should
trigger the expected exception independently of platform's endianness.