### PR TITLE
Making charset auto-detection strictly opt-in.

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -167,6 +167,7 @@ class BaseClient:
         event_hooks: typing.Mapping[str, typing.List[typing.Callable]] = None,
         base_url: URLTypes = "",
         trust_env: bool = True,
+        default_encoding: str = "utf-8",
     ):
         event_hooks = {} if event_hooks is None else event_hooks
 
@@ -184,6 +185,7 @@ class BaseClient:
             "response": list(event_hooks.get("response", [])),
         }
         self._trust_env = trust_env
+        self._default_encoding = default_encoding
         self._netrc = NetRCInfo()
         self._state = ClientState.UNOPENED
 
@@ -998,6 +1000,7 @@ class Client(BaseClient):
         response.stream = BoundSyncStream(
             response.stream, response=response, timer=timer
         )
+        response.default_encoding = self._default_encoding
         self.cookies.extract_cookies(response)
 
         status = f"{response.status_code} {response.reason_phrase}"
@@ -1702,6 +1705,7 @@ class AsyncClient(BaseClient):
         response.stream = BoundAsyncStream(
             response.stream, response=response, timer=timer
         )
+        response.default_encoding = self._default_encoding
         self.cookies.extract_cookies(response)
 
         status = f"{response.status_code} {response.reason_phrase}"

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -15,7 +15,7 @@ def test_get(server):
     assert response.content == b"Hello, world!"
     assert response.text == "Hello, world!"
     assert response.http_version == "HTTP/1.1"
-    assert response.encoding is None
+    assert response.encoding == "utf-8"
     assert response.request.url == url
     assert response.headers
     assert response.is_redirect is False

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -164,9 +164,9 @@ def test_response_content_type_encoding():
     assert response.encoding == "latin-1"
 
 
-def test_response_autodetect_encoding():
+def test_response_default_encoding():
     """
-    Autodetect encoding if there is no Content-Type header.
+    Use default encoding if there is no Content-Type header.
     """
     content = "おはようございます。".encode("utf-8")
     response = httpx.Response(
@@ -174,12 +174,12 @@ def test_response_autodetect_encoding():
         content=content,
     )
     assert response.text == "おはようございます。"
-    assert response.encoding is None
+    assert response.encoding == "utf-8"
 
 
 def test_response_fallback_to_autodetect():
     """
-    Fallback to autodetection if we get an invalid charset in the Content-Type header.
+    Fallback to default encoding if we get an invalid charset in the Content-Type header.
     """
     headers = {"Content-Type": "text-plain; charset=invalid-codec-name"}
     content = "おはようございます。".encode("utf-8")
@@ -189,7 +189,7 @@ def test_response_fallback_to_autodetect():
         headers=headers,
     )
     assert response.text == "おはようございます。"
-    assert response.encoding is None
+    assert response.encoding == "utf-8"
 
 
 def test_response_no_charset_with_ascii_content():
@@ -205,7 +205,7 @@ def test_response_no_charset_with_ascii_content():
         headers=headers,
     )
     assert response.status_code == 200
-    assert response.encoding is None
+    assert response.encoding == "utf-8"
     assert response.text == "Hello, world!"
 
 
@@ -222,13 +222,15 @@ def test_response_no_charset_with_utf8_content():
         headers=headers,
     )
     assert response.text == "Unicode Snowman: ☃"
-    assert response.encoding is None
+    assert response.encoding == "utf-8"
 
 
 def test_response_no_charset_with_iso_8859_1_content():
     """
     A response with ISO 8859-1 encoded content should decode correctly,
     even with no charset specified.
+
+    TODO: nope
     """
     content = "Accented: Österreich abcdefghijklmnopqrstuzwxyz".encode("iso-8859-1")
     headers = {"Content-Type": "text/plain"}
@@ -239,13 +241,16 @@ def test_response_no_charset_with_iso_8859_1_content():
     )
     assert response.text == "Accented: Österreich abcdefghijklmnopqrstuzwxyz"
     assert response.charset_encoding is None
-    assert response.apparent_encoding is not None
+    assert response.default_encoding == "utf-8"
+    assert response.encoding == "utf-8"
 
 
 def test_response_no_charset_with_cp_1252_content():
     """
     A response with Windows 1252 encoded content should decode correctly,
     even with no charset specified.
+
+    TODO: nope
     """
     content = "Euro Currency: € abcdefghijklmnopqrstuzwxyz".encode("cp1252")
     headers = {"Content-Type": "text/plain"}
@@ -256,12 +261,13 @@ def test_response_no_charset_with_cp_1252_content():
     )
     assert response.text == "Euro Currency: € abcdefghijklmnopqrstuzwxyz"
     assert response.charset_encoding is None
-    assert response.apparent_encoding is not None
+    assert response.default_encoding == "utf-8"
+    assert response.encoding == "utf-8"
 
 
 def test_response_non_text_encoding():
     """
-    Default to apparent encoding for non-text content-type headers.
+    Apply default encoding for non-text content-type headers.
     """
     headers = {"Content-Type": "image/png"}
     response = httpx.Response(
@@ -270,7 +276,7 @@ def test_response_non_text_encoding():
         headers=headers,
     )
     assert response.text == "xyz"
-    assert response.encoding is None
+    assert response.encoding == "utf-8"
 
 
 def test_response_set_explicit_encoding():
@@ -307,7 +313,7 @@ def test_read():
 
     assert response.status_code == 200
     assert response.text == "Hello, world!"
-    assert response.encoding is None
+    assert response.encoding == "utf-8"
     assert response.is_closed
 
     content = response.read()
@@ -322,7 +328,7 @@ def test_empty_read():
 
     assert response.status_code == 200
     assert response.text == ""
-    assert response.encoding is None
+    assert response.encoding == "utf-8"
     assert response.is_closed
 
     content = response.read()
@@ -341,7 +347,7 @@ async def test_aread():
 
     assert response.status_code == 200
     assert response.text == "Hello, world!"
-    assert response.encoding is None
+    assert response.encoding == "utf-8"
     assert response.is_closed
 
     content = await response.aread()
@@ -357,7 +363,7 @@ async def test_empty_aread():
 
     assert response.status_code == 200
     assert response.text == ""
-    assert response.encoding is None
+    assert response.encoding == "utf-8"
     assert response.is_closed
 
     content = await response.aread()


### PR DESCRIPTION
From discussion https://github.com/encode/httpx/discussions/2083

Remove our auto-charset-guessing behaviour for cases where `response.text` is accessed, but the response has no explicit charset. The behaviour is too fuzzy and inconsistent to support as a default.

Instead we allow explicitly setting the default encoding. Furthermore we *also* allow 

- [x] Drop `response.apparent_encoding` in favour of an explicit `response.default_encoding`.
- [x] Type of `response.encoding` becomes `str`, not `Optional[str]`.
- [x] Support `Response(default_encoding=...)`.
- [x] Support `Client(default_encoding=...)`. 
- [ ] Support `Response(encoding_errors=...)`.
- [ ] Support `Client(encoding_errors=...)`.
- [ ] Remove `charset_normalizer` dependancy.
- [ ] Support `default_encoding="charset_normalizer"` and `default_encoding="chardet"` to allow for auto-detection behaviours.
- [ ] Documentation on text encodings.