### PR TITLE
Fix empty query params

### DIFF
--- a/httpx/_urls.py
+++ b/httpx/_urls.py
@@ -540,7 +540,7 @@ class QueryParams(typing.Mapping[str, str]):
         items: typing.Sequence[typing.Tuple[str, PrimitiveData]]
         if value is None or isinstance(value, (str, bytes)):
             value = value.decode("ascii") if isinstance(value, bytes) else value
-            self._dict = parse_qs(value)
+            self._dict = parse_qs(value, keep_blank_values=True)
         elif isinstance(value, QueryParams):
             self._dict = {k: list(v) for k, v in value._dict.items()}
         else:

--- a/tests/models/test_queryparams.py
+++ b/tests/models/test_queryparams.py
@@ -76,6 +76,17 @@ def test_queryparam_types():
     assert str(q) == "a=1&a=2"
 
 
+def test_empty_query_params():
+    q = httpx.QueryParams({"a": ""})
+    assert str(q) == "a="
+
+    q = httpx.QueryParams("a=")
+    assert str(q) == "a="
+
+    q = httpx.QueryParams("a")
+    assert str(q) == "a="
+
+
 def test_queryparam_update_is_hard_deprecated():
     q = httpx.QueryParams("a=123")
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
Closes #2331

We might also want to distinguish between `q=` and `q` at some point, but that's a more complex conversation.