### PR TITLE
Fix: Keep-alive configuration is not documented. 

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -672,8 +672,9 @@ argument on the client. It takes instances of `httpx.Limits` which define:
 
 - `max_keepalive`, number of allowable keep-alive connections, or `None` to always
 allow. (Defaults 20)
-- `max_connections`, maximum number of allowable connections, or` None` for no limits.
+- `max_connections`, maximum number of allowable connections, or `None` for no limits.
 (Default 100)
+- `keepalive_expiry`, time limit on idle keep-alive connections in seconds, or `None` for no limits. (Default 5)
 
 ```python
 limits = httpx.Limits(max_keepalive_connections=5, max_connections=10)

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -284,6 +284,7 @@ class Limits:
     * **max_keepalive_connections** - Allow the connection pool to maintain
             keep-alive connections below this point. Should be less than or equal
             to `max_connections`.
+    * **keepalive_expiry** - Time limit on idle keep-alive connections in seconds.
     """
 
     def __init__(


### PR DESCRIPTION
Closes: #2079 
Updated docs and class docstring for `keepalive_expiry` param.