### PR TITLE
Remove `RequestBodyUnavailable` from module docstring

### DIFF
--- a/httpx/_exceptions.py
+++ b/httpx/_exceptions.py
@@ -21,7 +21,6 @@ Our exception hierarchy:
       - UnsupportedProtocol
     + DecodingError
     + TooManyRedirects
-    + RequestBodyUnavailable
   x HTTPStatusError
 * InvalidURL
 * CookieConflict


### PR DESCRIPTION
The `RequestBodyUnavailable` class no longer exists?

