### PR TITLE
Replaces `yield` as part of `for` loops with `yield from`

### DIFF
--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -341,7 +341,7 @@ class Proxy:
         return f"Basic {token}"
 
     def __repr__(self) -> str:
-        return f"Proxy(url={str(self.url)!r}, headers={dict(self.headers)!r})"
+        return f'Proxy(url={self.url!r}, headers={dict(self.headers)!r})'
 
 
 DEFAULT_TIMEOUT_CONFIG = Timeout(timeout=5.0)

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -341,7 +341,7 @@ class Proxy:
         return f"Basic {token}"
 
     def __repr__(self) -> str:
-        return f'Proxy(url={self.url!r}, headers={dict(self.headers)!r})'
+        return f"Proxy(url={self.url!r}, headers={dict(self.headers)!r})"
 
 
 DEFAULT_TIMEOUT_CONFIG = Timeout(timeout=5.0)

--- a/httpx/_content.py
+++ b/httpx/_content.py
@@ -48,8 +48,7 @@ class IteratorByteStream(SyncByteStream):
             raise StreamConsumed()
 
         self._is_stream_consumed = True
-        for part in self._stream:
-            yield part
+        yield from self._stream
 
 
 class AsyncIteratorByteStream(AsyncByteStream):

--- a/httpx/_decoders.py
+++ b/httpx/_decoders.py
@@ -272,15 +272,11 @@ class LineDecoder:
             if text.startswith("\n"):
                 # Handle the case where we have an "\r\n" split across
                 # our previous input, and our new chunk.
-                lines.append(self.buffer[:-1] + "\n")
-                self.buffer = ""
-                text = text[1:]
-            else:
                 # Handle the case where we have "\r" at the end of our
                 # previous input.
-                lines.append(self.buffer[:-1] + "\n")
-                self.buffer = ""
-
+                text = text[1:]
+            lines.append(self.buffer[:-1] + "\n")
+            self.buffer = ""
         while text:
             num_chars = len(text)
             for idx in range(num_chars):

--- a/httpx/_decoders.py
+++ b/httpx/_decoders.py
@@ -175,23 +175,23 @@ class ByteChunker:
             return [content]
 
         self._buffer.write(content)
-        if self._buffer.tell() >= self._chunk_size:
-            value = self._buffer.getvalue()
-            chunks = [
-                value[i : i + self._chunk_size]
-                for i in range(0, len(value), self._chunk_size)
-            ]
-            if len(chunks[-1]) == self._chunk_size:
-                self._buffer.seek(0)
-                self._buffer.truncate()
-                return chunks
-            else:
-                self._buffer.seek(0)
-                self._buffer.write(chunks[-1])
-                self._buffer.truncate()
-                return chunks[:-1]
-        else:
+        if self._buffer.tell() < self._chunk_size:
             return []
+
+        value = self._buffer.getvalue()
+        chunks = [
+            value[i : i + self._chunk_size]
+            for i in range(0, len(value), self._chunk_size)
+        ]
+        if len(chunks[-1]) == self._chunk_size:
+            self._buffer.seek(0)
+            self._buffer.truncate()
+            return chunks
+        else:
+            self._buffer.seek(0)
+            self._buffer.write(chunks[-1])
+            self._buffer.truncate()
+            return chunks[:-1]
 
     def flush(self) -> typing.List[bytes]:
         value = self._buffer.getvalue()
@@ -214,23 +214,23 @@ class TextChunker:
             return [content]
 
         self._buffer.write(content)
-        if self._buffer.tell() >= self._chunk_size:
-            value = self._buffer.getvalue()
-            chunks = [
-                value[i : i + self._chunk_size]
-                for i in range(0, len(value), self._chunk_size)
-            ]
-            if len(chunks[-1]) == self._chunk_size:
-                self._buffer.seek(0)
-                self._buffer.truncate()
-                return chunks
-            else:
-                self._buffer.seek(0)
-                self._buffer.write(chunks[-1])
-                self._buffer.truncate()
-                return chunks[:-1]
-        else:
+        if self._buffer.tell() < self._chunk_size:
             return []
+
+        value = self._buffer.getvalue()
+        chunks = [
+            value[i : i + self._chunk_size]
+            for i in range(0, len(value), self._chunk_size)
+        ]
+        if len(chunks[-1]) == self._chunk_size:
+            self._buffer.seek(0)
+            self._buffer.truncate()
+            return chunks
+        else:
+            self._buffer.seek(0)
+            self._buffer.write(chunks[-1])
+            self._buffer.truncate()
+            return chunks[:-1]
 
     def flush(self) -> typing.List[str]:
         value = self._buffer.getvalue()

--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -101,8 +101,7 @@ class ResponseStream(SyncByteStream):
 
     def __iter__(self) -> typing.Iterator[bytes]:
         with map_httpcore_exceptions():
-            for part in self._httpcore_stream:
-                yield part
+            yield from self._httpcore_stream
 
     def close(self) -> None:
         if hasattr(self._httpcore_stream, "close"):

--- a/httpx/_transports/wsgi.py
+++ b/httpx/_transports/wsgi.py
@@ -22,8 +22,7 @@ class WSGIByteStream(SyncByteStream):
         self._result = _skip_leading_empty_chunks(result)
 
     def __iter__(self) -> typing.Iterator[bytes]:
-        for part in self._result:
-            yield part
+        yield from self._result
 
     def close(self) -> None:
         if self._close is not None:


### PR DESCRIPTION
Based on what @tomchristie recommended to make https://github.com/encode/httpx/pull/1909 this PR into a shorter one to validate multiple things and let it more clear and ready for review.