### PR TITLE
Dont perform implicit close/warning on `__del__`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.21.3 (6th January, 2022)
+
+### Fixed
+
+* Fix streaming uploads using `SyncByteStream` or `AsyncByteStream`. Regression in 0.12.2. (#2016)
+
 ## 0.21.2 (5th January, 2022)
 
 ### Fixed

--- a/httpx/__version__.py
+++ b/httpx/__version__.py
@@ -1,3 +1,3 @@
 __title__ = "httpx"
 __description__ = "A next generation HTTP client, for Python 3."
-__version__ = "0.21.2"
+__version__ = "0.21.3"

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -286,14 +286,6 @@ async def test_client_closed_state_using_with_block():
         await client.get("http://example.com")
 
 
-@pytest.mark.usefixtures("async_environment")
-async def test_deleting_unclosed_async_client_causes_warning():
-    client = httpx.AsyncClient(transport=httpx.MockTransport(hello_world))
-    await client.get("http://example.com")
-    with pytest.warns(UserWarning):
-        del client
-
-
 def unmounted(request: httpx.Request) -> httpx.Response:
     data = {"app": "unmounted"}
     return httpx.Response(200, json=data)


### PR DESCRIPTION
- Prompted by discussion #1951
- Closes #2024

We currently attempt to perform a bit of hand-holding for cases where a client instance has not been closed at the point it is deleted. The reasoning here was to try to give users a bit more of a guard against unintentional resource leaks.

Our behaviour here was...

* For sync clients, automatically `.close()` clients on `__del__`, if they're still open.
* For async clients, issue a warning on `__del__`, if they're still open.

As it turns out, this *just isn't reliable*. We really can't do this properly, because if `__del__` is called at `atexit` then there's all sorted of bit of stdlib that may not be available. We can't reliably call into `warnings.warn`, and it turns out we can't even reliably access the properties on an `intenum` class. Geez.

So. Let's just *not do this anymore*.

If you're leaking client instances (which as it happens, zillions of `requests` and `urllib3` using codebases currently already do.) Then okay, that's just the way it is. I'm not sure what flags you'd need to enable in python to have the system warn you about when that's the case, but we should rely on that level of warning, rather than attempting to add any ourselves.

Better that we stick with the current status-quo, than attempt to do better and actually just end up with user-hostile exceptions or undefined behaviours.