### PR TITLE
Add sidebar ad placements through EthicalAds platform

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+  <script async src="https://media.ethicalads.io/media/client/ethicalads.min.js"></script>
+{% endblock %}

--- a/docs/overrides/partials/nav.html
+++ b/docs/overrides/partials/nav.html
@@ -1,0 +1,51 @@
+<!-- Determine class according to configuration -->
+{% set class = "md-nav md-nav--primary" %}
+{% if "navigation.tabs" in features %}
+  {% set class = class ~ " md-nav--lifted" %}
+{% endif %}
+{% if "toc.integrate" in features %}
+  {% set class = class ~ " md-nav--integrated" %}
+{% endif %}
+
+<!-- Main navigation -->
+<nav
+  class="{{ class }}"
+  aria-label="{{ lang.t('nav.title') }}"
+  data-md-level="0"
+>
+
+  <!-- Site title -->
+  <label class="md-nav__title" for="__drawer">
+    <a
+      href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}"
+      title="{{ config.site_name | e }}"
+      class="md-nav__button md-logo"
+      aria-label="{{ config.site_name }}"
+      data-md-component="logo"
+    >
+      {% include "partials/logo.html" %}
+    </a>
+    {{ config.site_name }}
+  </label>
+
+  <!-- Repository information -->
+  {% if config.repo_url %}
+    <div class="md-nav__source">
+      {% include "partials/source.html" %}
+    </div>
+  {% endif %}
+
+  <!-- Render item list -->
+  <ul class="md-nav__list" data-md-scrollfix>
+    {% for nav_item in nav %}
+      {% set path = "__nav_" ~ loop.index %}
+      {% set level = 1 %}
+      {% include "partials/nav-item.html" %}
+    {% endfor %}
+  </ul>
+
+  <ul class="md-nav__list" data-md-scrollfix>
+    <strong>Ad placement...</strong>
+    <div data-ea-publisher="readthedocs-encode" data-ea-type="image"></div>
+  </ul>
+</nav>

--- a/docs/overrides/partials/nav.html
+++ b/docs/overrides/partials/nav.html
@@ -44,8 +44,7 @@
     {% endfor %}
   </ul>
 
-  <ul class="md-nav__list" data-md-scrollfix>
-    <strong>Ad placement...</strong>
+  <ul class="md-nav__list" data-md-scrollfix style="padding-top: 15px">
     <div data-ea-publisher="readthedocs-encode" data-ea-type="image"></div>
   </ul>
 </nav>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ site_url: https://www.python-httpx.org/
 
 theme:
     name: 'material'
+    custom_dir: docs/overrides
 
 repo_name: encode/httpx
 repo_url: https://github.com/encode/httpx/


### PR DESCRIPTION
The intent of this pull request is to add sidebar ads served through [the EthicalAds platform](https://www.ethicalads.io).

This'd allow us to manage a set of sponsors that'd display in the sidebar.

I'd probably prefer us to be able to do this, rather than extending the custom app I originally built for [the REST framework sidebar ads](https://www.django-rest-framework.org).

However I've obviously not got something right with the integration, because at the moment, I'm just seeing this...

<img width="594" alt="Screenshot 2021-08-10 at 16 05 43" src="https://user-images.githubusercontent.com/647359/128891595-ab4b6b66-6491-4516-8ce7-32910d279d1b.png">
