### PR TITLE
add basic type annotation for extensions

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -38,6 +38,7 @@ from ._types import (
     QueryParamTypes,
     RequestContent,
     RequestData,
+    RequestExtensions,
     RequestFiles,
     SyncByteStream,
     TimeoutTypes,
@@ -328,7 +329,7 @@ class BaseClient:
         headers: typing.Optional[HeaderTypes] = None,
         cookies: typing.Optional[CookieTypes] = None,
         timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
-        extensions: typing.Optional[dict] = None,
+        extensions: typing.Optional[RequestExtensions] = None,
     ) -> Request:
         """
         Build and return a request instance.
@@ -345,7 +346,7 @@ class BaseClient:
         headers = self._merge_headers(headers)
         cookies = self._merge_cookies(cookies)
         params = self._merge_queryparams(params)
-        extensions = {} if extensions is None else extensions
+        extensions = dict({} if extensions is None else extensions)
         if "timeout" not in extensions:
             timeout = (
                 self.timeout
@@ -773,7 +774,7 @@ class Client(BaseClient):
         auth: typing.Union[AuthTypes, UseClientDefault, None] = USE_CLIENT_DEFAULT,
         follow_redirects: typing.Union[bool, UseClientDefault] = USE_CLIENT_DEFAULT,
         timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
-        extensions: typing.Optional[dict] = None,
+        extensions: typing.Optional[RequestExtensions] = None,
     ) -> Response:
         """
         Build and send a request.
@@ -830,7 +831,7 @@ class Client(BaseClient):
         auth: typing.Union[AuthTypes, UseClientDefault, None] = USE_CLIENT_DEFAULT,
         follow_redirects: typing.Union[bool, UseClientDefault] = USE_CLIENT_DEFAULT,
         timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
-        extensions: typing.Optional[dict] = None,
+        extensions: typing.Optional[RequestExtensions] = None,
     ) -> typing.Iterator[Response]:
         """
         Alternative to `httpx.request()` that streams the response body
@@ -1029,7 +1030,7 @@ class Client(BaseClient):
         auth: typing.Union[AuthTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
         follow_redirects: typing.Union[bool, UseClientDefault] = USE_CLIENT_DEFAULT,
         timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
-        extensions: typing.Optional[dict] = None,
+        extensions: typing.Optional[RequestExtensions] = None,
     ) -> Response:
         """
         Send a `GET` request.
@@ -1058,7 +1059,7 @@ class Client(BaseClient):
         auth: typing.Union[AuthTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
         follow_redirects: typing.Union[bool, UseClientDefault] = USE_CLIENT_DEFAULT,
         timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
-        extensions: typing.Optional[dict] = None,
+        extensions: typing.Optional[RequestExtensions] = None,
     ) -> Response:
         """
         Send an `OPTIONS` request.
@@ -1087,7 +1088,7 @@ class Client(BaseClient):
         auth: typing.Union[AuthTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
         follow_redirects: typing.Union[bool, UseClientDefault] = USE_CLIENT_DEFAULT,
         timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
-        extensions: typing.Optional[dict] = None,
+        extensions: typing.Optional[RequestExtensions] = None,
     ) -> Response:
         """
         Send a `HEAD` request.
@@ -1120,7 +1121,7 @@ class Client(BaseClient):
         auth: typing.Union[AuthTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
         follow_redirects: typing.Union[bool, UseClientDefault] = USE_CLIENT_DEFAULT,
         timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
-        extensions: typing.Optional[dict] = None,
+        extensions: typing.Optional[RequestExtensions] = None,
     ) -> Response:
         """
         Send a `POST` request.
@@ -1157,7 +1158,7 @@ class Client(BaseClient):
         auth: typing.Union[AuthTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
         follow_redirects: typing.Union[bool, UseClientDefault] = USE_CLIENT_DEFAULT,
         timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
-        extensions: typing.Optional[dict] = None,
+        extensions: typing.Optional[RequestExtensions] = None,
     ) -> Response:
         """
         Send a `PUT` request.
