### PR TITLE
Allow str content for multipart upload files

### DIFF
--- a/httpx/_multipart.py
+++ b/httpx/_multipart.py
@@ -122,8 +122,14 @@ class FileField:
             # requests does the opposite (it overwrites the header with the 3rd tuple element)
             headers["Content-Type"] = content_type
 
-        if isinstance(fileobj, (str, io.StringIO)):
-            raise TypeError(f"Expected bytes or bytes-like object got: {type(fileobj)}")
+        if "b" not in getattr(fileobj, "mode", "b"):
+            raise TypeError(
+                "Multipart file uploads must be opened in binary mode, not text mode."
+            )
+        if isinstance(fileobj, io.StringIO):
+            raise TypeError(
+                "Multipart file uploads require 'io.BytesIO', not 'io.StringIO'."
+            )
 
         self.filename = filename
         self.file = fileobj

--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -80,7 +80,7 @@ ResponseExtensions = Dict[str, Any]
 
 RequestData = Mapping[str, Any]
 
-FileContent = Union[IO[bytes], bytes]
+FileContent = Union[IO[bytes], bytes, str]
 FileTypes = Union[
     # file (or bytes)
     FileContent,


### PR DESCRIPTION
Closes #2069.

Allow `str` for simple multipart uploads...

```python
httpx.post(url, files={"upload": "some content"})
```

However we (continue to) explicitly disallow `io.StringIO` and files opened in text mode, since we can't upfront determine their byte-length.

I think this is probably a pretty okay middle-ground, supporting the simple text-use-case, while enforcing bytes for the file-like cases. Not a breaking change, since we're *expanding* our supported cases here.