### PR TITLE
Suppress binary output on the command line.

### DIFF
--- a/httpx/_main.py
+++ b/httpx/_main.py
@@ -172,10 +172,11 @@ def print_response(response: Response) -> None:
                 text = response.text
         else:
             text = response.text
+
         syntax = rich.syntax.Syntax(text, lexer_name, theme="ansi_dark", word_wrap=True)
         console.print(syntax)
-    else:  # pragma: nocover
-        console.print(rich.markup.escape(response.text))
+    else:
+        console.print(f"<{len(response.content)} bytes of binary data>")
 
 
 def format_certificate(cert: dict) -> str:  # pragma: nocover

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,8 @@ async def app(scope, receive, send):
         await status_code(scope, receive, send)
     elif scope["path"].startswith("/echo_body"):
         await echo_body(scope, receive, send)
+    elif scope["path"].startswith("/echo_binary"):
+        await echo_binary(scope, receive, send)
     elif scope["path"].startswith("/echo_headers"):
         await echo_headers(scope, receive, send)
     elif scope["path"].startswith("/redirect_301"):
@@ -150,6 +152,25 @@ async def echo_body(scope, receive, send):
             "type": "http.response.start",
             "status": 200,
             "headers": [[b"content-type", b"text/plain"]],
+        }
+    )
+    await send({"type": "http.response.body", "body": body})
+
+
+async def echo_binary(scope, receive, send):
+    body = b""
+    more_body = True
+
+    while more_body:
+        message = await receive()
+        body += message.get("body", b"")
+        more_body = message.get("more_body", False)
+
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [[b"content-type", b"application/octet-stream"]],
         }
     )
     await send({"type": "http.response.body", "body": body})

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -52,6 +52,22 @@ def test_json(server):
     ]
 
 
+def test_binary(server):
+    url = str(server.url.copy_with(path="/echo_binary"))
+    runner = CliRunner()
+    content = "Hello, world!"
+    result = runner.invoke(httpx.main, [url, "-c", content])
+    assert result.exit_code == 0
+    assert remove_date_header(splitlines(result.output)) == [
+        "HTTP/1.1 200 OK",
+        "server: uvicorn",
+        "content-type: application/octet-stream",
+        "Transfer-Encoding: chunked",
+        "",
+        f"<{len(content)} bytes of binary data>",
+    ]
+
+
 def test_redirects(server):
     url = str(server.url.copy_with(path="/redirect_301"))
     runner = CliRunner()


### PR DESCRIPTION
Closes #2049

Changed print_response to simply display the content length of a binary response.

`get_lexer_for_response` returns 'Text only' for a `Content-Type: text/...` response, so it will be properly displayed using `rich.syntax.Syntax`. Those responses which do not get a corresponding lexer are considered binary and their output is suppressed.

To make the tests pass I had to add another route to the test server that would return a binary response. Feel free to point it out if there's another way to do it.
