### PR TITLE
Add fake setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 import sys
 
+from setuptools import setup
+
 sys.stderr.write(
     """
 ===============================

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,31 @@
+import sys
+
+from setuptools import setup
+
+sys.stderr.write(
+    """
+===============================
+Unsupported installation method
+===============================
+httpx no longer supports installation with `python setup.py install`.
+Please use `python -m pip install .` instead.
+"""
+)
+sys.exit(1)
+
+
+# The below code will never execute, however GitHub is particularly
+# picky about where it finds Python packaging metadata.
+# See: https://github.com/github/feedback/discussions/6456
+#
+# To be removed once GitHub catches up.
+
+setup(
+    name="httpx",
+    install_requires=[
+        "certifi",
+        "sniffio",
+        "rfc3986[idna2008]>=1.3,<2",
+        "httpcore>=0.15.0,<0.16.0",
+    ],
+)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 import sys
 
-from setuptools import setup
-
 sys.stderr.write(
     """
 ===============================


### PR DESCRIPTION
This is quite sad.

@michaeloliverx brought this to our attention on: https://github.com/encode/httpx/commit/45b7cfaad3a8987ea35fa5bf092bbdda485444fd#commitcomment-82042745.

The `Used by` section on the project's profile disappeared after we removed the `setup.py`. We can either accept this PR or revert https://github.com/encode/httpx/pull/2334, to have it back,

I'll let you folks decide @florimondmanca @tomchristie 🙏 

I'll update the Starlette and Uvicorn according to what is decided here.

Closes #2352