### PR TITLE
Read upload files using `read(CHUNK_SIZE)` rather than `iter()`.

### DIFF
--- a/httpx/_content.py
+++ b/httpx/_content.py
@@ -57,10 +57,9 @@ class IteratorByteStream(SyncByteStream):
                 yield chunk
                 chunk = self._stream.read(self.CHUNK_SIZE)  # type: ignore
         else:
-            # Otherwise iterate, but enforce a maximum chunk size.
+            # Otherwise iterate.
             for part in self._stream:
-                for idx in range(0, len(part), self.CHUNK_SIZE):
-                    yield part[idx : idx + self.CHUNK_SIZE]
+                yield part
 
 
 class AsyncIteratorByteStream(AsyncByteStream):
@@ -83,10 +82,9 @@ class AsyncIteratorByteStream(AsyncByteStream):
                 yield chunk
                 chunk = await self._stream.aread(self.CHUNK_SIZE)  # type: ignore
         else:
-            # Otherwise iterate, but enforce a maximum chunk size.
+            # Otherwise iterate.
             async for part in self._stream:
-                for idx in range(0, len(part), self.CHUNK_SIZE):
-                    yield part[idx : idx + self.CHUNK_SIZE]
+                yield part
 
 
 class UnattachedStream(AsyncByteStream, SyncByteStream):

--- a/httpx/_content.py
+++ b/httpx/_content.py
@@ -49,7 +49,8 @@ class IteratorByteStream(SyncByteStream):
 
         self._is_stream_consumed = True
         for part in self._stream:
-            yield part
+            for idx in range(0, len(part), 65_536):
+                yield part[idx : idx + 65_536]
 
 
 class AsyncIteratorByteStream(AsyncByteStream):
@@ -64,7 +65,8 @@ class AsyncIteratorByteStream(AsyncByteStream):
 
         self._is_stream_consumed = True
         async for part in self._stream:
-            yield part
+            for idx in range(0, len(part), 65_536):
+                yield part[idx : idx + 65_536]
 
 
 class UnattachedStream(AsyncByteStream, SyncByteStream):

--- a/httpx/_multipart.py
+++ b/httpx/_multipart.py
@@ -71,6 +71,8 @@ class FileField:
     A single file field item, within a multipart form field.
     """
 
+    CHUNK_SIZE = 64 * 1024
+
     def __init__(self, name: str, value: FileTypes) -> None:
         self.name = name
 
@@ -142,10 +144,10 @@ class FileField:
             self.file.seek(0)
         self._consumed = True
 
-        for chunk in self.file:
-            chunk = to_bytes(chunk)
-            for idx in range(0, len(chunk), 65_536):
-                yield chunk[idx : idx + 65_536]
+        chunk = self.file.read(self.CHUNK_SIZE)
+        while chunk:
+            yield to_bytes(chunk)
+            chunk = self.file.read(self.CHUNK_SIZE)
 
     def render(self) -> typing.Iterator[bytes]:
         yield self.render_headers()

--- a/httpx/_multipart.py
+++ b/httpx/_multipart.py
@@ -143,7 +143,9 @@ class FileField:
         self._consumed = True
 
         for chunk in self.file:
-            yield to_bytes(chunk)
+            chunk = to_bytes(chunk)
+            for idx in range(0, len(chunk), 65_536):
+                yield chunk[idx : idx + 65_536]
 
     def render(self) -> typing.Iterator[bytes]:
         yield self.render_headers()


### PR DESCRIPTION
Resolves #1911

When digging into this, it turns out that when sending an upload file we're using `iter(file_obj)`, which *happens* to be a line-by-line iterator, and might yield super-large chunks for binary files. That happens to be slow because you don't really end up streaming the file to the network at all, but rather batching it all up in memory first.

The low-hanging fruit here is to cap the size of the chunks that we send to a max of 64k, which from a bit of prodding seems to be a fairly decent value.

It's possible that using `.read()` on a stream if it exists might be beneficial too, but I've not dug into that yet.