### PR TITLE
BUG: wsgi.error should be TextIO, not BytesIO in WSGI transport

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -35,7 +35,7 @@ and is expected to be fully removed with the HTTPX 1.0 release.
 
 HTTPX uses `utf-8` for encoding `str` request bodies. For example, when using `content=<str>` the request body will be encoded to `utf-8` before being sent over the wire. This differs from Requests which uses `latin1`. If you need an explicit encoding, pass encoded bytes explictly, e.g. `content=<str>.encode("latin1")`.
 
-For response bodies, assuming the server didn't send an explicit encoding then HTTPX will do its best to figure out an appropriate encoding. Unlike Requests which uses the `chardet` library, HTTPX relies on a plainer fallback strategy (basically attempting UTF-8, or using Windows-1252 as a fallback). This strategy should be robust enough to handle the vast majority of use cases.
+For response bodies, assuming the server didn't send an explicit encoding then HTTPX will do its best to figure out an appropriate encoding. HTTPX makes a guess at the encoding to use for decoding the response using `charset_normalizer`. Fallback to that or any content with less than 32 octets will be decoded using `utf-8` with the `error="replace"` decoder strategy.  
 
 ## Cookies
 

--- a/httpx/_transports/wsgi.py
+++ b/httpx/_transports/wsgi.py
@@ -89,7 +89,7 @@ class WSGITransport(BaseTransport):
             "wsgi.version": (1, 0),
             "wsgi.url_scheme": scheme.decode("ascii"),
             "wsgi.input": wsgi_input,
-            "wsgi.errors": io.BytesIO(),
+            "wsgi.errors": io.StringIO(),
             "wsgi.multithread": True,
             "wsgi.multiprocess": False,
             "wsgi.run_once": False,

--- a/httpx/_transports/wsgi.py
+++ b/httpx/_transports/wsgi.py
@@ -63,13 +63,13 @@ class WSGITransport(BaseTransport):
         raise_app_exceptions: bool = True,
         script_name: str = "",
         remote_addr: str = "127.0.0.1",
-        log_file: typing.Optional[typing.TextIO] = None,
+        wsgi_errors: typing.Optional[typing.TextIO] = None,
     ) -> None:
         self.app = app
         self.raise_app_exceptions = raise_app_exceptions
         self.script_name = script_name
         self.remote_addr = remote_addr
-        self.log_file = log_file
+        self.wsgi_errors = wsgi_errors
 
     def handle_request(
         self,
@@ -92,7 +92,7 @@ class WSGITransport(BaseTransport):
             "wsgi.version": (1, 0),
             "wsgi.url_scheme": scheme.decode("ascii"),
             "wsgi.input": wsgi_input,
-            "wsgi.errors": self.log_file or sys.stderr,
+            "wsgi.errors": self.wsgi_errors or sys.stderr,
             "wsgi.multithread": True,
             "wsgi.multiprocess": False,
             "wsgi.run_once": False,

--- a/httpx/_transports/wsgi.py
+++ b/httpx/_transports/wsgi.py
@@ -1,5 +1,6 @@
 import io
 import itertools
+import sys
 import typing
 from urllib.parse import unquote
 
@@ -62,11 +63,13 @@ class WSGITransport(BaseTransport):
         raise_app_exceptions: bool = True,
         script_name: str = "",
         remote_addr: str = "127.0.0.1",
+        log_file: typing.Optional[typing.TextIO] = None,
     ) -> None:
         self.app = app
         self.raise_app_exceptions = raise_app_exceptions
         self.script_name = script_name
         self.remote_addr = remote_addr
+        self.log_file = log_file
 
     def handle_request(
         self,
@@ -89,7 +92,7 @@ class WSGITransport(BaseTransport):
             "wsgi.version": (1, 0),
             "wsgi.url_scheme": scheme.decode("ascii"),
             "wsgi.input": wsgi_input,
-            "wsgi.errors": io.StringIO(),
+            "wsgi.errors": self.log_file or sys.stderr,
             "wsgi.multithread": True,
             "wsgi.multiprocess": False,
             "wsgi.run_once": False,

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -127,7 +127,7 @@ def test_wsgi_generator_empty():
 
 def test_logging():
     buffer = StringIO()
-    transport = httpx.WSGITransport(app=log_to_wsgi_log_buffer, log_file=buffer)
+    transport = httpx.WSGITransport(app=log_to_wsgi_log_buffer, wsgi_errors=buffer)
     client = httpx.Client(transport=transport)
     response = client.post("http://www.example.org/", content=b"example")
     assert response.status_code == 200  # no errors


### PR DESCRIPTION
I found this from here: https://github.com/falconry/falcon/blob/e255bff9ae5a90d0cb3fe9af7c16917f18a92dc3/falcon/request.py#L1879

Based on the documentation at https://modwsgi.readthedocs.io/en/master/user-guides/debugging-techniques.html#apache-error-log-files, I believe Falcon is right and HTTPX is wrong.

This PR:
1. Adds a parameter so that we can test it and users can easily collect the logs in their tests if they want.
2. Changes the default from an inaccessible `BytesIO` (wrong type of stream, can't be accessed by user) to `sys.stderr` so that users (or pytest automatically) will capture the logs.