### PR TITLE
Fix invalid max_keepalive_connections argument name

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -670,7 +670,7 @@ response = client.get('http://example.com/')
 You can control the connection pool size using the `limits` keyword
 argument on the client. It takes instances of `httpx.Limits` which define:
 
-- `max_keepalive`, number of allowable keep-alive connections, or `None` to always
+- `max_keepalive_connections`, number of allowable keep-alive connections, or `None` to always
 allow. (Defaults 20)
 - `max_connections`, maximum number of allowable connections, or `None` for no limits.
 (Default 100)


### PR DESCRIPTION
The argument to `httpx.Limits` is named `max_keepalive_connections` but is referenced as `max_keepalive` in the docs. This updates the single place I found it referenced incorrectly.

Thanks for all the great work on `httpx` 🙏
