### PR TITLE
Allow rich-11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         ],
         "cli": [
             "click==8.*",
-            "rich==10.*",
+            "rich>=10,<12",
             "pygments==2.*"
         ]
     },


### PR DESCRIPTION
Relax the version bind on rich to allow v11.  There are no test
regressions with the new version, and CLI seems to work correctly.