### PR TITLE
Remove unneeded installation on `install` script

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -17,4 +17,3 @@ fi
 
 "$PIP" install -U pip
 "$PIP" install -r "$REQUIREMENTS"
-"$PIP" install -e .


### PR DESCRIPTION
This is not needed because our `requirements.txt` already install with `-e .`.

See also https://github.com/encode/starlette/pull/1895
