### PR TITLE
Resolve Python 3.6 tests hanging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ HTTPX is a fully featured HTTP client for Python 3, which provides sync and asyn
 a stable point now, but would strongly recommend pinning your dependencies to the `0.18.*`
 release, so that you're able to properly review [API changes between package updates](https://github.com/encode/httpx/blob/master/CHANGELOG.md). A 1.0 release is expected to be issued sometime in 2021._
 
-TESTING A THING
-
 ---
 
 Let's get started...

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ HTTPX is a fully featured HTTP client for Python 3, which provides sync and asyn
 a stable point now, but would strongly recommend pinning your dependencies to the `0.18.*`
 release, so that you're able to properly review [API changes between package updates](https://github.com/encode/httpx/blob/master/CHANGELOG.md). A 1.0 release is expected to be issued sometime in 2021._
 
+TESTING A THING
+
 ---
 
 Let's get started...

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,6 @@ pytest-trio
 trio
 trio-typing
 trustme
-uvicorn
+uvicorn==0.14.0
 
 attrs>=19.3.0  # See: https://github.com/encode/httpx/pull/566#issuecomment-559862665


### PR DESCRIPTION
Test cases on Python 3.6 are hanging, both when running locally, and on CI.

Locally I ran...

```python
scripts/install -p python3.6
venv/bin/pytest --full-trace
```

in order to track down where the tests were hanging. Issue was when waiting for the uvicorn server to be available.

Pinning to Uvicorn 0.14.0 appears to resolve the issue.