### PR TITLE
Update docs to reflect supported python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Or, to include the optional HTTP/2 support, use:
 $ pip install httpx[http2]
 ```
 
-HTTPX requires Python 3.6+.
+HTTPX requires Python 3.7+.
 
 ## Documentation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -145,6 +145,6 @@ To include the optional brotli decoder support, use:
 $ pip install httpx[brotli]
 ```
 
-HTTPX requires Python 3.6+
+HTTPX requires Python 3.7+
 
 [sync-support]: https://github.com/encode/httpx/issues/572


### PR DESCRIPTION
Python3.6 references are still present in documentation even after
officially dropping support.

- [x] Initially raised as discussion #...
#2136 