### PR TITLE
Rework docs structure

### DIFF
--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -1,56 +1,8 @@
 # Exceptions
 
-## Request and Response exceptions
+This page lists exceptions that may be raised when using HTTPX.
 
-The most important exception classes in HTTPX are `RequestError` and `HTTPStatusError`.
-
-The `RequestError` class is a superclass that encompasses any exception that occurs
-while issuing an HTTP request. These exceptions include a `.request` attribute.
-
-```python
-try:
-    response = httpx.get("https://www.example.com/")
-except httpx.RequestError as exc:
-    print(f"An error occurred while requesting {exc.request.url!r}.")
-```
-
-The `HTTPStatusError` class is raised by `response.raise_for_status()` on responses which are not a 2xx success code.
-These exceptions include both a `.request` and a `.response` attribute.
-
-```python
-response = httpx.get("https://www.example.com/")
-try:
-    response.raise_for_status()
-except httpx.HTTPStatusError as exc:
-    print(f"Error response {exc.response.status_code} while requesting {exc.request.url!r}.")
-```
-
-There is also a base class `HTTPError` that includes both of these categories, and can be used
-to catch either failed requests, or 4xx and 5xx responses.
-
-You can either use this base class to catch both categories...
-
-```python
-try:
-    response = httpx.get("https://www.example.com/")
-    response.raise_for_status()
-except httpx.HTTPError as exc:
-    print(f"Error while requesting {exc.request.url!r}.")
-```
-
-Or handle each case explicitly...
-
-```python
-try:
-    response = httpx.get("https://www.example.com/")
-    response.raise_for_status()
-except httpx.RequestError as exc:
-    print(f"An error occurred while requesting {exc.request.url!r}.")
-except httpx.HTTPStatusError as exc:
-    print(f"Error response {exc.response.status_code} while requesting {exc.request.url!r}.")
-```
-
----
+For an overview of how to work with HTTPX exceptions, see [Exceptions (Quickstart)](quickstart.md#exceptions).
 
 ## The exception hierarchy
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -479,3 +479,57 @@ as above:
 >>> httpx.get("https://example.com", auth=auth)
 <Response [200 OK]>
 ```
+
+## Exceptions
+
+HTTPX will raise exceptions if an error occurs.
+
+The most important exception classes in HTTPX are `RequestError` and `HTTPStatusError`.
+
+The `RequestError` class is a superclass that encompasses any exception that occurs
+while issuing an HTTP request. These exceptions include a `.request` attribute.
+
+```python
+try:
+    response = httpx.get("https://www.example.com/")
+except httpx.RequestError as exc:
+    print(f"An error occurred while requesting {exc.request.url!r}.")
+```
+
+The `HTTPStatusError` class is raised by `response.raise_for_status()` on responses which are not a 2xx success code.
+These exceptions include both a `.request` and a `.response` attribute.
+
+```python
+response = httpx.get("https://www.example.com/")
+try:
+    response.raise_for_status()
+except httpx.HTTPStatusError as exc:
+    print(f"Error response {exc.response.status_code} while requesting {exc.request.url!r}.")
+```
+
+There is also a base class `HTTPError` that includes both of these categories, and can be used
+to catch either failed requests, or 4xx and 5xx responses.
+
+You can either use this base class to catch both categories...
+
+```python
+try:
+    response = httpx.get("https://www.example.com/")
+    response.raise_for_status()
+except httpx.HTTPError as exc:
+    print(f"Error while requesting {exc.request.url!r}.")
+```
+
+Or handle each case explicitly...
+
+```python
+try:
+    response = httpx.get("https://www.example.com/")
+    response.raise_for_status()
+except httpx.RequestError as exc:
+    print(f"An error occurred while requesting {exc.request.url!r}.")
+except httpx.HTTPStatusError as exc:
+    print(f"Error response {exc.response.status_code} while requesting {exc.request.url!r}.")
+```
+
+For a full list of available exceptions, see [Exceptions (API Reference)](exceptions.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,8 @@ site_url: https://www.python-httpx.org/
 
 theme:
     name: 'material'
+    features:
+        - navigation.sections
 
 repo_name: encode/httpx
 repo_url: https://github.com/encode/httpx/
@@ -11,18 +13,22 @@ edit_uri: ""
 
 nav:
     - Introduction: 'index.md'
-    - QuickStart: 'quickstart.md'
-    - Advanced Usage: 'advanced.md'
-    - Async Support: 'async.md'
-    - HTTP/2 Support: 'http2.md'
-    - Environment Variables: 'environment_variables.md'
-    - Requests Compatibility: 'compatibility.md'
-    - Developer Interface: 'api.md'
-    - Exceptions: 'exceptions.md'
-    - Troubleshooting: 'troubleshooting.md'
-    - Third Party Packages: 'third_party_packages.md'
-    - Contributing: 'contributing.md'
-    - Code of Conduct: 'code_of_conduct.md'
+    - Usage:
+        - QuickStart: 'quickstart.md'
+        - Advanced Usage: 'advanced.md'
+    - Guides:
+        - Async Support: 'async.md'
+        - HTTP/2 Support: 'http2.md'
+        - Requests Compatibility: 'compatibility.md'
+        - Troubleshooting: 'troubleshooting.md'
+    - API Reference:
+        - Developer Interface: 'api.md'
+        - Exceptions: 'exceptions.md'
+        - Environment Variables: 'environment_variables.md'
+    - Community:
+        - Third Party Packages: 'third_party_packages.md'
+        - Contributing: 'contributing.md'
+        - Code of Conduct: 'code_of_conduct.md'
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
I didn't raise a discussion about this, but this PR also serves as a hands-on proposal. Happy to discuss separately if need be.

This PR restructures the documentation in four well-visible sections:

![View of the updated sidebar navigation](https://user-images.githubusercontent.com/15911462/179053656-00a05954-8504-40d8-a1b4-d0f2a67d31af.png)

<details>
<summary>Open for text version</summary>

* Usage
  * Quickstart
  * Advanced usage
* Guides
  * Async Support
  * HTTP/2 Support
  * Requests Compatibility
  * Troubleshooting
* API Reference
  * Developer Interface
  * Exceptions
  * Environment variables
* Community
  * Third-Party Packages
  * Contributing
  * Code of Conduct

</details>

This takes inspiration from the 4-part Tutorials/How-To's/Discussions/Reference theorised by Daniele Procida (see [What nobody tells you about documentation (talk)](https://www.youtube.com/watch?v=t4vKPhjcMZg)).

It doesn't _exactly_ match that structure -- e.g. I don't think we've got something resembling "discussions" yet, although stuff like #207 would be potential candidates.

But we do have different _kinds_ of documentation in HTTPX _already_. The motivation here was to group them to help people find what they're looking for more easily.

So, each section answers the following questions:

* Usage - "How do I generally use HTTPX?"
* Guides - "How do I do X with HTTPX?" (where X = Async, HTTP/2, migrating from Requests, troubleshooting problems)
* API Reference - "What components are available when coding?"
* Community - "What surrounds the HTTPX project?"

The only shuffling of content I had to do was split the "Exceptions" docs across Quickstart vs. API Reference, as it mixed general usage hints and reference material. This matches how there's a [Exceptions and errors](https://requests.readthedocs.io/en/latest/user/quickstart/#errors-and-exceptions) section in the Requests quickstart documentation, and then an [Exceptions](https://requests.readthedocs.io/en/latest/api/#exceptions) section on its API Reference page.