### PR TITLE
Add 'deploy' environment.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,3 @@
----
 name: Publish
 
 on:
@@ -10,6 +9,9 @@ jobs:
   publish:
     name: "Publish release"
     runs-on: "ubuntu-latest"
+
+    environment:
+       name: deploy
 
     steps:
       - uses: "actions/checkout@v2"


### PR DESCRIPTION
Switch the "publish" workflow to run on the "deploy" environment, so that we can require admin-reviews before deploying to PyPI.

I've also:

* Setup a `deploy` environment in this repo's settings.
* Configured it to have "required reviews" from the @encode/operations team (just me right now).
* Created a new PyPI API token for httpx.
* Saved that token in the deploy environment's secrets as PYPI_TOKEN.

We'll want to push a minor release at some point soonish so we can check this all runs okay.

See also https://github.com/encode/httpcore/pull/487 (Let's just try this out with `httpcore`/`httpx` to get started)