@@ -1194,7 +1195,7 @@ class Client(BaseClient):
         auth: typing.Union[AuthTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
         follow_redirects: typing.Union[bool, UseClientDefault] = USE_CLIENT_DEFAULT,
         timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
-        extensions: typing.Optional[dict] = None,
+        extensions: typing.Optional[RequestExtensions] = None,
     ) -> Response:
         """
         Send a `PATCH` request.
@@ -1227,7 +1228,7 @@ class Client(BaseClient):
         auth: typing.Union[AuthTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
         follow_redirects: typing.Union[bool, UseClientDefault] = USE_CLIENT_DEFAULT,
         timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
-        extensions: typing.Optional[dict] = None,
+        extensions: typing.Optional[RequestExtensions] = None,
     ) -> Response:
         """
         Send a `DELETE` request.
@@ -1493,7 +1494,7 @@ class AsyncClient(BaseClient):
         auth: typing.Union[AuthTypes, UseClientDefault, None] = USE_CLIENT_DEFAULT,
         follow_redirects: typing.Union[bool, UseClientDefault] = USE_CLIENT_DEFAULT,
         timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
-        extensions: typing.Optional[dict] = None,
+        extensions: typing.Optional[RequestExtensions] = None,
     ) -> Response:
         """
         Build and send a request.
@@ -1542,7 +1543,7 @@ class AsyncClient(BaseClient):
         auth: typing.Union[AuthTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
         follow_redirects: typing.Union[bool, UseClientDefault] = USE_CLIENT_DEFAULT,
         timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
-        extensions: typing.Optional[dict] = None,
+        extensions: typing.Optional[RequestExtensions] = None,
     ) -> typing.AsyncIterator[Response]:
         """
         Alternative to `httpx.request()` that streams the response body
@@ -1741,7 +1742,7 @@ class AsyncClient(BaseClient):
         auth: typing.Union[AuthTypes, UseClientDefault, None] = USE_CLIENT_DEFAULT,
         follow_redirects: typing.Union[bool, UseClientDefault] = USE_CLIENT_DEFAULT,
         timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
-        extensions: typing.Optional[dict] = None,
+        extensions: typing.Optional[RequestExtensions] = None,
     ) -> Response:
         """
         Send a `GET` request.
@@ -1770,7 +1771,7 @@ class AsyncClient(BaseClient):
         auth: typing.Union[AuthTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
         follow_redirects: typing.Union[bool, UseClientDefault] = USE_CLIENT_DEFAULT,
         timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
-        extensions: typing.Optional[dict] = None,
+        extensions: typing.Optional[RequestExtensions] = None,
     ) -> Response:
         """
         Send an `OPTIONS` request.
@@ -1799,7 +1800,7 @@ class AsyncClient(BaseClient):
         auth: typing.Union[AuthTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
         follow_redirects: typing.Union[bool, UseClientDefault] = USE_CLIENT_DEFAULT,
         timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
-        extensions: typing.Optional[dict] = None,
+        extensions: typing.Optional[RequestExtensions] = None,
     ) -> Response:
         """
         Send a `HEAD` request.
@@ -1832,7 +1833,7 @@ class AsyncClient(BaseClient):
         auth: typing.Union[AuthTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
         follow_redirects: typing.Union[bool, UseClientDefault] = USE_CLIENT_DEFAULT,
         timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
-        extensions: typing.Optional[dict] = None,
+        extensions: typing.Optional[RequestExtensions] = None,
     ) -> Response:
         """
         Send a `POST` request.
@@ -1869,7 +1870,7 @@ class AsyncClient(BaseClient):
         auth: typing.Union[AuthTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
         follow_redirects: typing.Union[bool, UseClientDefault] = USE_CLIENT_DEFAULT,
         timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
-        extensions: typing.Optional[dict] = None,
+        extensions: typing.Optional[RequestExtensions] = None,
     ) -> Response:
         """
         Send a `PUT` request.
@@ -1906,7 +1907,7 @@ class AsyncClient(BaseClient):
         auth: typing.Union[AuthTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
         follow_redirects: typing.Union[bool, UseClientDefault] = USE_CLIENT_DEFAULT,
         timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
-        extensions: typing.Optional[dict] = None,
+        extensions: typing.Optional[RequestExtensions] = None,
     ) -> Response:
         """
         Send a `PATCH` request.
