### PR TITLE
remove runtime type checks

### DIFF
--- a/httpx/_multipart.py
+++ b/httpx/_multipart.py
@@ -43,14 +43,6 @@ class DataField:
     def __init__(
         self, name: str, value: typing.Union[str, bytes, int, float, None]
     ) -> None:
-        if not isinstance(name, str):
-            raise TypeError(
-                f"Invalid type for name. Expected str, got {type(name)}: {name!r}"
-            )
-        if value is not None and not isinstance(value, (str, bytes, int, float)):
-            raise TypeError(
-                f"Invalid type for value. Expected primitive type, got {type(value)}: {value!r}"
-            )
         self.name = name
         self.value: typing.Union[str, bytes] = (
             value if isinstance(value, bytes) else primitive_value_to_str(value)

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -94,33 +94,6 @@ def test_multipart_header_without_boundary(header: str) -> None:
     assert response.request.headers["Content-Type"] == header
 
 
-@pytest.mark.parametrize(("key"), (b"abc", 1, 2.3, None))
-def test_multipart_invalid_key(key):
-    client = httpx.Client(transport=httpx.MockTransport(echo_request_content))
-
-    data = {key: "abc"}
-    files = {"file": io.BytesIO(b"<file content>")}
-    with pytest.raises(TypeError) as e:
-        client.post(
-            "http://127.0.0.1:8000/",
-            data=data,
-            files=files,
-        )
-    assert "Invalid type for name" in str(e.value)
-    assert repr(key) in str(e.value)
-
-
-@pytest.mark.parametrize(("value"), (object(), {"key": "value"}))
-def test_multipart_invalid_value(value):
-    client = httpx.Client(transport=httpx.MockTransport(echo_request_content))
-
-    data = {"text": value}
-    files = {"file": io.BytesIO(b"<file content>")}
-    with pytest.raises(TypeError) as e:
-        client.post("http://127.0.0.1:8000/", data=data, files=files)
-    assert "Invalid type for value" in str(e.value)
-
-
 def test_multipart_file_tuple():
     client = httpx.Client(transport=httpx.MockTransport(echo_request_content))
 


### PR DESCRIPTION
https://github.com/encode/httpx/pull/2404#issuecomment-1275925168

> Removing TypeError checks. Personally I'm probably against this, but more importantly let's discuss that as a separate issue.

My rationale for removing this: we should either adopt runtime type checking _systematically_ (using [beartype](https://github.com/beartype/beartype), [Pydantic's validation decorator](https://pydantic-docs.helpmanual.io/usage/validation_decorator/) or making our inputs (like a `Request` instance) Pydantic models) _or_ we should remove it all together and rely on static type checking.

I think having manual runtime type checking sprinkled around the codebase doesn't scale as well as either of those two solutions.

Amongst those two I think the obvious choice is to rely purely on static type checking and documentation. It's more valuable for users to know upfront that they're giving us the wrong type (e.g. by implementing #2404 which replaces an `Any` for the value with the types that we are checking for at runtime here) than to do it at runtime.