### PR TITLE
Update HTTP/2 support in `extras_require`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
         "async_generator; python_version < '3.7'"
     ],
     extras_require={
-        "http2": "h2==3.*",
+        "http2": "httpcore[http2]",
         "brotli": "brotlicffi==1.*",
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
         "async_generator; python_version < '3.7'"
     ],
     extras_require={
-        "http2": "httpcore[http2]",
+        "http2": "h2>=3,<5",
         "brotli": "brotlicffi==1.*",
     },
     classifiers=[


### PR DESCRIPTION
So, `httpx` itself doesn't have any specific requirements on which `h2` version should be installed.
That's actually up to `httpcore`.

This pull request updates the `extras_require` to reflect that.

*However*... I'm a bit wary that pip's dependency resolution *might* not actually get this right, so this pull request is a bit exploratory. 

Closes #1798