### PR TITLE
Tidy up the formatting of HTTP/2 requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ The HTTPX project relies on these excellent libraries:
 * `sniffio` - Async library autodetection.
 * `rich` - Rich terminal support. *(Optional, with `httpx[cli]`)*
 * `click` - Command line client support. *(Optional, with `httpx[cli]`)*
-* `async_generator` - Backport support for `contextlib.asynccontextmanager`. *(Only required for Python 3.6)*
 * `brotli` or `brotlicffi` - Decoding for "brotli" compressed responses. *(Optional, with `httpx[brotli]`)*
+* `async_generator` - Backport support for `contextlib.asynccontextmanager`. *(Only required for Python 3.6)*
 
 A huge amount of credit is due to `requests` for the API layout that
 much of this work follows, as well as to `urllib3` for plenty of design

--- a/docs/index.md
+++ b/docs/index.md
@@ -122,8 +122,8 @@ The HTTPX project relies on these excellent libraries:
 * `sniffio` - Async library autodetection.
 * `rich` - Rich terminal support. *(Optional, with `httpx[cli]`)*
 * `click` - Command line client support. *(Optional, with `httpx[cli]`)*
-* `async_generator` - Backport support for `contextlib.asynccontextmanager`. *(Only required for Python 3.6)*
 * `brotli` or `brotlicffi` - Decoding for "brotli" compressed responses. *(Optional, with `httpx[brotli]`)*
+* `async_generator` - Backport support for `contextlib.asynccontextmanager`. *(Only required for Python 3.6)*
 
 A huge amount of credit is due to `requests` for the API layout that
 much of this work follows, as well as to `urllib3` for plenty of design

--- a/httpx/_main.py
+++ b/httpx/_main.py
@@ -104,11 +104,12 @@ def get_lexer_for_response(response: Response) -> str:
 
 def format_request_headers(request: Request, http2: bool = False) -> str:
     version = "HTTP/2" if http2 else "HTTP/1.1"
-    headers = [(name.lower() if http2 else name, value) for name, value in request.headers.raw]
+    headers = [
+        (name.lower() if http2 else name, value) for name, value in request.headers.raw
+    ]
     target = request.url.raw[-1].decode("ascii")
     lines = [f"{request.method} {target} {version}"] + [
-        f"{name.decode('ascii')}: {value.decode('ascii')}"
-        for name, value in headers
+        f"{name.decode('ascii')}: {value.decode('ascii')}" for name, value in headers
     ]
     return "\n".join(lines)
 

--- a/httpx/_main.py
+++ b/httpx/_main.py
@@ -1,3 +1,4 @@
+import functools
 import json
 import sys
 import typing
@@ -101,11 +102,13 @@ def get_lexer_for_response(response: Response) -> str:
     return ""  # pragma: nocover
 
 
-def format_request_headers(request: Request) -> str:
+def format_request_headers(request: Request, http2: bool = False) -> str:
+    version = "HTTP/2" if http2 else "HTTP/1.1"
+    headers = [(name.lower() if http2 else name, value) for name, value in request.headers.raw]
     target = request.url.raw[-1].decode("ascii")
-    lines = [f"{request.method} {target} HTTP/1.1"] + [
+    lines = [f"{request.method} {target} {version}"] + [
         f"{name.decode('ascii')}: {value.decode('ascii')}"
-        for name, value in request.headers.raw
+        for name, value in headers
     ]
     return "\n".join(lines)
 
@@ -120,9 +123,9 @@ def format_response_headers(response: Response) -> str:
     return "\n".join(lines)
 
 
-def print_request_headers(request: Request) -> None:
+def print_request_headers(request: Request, http2: bool = False) -> None:
     console = rich.console.Console()
-    http_text = format_request_headers(request)
+    http_text = format_request_headers(request, http2=http2)
     syntax = rich.syntax.Syntax(http_text, "http", theme="ansi_dark", word_wrap=True)
     console.print(syntax)
     syntax = rich.syntax.Syntax("", "http", theme="ansi_dark", word_wrap=True)
@@ -395,7 +398,7 @@ def main(
 
     event_hooks: typing.Dict[str, typing.List[typing.Callable]] = {}
     if verbose:
-        event_hooks["request"] = [print_request_headers]
+        event_hooks["request"] = [functools.partial(print_request_headers, http2=http2)]
     if follow_redirects:
         event_hooks["response"] = [print_redirects]
 


### PR DESCRIPTION
HTTP/2 requests displayed in the console should:

* Use `"HTTP/2"` in the version.
* Display lowercase headers.

As it happens the HTTP/2 displays in the console are not completely ideal, because we print them in the `request` event hook, but we *don't actually know* at that point if HTTP/2 will be successfully negotiated or not. Still it's close enough to display it as an HTTP/2 request, and have the response indicate which version *actually* got used.

Sometime further down the line we'll want to address this with some additional information for verbose displays, eg...

```
* Connected to www.example.com (1.2.3.4) on port 443. (HTTP/2 Negotiated)
GET / HTTP/2
host: www.example.com
accept: */*
accept-encoding: gzip, deflate, br
connection: keep-alive
user-agent: python-httpx/1.0.0.beta0

HTTP/2 200 OK
content-encoding: gzip
accept-ranges: bytes
age: 425769
cache-control: max-age=604800
content-type: text/html; charset=UTF-8
date: Tue, 14 Sep 2021 12:09:17 GMT
etag: "3147526947+gzip"
expires: Tue, 21 Sep 2021 12:09:17 GMT
last-modified: Thu, 17 Oct 2019 07:18:26 GMT
server: ECS (nyb/1D0F)
vary: Accept-Encoding
x-cache: HIT
content-length: 648

<!doctype html>
<html>
<head>
    <title>Example Domain</title>

    <meta charset="utf-8" />
    <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1" />
    <style type="text/css">
    body {
        background-color: #f0f0f2;
        margin: 0;
        padding: 0;
        font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Open Sans", 
"Helvetica Neue", Helvetica, Arial, sans-serif;
        
    }
    div {
        width: 600px;
        margin: 5em auto;
        padding: 2em;
        background-color: #fdfdff;
        border-radius: 0.5em;
        box-shadow: 2px 3px 7px 2px rgba(0,0,0,0.02);
    }
    a:link, a:visited {
        color: #38488f;
        text-decoration: none;
    }
    @media (max-width: 700px) {
        div {
            margin: 0 auto;
            width: auto;
        }
    }
    </style>    
</head>

<body>
<div>
    <h1>Example Domain</h1>
    <p>This domain is for use in illustrative examples in documents. You may use this
    domain in literature without prior coordination or asking for permission.</p>
    <p><a href="https://www.iana.org/domains/example">More information...</a></p>
</div>
</body>
</html>
```

But that's an issue for another day.