### PR TITLE
Upgrade mkdocs to 1.3.0 to fix scripts/build failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 charset-normalizer==2.0.6
 
 # Documentation
-mkdocs==1.2.3
+mkdocs==1.3.0
 mkautodoc==0.1.0
 mkdocs-material==8.1.4
 


### PR DESCRIPTION
Refs https://github.com/encode/httpx/pull/2097#issuecomment-1080008519

CI currently broken due to mkdocs < 1.3.0 being broken after a new Jinja2 release

See: https://github.com/mkdocs/mkdocs/issues/2799

```
+ venv/bin/mkdocs build
Traceback (most recent call last):
  File "/Users/florimond/Developer/python-projects/httpx/venv/bin/mkdocs", line 8, in <module>
    sys.exit(cli())
  File "/Users/florimond/Developer/python-projects/httpx/venv/lib/python3.10/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/Users/florimond/Developer/python-projects/httpx/venv/lib/python3.10/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/Users/florimond/Developer/python-projects/httpx/venv/lib/python3.10/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/florimond/Developer/python-projects/httpx/venv/lib/python3.10/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/florimond/Developer/python-projects/httpx/venv/lib/python3.10/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/Users/florimond/Developer/python-projects/httpx/venv/lib/python3.10/site-packages/mkdocs/__main__.py", line 187, in build_command
    build.build(config.load_config(**kwargs), dirty=not clean)
  File "/Users/florimond/Developer/python-projects/httpx/venv/lib/python3.10/site-packages/mkdocs/config/base.py", line 216, in load_config
    from mkdocs.config.defaults import get_schema
  File "/Users/florimond/Developer/python-projects/httpx/venv/lib/python3.10/site-packages/mkdocs/config/defaults.py", line 1, in <module>
    from mkdocs.config import config_options
  File "/Users/florimond/Developer/python-projects/httpx/venv/lib/python3.10/site-packages/mkdocs/config/config_options.py", line 8, in <module>
    from mkdocs import utils, theme, plugins
  File "/Users/florimond/Developer/python-projects/httpx/venv/lib/python3.10/site-packages/mkdocs/theme.py", line 6, in <module>
    from mkdocs.utils import filters
  File "/Users/florimond/Developer/python-projects/httpx/venv/lib/python3.10/site-packages/mkdocs/utils/filters.py", line 13, in <module>
    @jinja2.contextfilter
AttributeError: module 'jinja2' has no attribute 'contextfilter'
```

This PR upgrades to 1.3.0 which includes a fix