### PR TITLE
Ensure that `iter_bytes` and `iter_raw` do not ever yield any zero-length chunks.

### DIFF
--- a/httpx/_decoders.py
+++ b/httpx/_decoders.py
@@ -172,7 +172,7 @@ class ByteChunker:
 
     def decode(self, content: bytes) -> typing.List[bytes]:
         if self._chunk_size is None:
-            return [content]
+            return [content] if content else []
 
         self._buffer.write(content)
         if self._buffer.tell() >= self._chunk_size:

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -1585,7 +1585,7 @@ class Response:
                         yield chunk
                 decoded = decoder.flush()
                 for chunk in chunker.decode(decoded):
-                    yield chunk
+                    yield chunk  # pragma: nocover
                 for chunk in chunker.flush():
                     yield chunk
 
@@ -1683,7 +1683,7 @@ class Response:
                         yield chunk
                 decoded = decoder.flush()
                 for chunk in chunker.decode(decoded):
-                    yield chunk
+                    yield chunk  # pragma: nocover
                 for chunk in chunker.flush():
                     yield chunk
 

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -396,6 +396,19 @@ def test_iter_raw_with_chunksize():
     assert parts == [b"Hello, world!"]
 
 
+def test_iter_raw_doesnt_return_empty_chunks():
+    def streaming_body_with_empty_chunks():
+        yield b"Hello, "
+        yield b""
+        yield b"world!"
+        yield b""
+
+    response = httpx.Response(200, content=streaming_body_with_empty_chunks())
+
+    parts = [part for part in response.iter_raw()]
+    assert parts == [b"Hello, ", b"world!"]
+
+
 def test_iter_raw_on_iterable():
     response = httpx.Response(
         200,
@@ -524,6 +537,19 @@ def test_iter_bytes_with_empty_response():
     response = httpx.Response(200, content=b"")
     parts = [part for part in response.iter_bytes()]
     assert parts == []
+
+
+def test_iter_bytes_doesnt_return_empty_chunks():
+    def streaming_body_with_empty_chunks():
+        yield b"Hello, "
+        yield b""
+        yield b"world!"
+        yield b""
+
+    response = httpx.Response(200, content=streaming_body_with_empty_chunks())
+
+    parts = [part for part in response.iter_bytes()]
+    assert parts == [b"Hello, ", b"world!"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #1739
