### PR TITLE
Expand docs note for async custom handler responses

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -260,7 +260,7 @@ client = httpx.Client(event_hooks={'response': [raise_on_4xx_5xx]})
     should be read or not.
 
     If you need access to the response body inside an event hook, you'll
-    need to call `response.read()` (or `response.aread()` for AsyncClients)
+    need to call `response.read()`, or for AsyncClients, `response.aread()`.
 
 The hooks are also allowed to modify `request` and `response` objects.
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -260,7 +260,7 @@ client = httpx.Client(event_hooks={'response': [raise_on_4xx_5xx]})
     should be read or not.
 
     If you need access to the response body inside an event hook, you'll
-    need to call `response.read()`.
+    need to call `response.read()` (or `response.aread()` for AsyncClients)
 
 The hooks are also allowed to modify `request` and `response` objects.
 


### PR DESCRIPTION
Custom response handlers need to run `response.read()` before they can read the content of the response. However when using an AsyncClient this will produce an error of `RuntimeError: Attempted to call a sync iterator on an async stream.`. Took me some digging to figure out I just needed to use `response.aread()` here instead of `response.read()` so figured I would an MR with an expansion on the note for anyone else.
Thanks!

The starting point for contributions should usually be [a discussion](https://github.com/encode/httpx/discussions)

Simple documentation typos may be raised as stand-alone pull requests, but otherwise
please ensure you've discussed your proposal prior to issuing a pull request.

This will help us direct work appropriately, and ensure that any suggested changes
have been okayed by the maintainers.

- [ ] Initially raised as discussion #...
