### PR TITLE
Test under 3.11.0-beta.3

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11.0-beta.3"]
 
     steps:
       - uses: "actions/checkout@v3"

--- a/scripts/install
+++ b/scripts/install
@@ -15,5 +15,5 @@ else
     PIP="pip"
 fi
 
+"$PIP" install -U pip setuptools wheel
 "$PIP" install -r "$REQUIREMENTS"
-"$PIP" install -e .

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ filterwarnings =
   default:::uvicorn
   default::DeprecationWarning:certifi
   default:'cgi' is deprecated:DeprecationWarning
+  default:module 'sre_constants' is deprecated:DeprecationWarning
 asyncio_mode = strict
 markers =
   copied_from(source, changes=None): mark test as copied from somewhere else, along with a description of changes made to accodomate e.g. our test setup

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,9 +21,9 @@ addopts = -rxXs
 filterwarnings =
   error
   default:::uvicorn
-  default::DeprecationWarning:certifi
+  default:path is deprecated:DeprecationWarning:certifi
   default:'cgi' is deprecated:DeprecationWarning
-  default:module 'sre_constants' is deprecated:DeprecationWarning
+  default:'sre_constants' is deprecated:DeprecationWarning
 asyncio_mode = strict
 markers =
   copied_from(source, changes=None): mark test as copied from somewhere else, along with a description of changes made to accodomate e.g. our test setup

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,8 @@ addopts = -rxXs
 filterwarnings =
   error
   default:::uvicorn
+  default::DeprecationWarning:certifi
+  default:'cgi' is deprecated:DeprecationWarning
 asyncio_mode = strict
 markers =
   copied_from(source, changes=None): mark test as copied from somewhere else, along with a description of changes made to accodomate e.g. our test setup

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ combine_as_imports = True
 addopts = -rxXs
 filterwarnings =
   error
-  default:::uvicorn
   default:path is deprecated:DeprecationWarning:certifi
   default:'cgi' is deprecated:DeprecationWarning
   default:'sre_constants' is deprecated:DeprecationWarning

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3 :: Only",
     ],
 )


### PR DESCRIPTION
Added a few warning filters because:
- `_models.py` and `test_multiplart.py` are relying on deprecated`cgi`
- `certifi` is using deprecated `importlib.resources.path`
- `rich` is using deprecated `sre_constants`
