### PR TITLE
API for status code checks.

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -945,7 +945,7 @@ class Client(BaseClient):
                     hook(response)
                 response.history = list(history)
 
-                if not response.is_redirect:
+                if not response.has_redirect_location:
                     return response
 
                 request = self._build_redirect_request(request, response)
@@ -1640,7 +1640,7 @@ class AsyncClient(BaseClient):
 
                 response.history = list(history)
 
-                if not response.is_redirect:
+                if not response.has_redirect_location:
                     return response
 
                 request = self._build_redirect_request(request, response)

--- a/httpx/_status_codes.py
+++ b/httpx/_status_codes.py
@@ -39,31 +39,46 @@ class codes(IntEnum):
             return ""
 
     @classmethod
-    def is_redirect(cls, value: int) -> bool:
-        return value in (
-            # 301 (Cacheable redirect. Method may change to GET.)
-            codes.MOVED_PERMANENTLY,
-            # 302 (Uncacheable redirect. Method may change to GET.)
-            codes.FOUND,
-            # 303 (Client should make a GET or HEAD request.)
-            codes.SEE_OTHER,
-            # 307 (Equiv. 302, but retain method)
-            codes.TEMPORARY_REDIRECT,
-            # 308 (Equiv. 301, but retain method)
-            codes.PERMANENT_REDIRECT,
-        )
+    def is_informational(cls, value: int) -> bool:
+        """
+        Returns `True` for 1xx status codes, `False` otherwise.
+        """
+        return 100 <= value <= 199
 
     @classmethod
-    def is_error(cls, value: int) -> bool:
-        return 400 <= value <= 599
+    def is_success(cls, value: int) -> bool:
+        """
+        Returns `True` for 2xx status codes, `False` otherwise.
+        """
+        return 200 <= value <= 299
+
+    @classmethod
+    def is_redirect(cls, value: int) -> bool:
+        """
+        Returns `True` for 3xx status codes, `False` otherwise.
+        """
+        return 300 <= value <= 399
 
     @classmethod
     def is_client_error(cls, value: int) -> bool:
+        """
+        Returns `True` for 4xx status codes, `False` otherwise.
+        """
         return 400 <= value <= 499
 
     @classmethod
     def is_server_error(cls, value: int) -> bool:
+        """
+        Returns `True` for 5xx status codes, `False` otherwise.
+        """
         return 500 <= value <= 599
+
+    @classmethod
+    def is_error(cls, value: int) -> bool:
+        """
+        Returns `True` for 4xx or 5xx status codes, `False` otherwise.
+        """
+        return 400 <= value <= 599
 
     # informational
     CONTINUE = 100, "Continue"


### PR DESCRIPTION
Add API for status code checks...

* `.is_informational`  Check for 1xx responses
* `.is_success`  Check for 2xx responses
* `.is_redirect`  Check for 3xx responses
* `.is_client_error`  Check for 4xx responses
* `.is_server_error`  Check for 5xx responses

Checking for a properly formed URL redirect is now...

* `.has_redirect_location`

The `.raise_for_status()` method now raises on any response except 2xx.