### PR TITLE
Update _client.py

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -1363,7 +1363,7 @@ class AsyncClient(BaseClient):
         transport: typing.Optional[AsyncBaseTransport] = None,
         app: typing.Optional[typing.Callable] = None,
         trust_env: bool = True,
-        default_encoding: str = "utf-8",
+        default_encoding: typing.Union[str, typing.Callable[[bytes], str]] = "utf-8",
     ):
         super().__init__(
             auth=auth,


### PR DESCRIPTION
Update the type annotation for the default_encoding parameter of AsyncClient's initializer to accept a callable of the form (bytes) -> str.

The starting point for contributions should usually be [a discussion](https://github.com/encode/httpx/discussions)

Simple documentation typos may be raised as stand-alone pull requests, but otherwise
please ensure you've discussed your proposal prior to issuing a pull request.

This will help us direct work appropriately, and ensure that any suggested changes
have been okayed by the maintainers.

- [x] Initially raised as discussion #...

Closes #2246 