### PR TITLE
Fix console markup escaping issue

### DIFF
--- a/httpx/_main.py
+++ b/httpx/_main.py
@@ -174,6 +174,8 @@ def print_response(response: Response) -> None:
 
 
 def download_response(response: Response, download: typing.BinaryIO) -> None:
+    console = rich.console.Console()
+    console.print()
     content_length = response.headers.get("Content-Length")
     with rich.progress.Progress(
         "[progress.description]{task.description}",

--- a/httpx/_main.py
+++ b/httpx/_main.py
@@ -12,7 +12,6 @@ import rich.progress
 import rich.syntax
 import rich.table
 
-
 from ._client import Client
 from ._exceptions import RequestError
 from ._models import Request, Response

--- a/httpx/_main.py
+++ b/httpx/_main.py
@@ -175,7 +175,7 @@ def print_response(response: Response) -> None:
         syntax = rich.syntax.Syntax(text, lexer_name, theme="ansi_dark", word_wrap=True)
         console.print(syntax)
     else:  # pragma: nocover
-        console.print(response.text)
+        console.print(rich.markup.escape(response.text))
 
 
 def format_certificate(cert: dict) -> str:  # pragma: nocover

--- a/httpx/_main.py
+++ b/httpx/_main.py
@@ -7,8 +7,11 @@ import click
 import pygments.lexers
 import pygments.util
 import rich.console
+import rich.markup
 import rich.progress
 import rich.syntax
+import rich.table
+
 
 from ._client import Client
 from ._exceptions import RequestError
@@ -172,12 +175,7 @@ def print_response(response: Response) -> None:
 
 
 def download_response(response: Response, download: typing.BinaryIO) -> None:
-    console = rich.console.Console()
-    syntax = rich.syntax.Syntax("", "http", theme="ansi_dark", word_wrap=True)
-    console.print(syntax)
-
     content_length = response.headers.get("Content-Length")
-    kwargs = {"total": int(content_length)} if content_length else {}
     with rich.progress.Progress(
         "[progress.description]{task.description}",
         "[progress.percentage]{task.percentage:>3.0f}%",
@@ -185,8 +183,12 @@ def download_response(response: Response, download: typing.BinaryIO) -> None:
         rich.progress.DownloadColumn(),
         rich.progress.TransferSpeedColumn(),
     ) as progress:
-        description = f"Downloading [bold]{download.name}"
-        download_task = progress.add_task(description, **kwargs)  # type: ignore
+        description = f"Downloading [bold]{rich.markup.escape(download.name)}"
+        download_task = progress.add_task(
+            description,
+            total=int(content_length or 0),
+            start=content_length is not None,
+        )
         for chunk in response.iter_bytes():
             download.write(chunk)
             progress.update(download_task, completed=response.num_bytes_downloaded)


### PR DESCRIPTION
Escapes the download name so that it won't render console markup.

- [X] Initially raised as discussion https://github.com/encode/httpx/discussions/1865
