### PR TITLE
Drop mention of backend selection for AsyncHTTPTransport() in docs

### DIFF
--- a/docs/async.md
+++ b/docs/async.md
@@ -207,12 +207,6 @@ async def main():
 anyio.run(main, backend='trio')
 ```
 
-When instantiating a transport instance explicitly, for maximum consistency, the same `backend` parameter can be passed to `AsyncHTTPTransport`.
-```python
-transport = httpx.AsyncHTTPTransport(backend="trio")
-```
-
-
 ## Calling into Python Web Apps
 
 Just as `httpx.Client` allows you to call directly into WSGI web applications,


### PR DESCRIPTION
There is no 'backend' parameter to AsyncHTTPTransport and it seems that
the backend is detected automatically for anyio as it is for other async
libraries.