### PR TITLE
docs: Fix proxy examples

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -213,7 +213,7 @@ this is where our previously generated `client.pem` comes in:
 ```
 import httpx
 
-proxies = {"all": "http://127.0.0.1:8080/"}
+proxies = {"all://": "http://127.0.0.1:8080/"}
 
 with httpx.Client(proxies=proxies, verify="/path/to/client.pem") as client:
     response = client.get("https://example.org")

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -20,8 +20,8 @@ httpx.ProxyError: _ssl.c:1091: The handshake operation timed out
 
 ```python
 proxies = {
-  "http": "http://myproxy.org",
-  "https": "https://myproxy.org",
+  "http://": "http://myproxy.org",
+  "https://": "https://myproxy.org",
 }
 ```
 
@@ -33,8 +33,8 @@ Change the scheme of your HTTPS proxy to `http://...` instead of `https://...`:
 
 ```python
 proxies = {
-  "http": "http://myproxy.org",
-  "https": "http://myproxy.org",
+  "http://": "http://myproxy.org",
+  "https://": "http://myproxy.org",
 }
 ```
 


### PR DESCRIPTION
Per https://www.python-httpx.org/compatibility/#proxy-keys, there should always be a `://` after the protocol. The given examples raise an exception when used as-is.