@@ -1939,7 +1940,7 @@ class AsyncClient(BaseClient):
         auth: typing.Union[AuthTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
         follow_redirects: typing.Union[bool, UseClientDefault] = USE_CLIENT_DEFAULT,
         timeout: typing.Union[TimeoutTypes, UseClientDefault] = USE_CLIENT_DEFAULT,
-        extensions: typing.Optional[dict] = None,
+        extensions: typing.Optional[RequestExtensions] = None,
     ) -> Response:
         """
         Send a `DELETE` request.

--- a/httpx/_main.py
+++ b/httpx/_main.py
@@ -197,7 +197,7 @@ def format_certificate(cert: dict) -> str:  # pragma: nocover
     return "\n".join(lines)
 
 
-def trace(name: str, info: dict, verbose: bool = False) -> None:
+def trace(name: str, info: typing.Mapping[str, typing.Any], verbose: bool = False) -> None:
     console = rich.console.Console()
     if name == "connection.connect_tcp.started" and verbose:
         host = info["host"]

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -35,8 +35,10 @@ from ._types import (
     QueryParamTypes,
     RequestContent,
     RequestData,
+    RequestExtensions,
     RequestFiles,
     ResponseContent,
+    ResponseExtensions,
     SyncByteStream,
 )
 from ._urls import URL
@@ -316,7 +318,7 @@ class Request:
         files: typing.Optional[RequestFiles] = None,
         json: typing.Optional[typing.Any] = None,
         stream: typing.Union[SyncByteStream, AsyncByteStream, None] = None,
-        extensions: typing.Optional[dict] = None,
+        extensions: typing.Optional[RequestExtensions] = None,
     ):
         self.method = (
             method.decode("ascii").upper()
@@ -327,7 +329,7 @@ class Request:
         if params is not None:
             self.url = self.url.copy_merge_params(params=params)
         self.headers = Headers(headers)
-        self.extensions = {} if extensions is None else extensions
+        self.extensions = dict({} if extensions is None else extensions)
 
         if cookies:
             Cookies(cookies).set_cookie_header(self)
@@ -452,7 +454,7 @@ class Response:
         json: typing.Any = None,
         stream: typing.Union[SyncByteStream, AsyncByteStream, None] = None,
         request: typing.Optional[Request] = None,
-        extensions: typing.Optional[dict] = None,
+        extensions: typing.Optional[ResponseExtensions] = None,
         history: typing.Optional[typing.List["Response"]] = None,
         default_encoding: typing.Union[str, typing.Callable[[bytes], str]] = "utf-8",
     ):
@@ -465,7 +467,7 @@ class Response:
         # the client will set `response.next_request`.
         self.next_request: typing.Optional[Request] = None
 
-        self.extensions = {} if extensions is None else extensions
+        self.extensions = dict({} if extensions is None else extensions)
         self.history = [] if history is None else list(history)
 
         self.is_closed = False

--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -7,6 +7,7 @@ from http.cookiejar import CookieJar
 from typing import (
     IO,
     TYPE_CHECKING,
+    Any,
     AsyncIterable,
     AsyncIterator,
     Callable,
@@ -75,8 +76,9 @@ AuthTypes = Union[
 
 RequestContent = Union[str, bytes, Iterable[bytes], AsyncIterable[bytes]]
 ResponseContent = Union[str, bytes, Iterable[bytes], AsyncIterable[bytes]]
+ResponseExtensions = Mapping[str, Any]
 
-RequestData = dict
+RequestData = Mapping[str, Any]
 
 FileContent = Union[IO[bytes], bytes]
 FileTypes = Union[
@@ -90,6 +92,8 @@ FileTypes = Union[
     Tuple[Optional[str], FileContent, Optional[str], Mapping[str, str]],
 ]
 RequestFiles = Union[Mapping[str, FileTypes], Sequence[Tuple[str, FileTypes]]]
+
+RequestExtensions = Mapping[str, Any]
 
 
 class SyncByteStream:


### PR DESCRIPTION
Mentioned on gitter

Before:
<img width="1427" alt="Screen Shot 2022-09-12 at 1 16 40 PM" src="https://user-images.githubusercontent.com/1755071/189727159-b2fdd01e-2d54-4c07-ba2d-36a0e5dd9000.png">

After:
<img width="1480" alt="Screen Shot 2022-09-12 at 1 16 59 PM" src="https://user-images.githubusercontent.com/1755071/189727182-0a007e05-d435-4dce-8aed-c3927b4452c2.png">

We can always come back later and add a more accurate type (`TypedDict` or something)