### PR TITLE
Bump `black` to 22.3.0

### DIFF
--- a/httpx/_compat.py
+++ b/httpx/_compat.py
@@ -36,7 +36,6 @@ if sys.version_info >= (3, 10) or (
         # https://docs.python.org/3.7/library/ssl.html#ssl.SSLContext.minimum_version
         context.minimum_version = ssl.TLSVersion.TLSv1_2
 
-
 else:
 
     def set_minimum_tls_version_1_2(context: ssl.SSLContext) -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ wheel==0.37.0
 
 # Tests & Linting
 autoflake==1.4
-black==21.11b1
+black==22.3.0
 coverage==6.0.2
 cryptography==36.0.1
 flake8==3.9.2


### PR DESCRIPTION
As mentioned on https://github.com/encode/httpx/pull/2097#issuecomment-1082207141, the pipeline is broken due to `black`/`click`.

Thanks @ofek! :)