### PR TITLE
add options to override tcp hostname and tls hostname

### DIFF
--- a/httpx/_main.py
+++ b/httpx/_main.py
@@ -492,9 +492,7 @@ def main(
             verify=verify,
             http2=http2,
         ) as client:
-            extensions: typing.Dict[str, typing.Any] = {
-                "trace": functools.partial(trace, verbose=verbose)
-            }
+            extensions: dict = {"trace": functools.partial(trace, verbose=verbose)}
             if x_connect_to is not None:
                 extensions["connect_to"] = x_connect_to
             if x_sni_hostname is not None:

--- a/httpx/_main.py
+++ b/httpx/_main.py
@@ -80,8 +80,13 @@ def print_help() -> None:
     )
 
     table.add_row("--follow-redirects", "Automatically follow redirects.")
-    table.add_row("--x-connect-to", "Use alternative hostname for tcp connection.")
-    table.add_row("--x-sni-hostname", "Use alternative hostname for TLS handshake.")
+    table.add_row(
+        "--x-connect-to [cyan]HOSTNAME", "Use alternative hostname for tcp connection."
+    )
+    table.add_row(
+        "--x-sni-hostname  [cyan]HOSTNAME",
+        "Use alternative hostname for TLS handshake.",
+    )
 
     table.add_row("--no-verify", "Disable SSL verification.")
     table.add_row(
@@ -487,7 +492,9 @@ def main(
             verify=verify,
             http2=http2,
         ) as client:
-            extensions = {"trace": functools.partial(trace, verbose=verbose)}
+            extensions: typing.Dict[str, typing.Any] = {
+                "trace": functools.partial(trace, verbose=verbose)
+            }
             if x_connect_to is not None:
                 extensions["connect_to"] = x_connect_to
             if x_sni_hostname is not None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -167,6 +167,35 @@ def test_auth(server):
     ]
 
 
+def test_connect_to(server):
+    hostname = "never.in.dns:8000"
+    url = f"http://{hostname}/"
+    runner = CliRunner()
+    result = runner.invoke(
+        httpx.main,
+        [url, "-v", "--x-connect-to", "127.0.0.1", "--x-sni-hostname", "invalid.cert"],
+    )
+    print(result.output)
+    assert result.exit_code == 0
+    assert remove_date_header(splitlines(result.output)) == [
+        "* Connecting to '127.0.0.1'",
+        "* Connected to '127.0.0.1' on port 8000",
+        "GET / HTTP/1.1",
+        f"Host: {hostname}",
+        "Accept: */*",
+        "Accept-Encoding: gzip, deflate, br",
+        "Connection: keep-alive",
+        f"User-Agent: python-httpx/{httpx.__version__}",
+        "",
+        "HTTP/1.1 200 OK",
+        "server: uvicorn",
+        "content-type: text/plain",
+        "Transfer-Encoding: chunked",
+        "",
+        "Hello, world!",
+    ]
+
+
 def test_download(server):
     url = str(server.url)
     runner = CliRunner()


### PR DESCRIPTION
this requires new extensions inside httpcore  (https://github.com/encode/httpcore/pull/507)

Here is a snipped I used to test this.  
`python -c 'import httpx; import sys;httpx.main(sys.argv[1:])'  https://neverin.org/headers --x-connect-to 54.221.78.73  --x-sni-hostname httpbin.org`