### PR TITLE
Replace cgi which will be deprecated in Python 3.11

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -1,4 +1,3 @@
-import cgi
 import datetime
 import email.message
 import json as jsonlib
@@ -47,6 +46,7 @@ from ._utils import (
     normalize_header_key,
     normalize_header_value,
     obfuscate_sensitive_headers,
+    parse_content_type_charset,
     parse_header_links,
 )
 
@@ -608,11 +608,7 @@ class Response:
         if content_type is None:
             return None
 
-        _, params = cgi.parse_header(content_type)
-        if "charset" not in params:
-            return None
-
-        return params["charset"].strip("'\"")
+        return parse_content_type_charset(content_type)
 
     def _get_content_decoder(self) -> ContentDecoder:
         """

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -215,10 +215,7 @@ def parse_content_type_charset(content_type: str) -> typing.Optional[str]:
     # See: https://peps.python.org/pep-0594/#cgi
     msg = email.message.Message()
     msg["content-type"] = content_type
-    charset = msg.get_param("charset")
-    if charset is None:
-        return None
-    return str(charset).strip("'\"")
+    return msg.get_content_charset(failobj=None)
 
 
 SENSITIVE_HEADERS = {"authorization", "proxy-authorization"}

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -1,4 +1,5 @@
 import codecs
+import email.message
 import logging
 import mimetypes
 import netrc
@@ -207,6 +208,17 @@ def parse_header_links(value: str) -> typing.List[typing.Dict[str, str]]:
             link[key.strip(replace_chars)] = value.strip(replace_chars)
         links.append(link)
     return links
+
+
+def parse_content_type_charset(content_type: str) -> typing.Optional[str]:
+    # We used to use `cgi.parse_header()` here, but `cgi` became a dead battery.
+    # See: https://peps.python.org/pep-0594/#cgi
+    msg = email.message.Message()
+    msg["content-type"] = content_type
+    charset = msg.get_param("charset")
+    if charset is None:
+        return None
+    return str(charset).strip("'\"")
 
 
 SENSITIVE_HEADERS = {"authorization", "proxy-authorization"}


### PR DESCRIPTION
Prompted by https://github.com/encode/httpx/pull/2302 which surfaced a warning in the upcoming Python 3.11 as `cgi` is being deprecated as per [PEP-594](https://peps.python.org/pep-0594/).