### PR TITLE
Run CI on 3.9.6

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10.0-rc.1"]
+        python-version: ["3.6", "3.7", "3.8", "3.9.6", "3.10.0-rc.1"]
 
     steps:
       - uses: "actions/checkout@v2"


### PR DESCRIPTION
Asyncio on Python 3.9.7 has some grubby bug that's causing our CI to hang.

I don't really understand the interaction there, but right now I don't really care either, I'd just like to see the tests running properly. I'm *assuming* that a `"3.9.6" specifier here will do what we'd expect, but let's find out, eh?

Some things that'd be useful...

* Doc'ing up exactly what the 3.9 CPython `asyncio` bug is and why it's causing our tests to hang.
* Where does GitHub document which versions are available on it's CI platform?

Anyone's want to chime in on these in this thread?