### PR TITLE
Allow str in form files.

### DIFF
--- a/httpx/_multipart.py
+++ b/httpx/_multipart.py
@@ -107,8 +107,12 @@ class FileField:
             # requests does the opposite (it overwrites the header with the 3rd tuple element)
             headers["Content-Type"] = content_type
 
-        if isinstance(fileobj, (str, io.StringIO)):
-            raise TypeError(f"Expected bytes or bytes-like object got: {type(fileobj)}")
+        if isinstance(fileobj, io.TextIOBase):
+            # Both `StringIO` and `TextIOWrapper` inerit from `TextIOBase`.
+            # This allows to pass plain `str` content, but not a text buffer or text file.
+            raise TypeError(
+                f"Expected bytes, bytes-like or str object, got: {type(fileobj)}"
+            )
 
         self.filename = filename
         self.file = fileobj

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -287,12 +287,11 @@ def test_multipart_encode_files_allows_bytes_content() -> None:
         assert content == b"".join(stream)
 
 
-def test_multipart_encode_files_raises_exception_with_str_content() -> None:
+def test_multipart_encode_files_accepts_str_content() -> None:
     files = {"file": ("test.txt", "<bytes content>", "text/plain")}
     with mock.patch("os.urandom", return_value=os.urandom(16)):
 
-        with pytest.raises(TypeError):
-            encode_request(data={}, files=files)  # type: ignore
+        assert encode_request(data={}, files=files)  # type: ignore
 
 
 def test_multipart_encode_files_raises_exception_with_StringIO_content() -> None:
@@ -301,6 +300,26 @@ def test_multipart_encode_files_raises_exception_with_StringIO_content() -> None
 
         with pytest.raises(TypeError):
             encode_request(data={}, files=files)  # type: ignore
+
+
+def test_multipart_encode_files_raises_exception_with_TextIOWrapper_content() -> None:
+    files = {
+        "file": ("test.txt", io.TextIOWrapper(io.BytesIO(b"content")), "text/plain")
+    }
+    with mock.patch("os.urandom", return_value=os.urandom(16)):
+
+        with pytest.raises(TypeError):
+            encode_request(data={}, files=files)  # type: ignore
+
+
+def test_multipart_encode_files_raises_exception_with_file_in_text_mode() -> None:
+    with tempfile.TemporaryFile("r") as f:
+
+        files = {"file": f}
+        with mock.patch("os.urandom", return_value=os.urandom(16)):
+
+            with pytest.raises(TypeError):
+                encode_request(data={}, files=files)  # type: ignore
 
 
 def test_multipart_encode_non_seekable_filelike() -> None:


### PR DESCRIPTION
Closes: #2069

Changed `FileField` to allow `str` content, but raise exception on text buffers.
