### PR TITLE
Fix `response.url` annotation.

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -1302,7 +1302,7 @@ class Response:
             return codes.get_reason_phrase(self.status_code)
 
     @property
-    def url(self) -> typing.Optional[URL]:
+    def url(self) -> URL:
         """
         Returns the URL for which the request was made.
         """


### PR DESCRIPTION
The `response.url` property is now correctly annotated as `URL`, instead of `Optional[URL]`.

Closes #1928
