### PR TITLE
Pin markdown==3.3.7 to prevent mkautodoc loading failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ types-chardet==4.0.4
 mkdocs==1.3.0
 mkautodoc==0.1.0
 mkdocs-material==8.3.8
+markdown==3.3.7  # Pin until backwards-incompatible changes here are addressed in mkautodoc: https://python-markdown.github.io/change_log/release-3.4/
 
 # Packaging
 twine==4.0.1


### PR DESCRIPTION
This PR gets CI back in shape as there is an issue with `mkautodoc` when the latest Markdown version is installed:

```console
Python 3.10.0 (default, Nov 28 2021, 23:05:33) [GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import mkautodoc
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/florimond/dev/fairness/httpx/venv/lib/python3.10/site-packages/mkautodoc/__init__.py", line 1, in <module>
    from .extension import MKAutoDocExtension, makeExtension
  File "/home/florimond/dev/fairness/httpx/venv/lib/python3.10/site-packages/mkautodoc/extension.py", line 4, in <module>
    from markdown.util import etree
ImportError: cannot import name 'etree' from 'markdown.util' (/home/florimond/dev/fairness/httpx/venv/lib/python3.10/site-packages/markdown/util.py)
>>> 
```

https://python-markdown.github.io/change_log/release-3.4/

> Previously deprecated objects have been removed
>
> Deprecated Object | Replacement Object
> -- | --
> markdown.util.etree | xml.etree.ElementTree
