### PR TITLE
Remove 3.6 from the package classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,6 @@ setup(
         "Framework :: AsyncIO",
         "Framework :: Trio",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
The starting point for contributions should usually be [a discussion](https://github.com/encode/httpx/discussions)

Simple documentation typos may be raised as stand-alone pull requests, but otherwise
please ensure you've discussed your proposal prior to issuing a pull request.

This will help us direct work appropriately, and ensure that any suggested changes
have been okayed by the maintainers.

- [ ] Initially raised as discussion #...
