### PR TITLE
Stricter enforcement of client lifespan styles.

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -1232,6 +1232,13 @@ class Client(BaseClient):
                     transport.close()
 
     def __enter__(self: T) -> T:
+        if self._state != ClientState.UNOPENED:
+            msg = {
+                ClientState.OPENED: "Cannot open a client instance more than once.",
+                ClientState.CLOSED: "Cannot reopen a client instance, once it has been closed.",
+            }[self._state]
+            raise RuntimeError(msg)
+
         self._state = ClientState.OPENED
 
         self._transport.__enter__()
@@ -1941,6 +1948,13 @@ class AsyncClient(BaseClient):
                     await proxy.aclose()
 
     async def __aenter__(self: U) -> U:
+        if self._state != ClientState.UNOPENED:
+            msg = {
+                ClientState.OPENED: "Cannot open a client instance more than once.",
+                ClientState.CLOSED: "Cannot reopen a client instance, once it has been closed.",
+            }[self._state]
+            raise RuntimeError(msg)
+
         self._state = ClientState.OPENED
 
         await self._transport.__aenter__()

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -265,8 +265,14 @@ async def test_client_closed_state_using_implicit_open():
     await client.aclose()
 
     assert client.is_closed
+    # Once we're close we cannot make any more requests.
     with pytest.raises(RuntimeError):
         await client.get("http://example.com")
+
+    # Once we're closed we cannot reopen the client.
+    with pytest.raises(RuntimeError):
+        async with client:
+            pass  # pragma: nocover
 
 
 @pytest.mark.usefixtures("async_environment")

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -305,8 +305,15 @@ def test_client_closed_state_using_implicit_open():
     client.close()
 
     assert client.is_closed
+
+    # Once we're close we cannot make any more requests.
     with pytest.raises(RuntimeError):
         client.get("http://example.com")
+
+    # Once we're closed we cannot reopen the client.
+    with pytest.raises(RuntimeError):
+        with client:
+            pass  # pragma: nocover
 
 
 def test_client_closed_state_using_with_block():


### PR DESCRIPTION
When using a client, the expectation is that users should use one of the two following styles...

```python
with httpx.Client() as client:
    ...
```

Or...

```python
client = httpx.Client()
...
```

This pull request introduces a little bit of guarding around the opening of a `client` with block in order to enforce that unexpected usages mixing the two styles don't occur, so that we can't...

* Reopen a client once it's been closed.
* Enter into a client `with` block more than once.

Nailing down the possible usages here should just help guard against odd unexpected states.

Closes #1615