### PR TITLE
Add thread-safety note on the `Client` docstring

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -574,6 +574,8 @@ class Client(BaseClient):
     """
     An HTTP client, with connection pooling, HTTP/2, redirects, cookie persistence, etc.
 
+    It can be shared between threads.
+
     Usage:
 
     ```python


### PR DESCRIPTION
This is coming from: https://github.com/encode/httpx/discussions/1633#discussioncomment-717752