### PR TITLE
Always use latest version of `pip`.

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -15,5 +15,6 @@ else
     PIP="pip"
 fi
 
+"$PIP" install -U pip
 "$PIP" install -r "$REQUIREMENTS"
 "$PIP" install -e .


### PR DESCRIPTION
Installation should start by updating `pip` to the latest version.

Resolves issue noted in https://github.com/encode/httpx/pull/2334#issuecomment-1268308195
