### PR TITLE
Support rfc3986 v2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         "certifi",
         "charset_normalizer",
         "sniffio",
-        "rfc3986[idna2008]>=1.3,<2",
+        "rfc3986[idna2008]>=1.3,<3",
         "httpcore>=0.14.5,<0.15.0",
         "async_generator; python_version < '3.7'"
     ],


### PR DESCRIPTION
Would be nice to support rfc3986 to that enables python 3.8,3.9,3.10 support.

https://rfc3986.readthedocs.io/en/latest/release-notes/unreleased.html

Thanks!