### PR TITLE
SOCKS proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,12 +129,16 @@ The HTTPX project relies on these excellent libraries:
 
 * `httpcore` - The underlying transport implementation for `httpx`.
   * `h11` - HTTP/1.1 support.
-  * `h2` - HTTP/2 support. *(Optional, with `httpx[http2]`)*
 * `certifi` - SSL certificates.
 * `charset_normalizer` - Charset auto-detection.
 * `rfc3986` - URL parsing & normalization.
   * `idna` - Internationalized domain name support.
 * `sniffio` - Async library autodetection.
+
+As well as these optional installs:
+
+* `h2` - HTTP/2 support. *(Optional, with `httpx[http2]`)*
+* `socksio` - SOCKS proxy support. *(Optional, with `httpx[socks]`)*
 * `rich` - Rich terminal support. *(Optional, with `httpx[cli]`)*
 * `click` - Command line client support. *(Optional, with `httpx[cli]`)*
 * `brotli` or `brotlicffi` - Decoding for "brotli" compressed responses. *(Optional, with `httpx[brotli]`)*

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -387,8 +387,6 @@ client = httpx.Client(trust_env=False)
 
 HTTPX supports setting up [HTTP proxies](https://en.wikipedia.org/wiki/Proxy_server#Web_proxy_servers) via the `proxies` parameter to be passed on client initialization or top-level API functions like `httpx.get(..., proxies=...)`.
 
-_Note: SOCKS proxies are not supported yet._
-
 <div align="center">
     <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/27/Open_proxy_h2g2bob.svg/480px-Open_proxy_h2g2bob.svg.png"/>
     <figcaption><em>Diagram of how a proxy works (source: Wikipedia). The left hand side "Internet" blob may be your HTTPX client requesting <code>example.com</code> through a proxy.</em></figcaption>
@@ -565,43 +563,33 @@ See documentation on [`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`](environment_vari
 In general, the flow for making an HTTP request through a proxy is as follows:
 
 1. The client connects to the proxy (initial connection request).
-1. The proxy somehow transfers data to the server on your behalf.
+2. The proxy transfers data to the server on your behalf.
 
 How exactly step 2/ is performed depends on which of two proxying mechanisms is used:
 
 * **Forwarding**: the proxy makes the request for you, and sends back the response it obtained from the server.
-* **Tunneling**: the proxy establishes a TCP connection to the server on your behalf, and the client reuses this connection to send the request and receive the response. This is known as an [HTTP Tunnel](https://en.wikipedia.org/wiki/HTTP_tunnel). This mechanism is how you can access websites that use HTTPS from an HTTP proxy (the client "upgrades" the connection to HTTPS by performing the TLS handshake with the server over the TCP connection provided by the proxy).
-
-#### Default behavior
-
-Given the technical definitions above, by default (and regardless of whether you're using an HTTP or HTTPS proxy), HTTPX will:
-
-* Use forwarding for HTTP requests.
-* Use tunneling for HTTPS requests.
-
-This ensures that you can make HTTP and HTTPS requests in all cases (i.e. regardless of which type of proxy you're using).
-
-#### Forcing the proxy mechanism
-
-In most cases, the default behavior should work just fine as well as provide enough security.
-
-But if you know what you're doing and you want to force which mechanism to use, you can do so by passing an `httpx.Proxy()` instance, setting the `mode` to either `FORWARD_ONLY` or `TUNNEL_ONLY`. For example...
-
-```python
-# Route all requests through an HTTPS proxy, using tunneling only.
-proxies = httpx.Proxy(
-    url="https://localhost:8030",
-    mode="TUNNEL_ONLY",
-)
-
-with httpx.Client(proxies=proxies) as client:
-    # This HTTP request will be tunneled instead of forwarded.
-    r = client.get("http://example.com")
-```
+* **Tunnelling**: the proxy establishes a TCP connection to the server on your behalf, and the client reuses this connection to send the request and receive the response. This is known as an [HTTP Tunnel](https://en.wikipedia.org/wiki/HTTP_tunnel). This mechanism is how you can access websites that use HTTPS from an HTTP proxy (the client "upgrades" the connection to HTTPS by performing the TLS handshake with the server over the TCP connection provided by the proxy).
 
 ### Troubleshooting proxies
 
 If you encounter issues when setting up proxies, please refer to our [Troubleshooting guide](troubleshooting.md#proxies).
+
+## SOCKS
+
+In addition to HTTP proxies, `httpcore` also supports proxies using the SOCKS protocol.
+This is an optional feature that requires an additional third-party library be installed before use.
+
+You can install SOCKS support using `pip`:
+
+```shell
+$ pip install httpx[socks]
+```
+
+You can now configure a client to make requests via a proxy using the SOCKS protocol:
+
+```python
+httpx.Client(proxies='socks5://user:pass@host:port')
+```
 
 ## Timeout Configuration
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -112,12 +112,16 @@ The HTTPX project relies on these excellent libraries:
 
 * `httpcore` - The underlying transport implementation for `httpx`.
   * `h11` - HTTP/1.1 support.
-  * `h2` - HTTP/2 support. *(Optional, with `httpx[http2]`)*
 * `certifi` - SSL certificates.
 * `charset_normalizer` - Charset auto-detection.
 * `rfc3986` - URL parsing & normalization.
   * `idna` - Internationalized domain name support.
 * `sniffio` - Async library autodetection.
+
+As well as these optional installs:
+
+* `h2` - HTTP/2 support. *(Optional, with `httpx[http2]`)*
+* `socksio` - SOCKS proxy support. *(Optional, with `httpx[socks]`)*
 * `rich` - Rich terminal support. *(Optional, with `httpx[cli]`)*
 * `click` - Command line client support. *(Optional, with `httpx[cli]`)*
 * `brotli` or `brotlicffi` - Decoding for "brotli" compressed responses. *(Optional, with `httpx[brotli]`)*

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # On the other hand, we're not pinning package dependencies, because our tests
 # needs to pass with the latest version of the packages.
 # Reference: https://github.com/encode/httpx/pull/1721#discussion_r661241588
--e .[cli,http2,brotli]
+-e .[brotli,cli,http2,socks]
 
 charset-normalizer==2.0.6
 

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
     ],
     extras_require={
         "http2": "h2>=3,<5",
+        "socks": "socksio==1.*",
         "brotli": [
             "brotli; platform_python_implementation == 'CPython'",
             "brotlicffi; platform_python_implementation != 'CPython'"

--- a/tests/client/test_proxies.py
+++ b/tests/client/test_proxies.py
@@ -47,6 +47,20 @@ def test_proxies_parameter(proxies, expected_proxies):
     assert len(expected_proxies) == len(client._mounts)
 
 
+def test_socks_proxy():
+    url = httpx.URL("http://www.example.com")
+
+    client = httpx.Client(proxies="socks5://localhost/")
+    transport = client._transport_for_url(url)
+    assert isinstance(transport, httpx.HTTPTransport)
+    assert isinstance(transport._pool, httpcore.SOCKSProxy)
+
+    async_client = httpx.AsyncClient(proxies="socks5://localhost/")
+    async_transport = async_client._transport_for_url(url)
+    assert isinstance(async_transport, httpx.AsyncHTTPTransport)
+    assert isinstance(async_transport._pool, httpcore.AsyncSOCKSProxy)
+
+
 PROXY_URL = "http://[::1]"
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -199,25 +199,22 @@ def test_ssl_config_support_for_keylog_file(tmpdir, monkeypatch):  # pragma: noc
         assert context.keylog_filename is None  # type: ignore
 
 
-@pytest.mark.parametrize(
-    "url,expected_url,expected_headers",
-    [
-        ("https://example.com", "https://example.com", {}),
-        (
-            "https://user:pass@example.com",
-            "https://example.com",
-            {"proxy-authorization": "Basic dXNlcjpwYXNz"},
-        ),
-    ],
-)
-def test_proxy_from_url(url, expected_url, expected_headers):
-    proxy = httpx.Proxy(url)
+def test_proxy_from_url():
+    proxy = httpx.Proxy("https://example.com")
 
-    assert str(proxy.url) == expected_url
-    assert dict(proxy.headers) == expected_headers
-    assert repr(proxy) == "Proxy(url='{}', headers={})".format(
-        expected_url, str(expected_headers)
-    )
+    assert str(proxy.url) == "https://example.com"
+    assert proxy.auth is None
+    assert proxy.headers == {}
+    assert repr(proxy) == "Proxy('https://example.com')"
+
+
+def test_proxy_with_auth_from_url():
+    proxy = httpx.Proxy("https://username:password@example.com")
+
+    assert str(proxy.url) == "https://example.com"
+    assert proxy.auth == ("username", "password")
+    assert proxy.headers == {}
+    assert repr(proxy) == "Proxy('https://example.com', auth=('username', '********'))"
 
 
 def test_invalid_proxy_scheme():


### PR DESCRIPTION
Integration against `httpcore` 0.14.5, which adds SOCKS5 proxy support, via [the fantastic `socksio` package](https://github.com/sethmlarson/socksio).