### PR TITLE
Drop `.read`/`.aread` from `SyncByteStream`/`AsyncByteStream`

### DIFF
--- a/httpx/_content.py
+++ b/httpx/_content.py
@@ -52,9 +52,7 @@ class IteratorByteStream(SyncByteStream):
             raise StreamConsumed()
 
         self._is_stream_consumed = True
-        if hasattr(self._stream, "read") and not isinstance(
-            self._stream, SyncByteStream
-        ):
+        if hasattr(self._stream, "read"):
             # File-like interfaces should use 'read' directly.
             chunk = self._stream.read(self.CHUNK_SIZE)  # type: ignore
             while chunk:
@@ -79,9 +77,7 @@ class AsyncIteratorByteStream(AsyncByteStream):
             raise StreamConsumed()
 
         self._is_stream_consumed = True
-        if hasattr(self._stream, "aread") and not isinstance(
-            self._stream, AsyncByteStream
-        ):
+        if hasattr(self._stream, "aread"):
             # File-like interfaces should use 'aread' directly.
             chunk = await self._stream.aread(self.CHUNK_SIZE)  # type: ignore
             while chunk:

--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -107,33 +107,7 @@ class SyncByteStream:
         """
         Subclasses can override this method to release any network resources
         after a request/response cycle is complete.
-
-        Streaming cases should use a `try...finally` block to ensure that
-        the stream `close()` method is always called.
-
-        Example:
-
-            status_code, headers, stream, extensions = transport.handle_request(...)
-            try:
-                ...
-            finally:
-                stream.close()
         """
-
-    def read(self) -> bytes:
-        """
-        Simple cases can use `.read()` as a convenience method for consuming
-        the entire stream and then closing it.
-
-        Example:
-
-            status_code, headers, stream, extensions = transport.handle_request(...)
-            body = stream.read()
-        """
-        try:
-            return b"".join([part for part in self])
-        finally:
-            self.close()
 
 
 class AsyncByteStream:
@@ -145,9 +119,3 @@ class AsyncByteStream:
 
     async def aclose(self) -> None:
         pass
-
-    async def aread(self) -> bytes:
-        try:
-            return b"".join([part async for part in self])
-        finally:
-            await self.aclose()

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -13,8 +13,8 @@ async def test_empty_content():
     assert isinstance(stream, httpx.SyncByteStream)
     assert isinstance(stream, httpx.AsyncByteStream)
 
-    sync_content = stream.read()
-    async_content = await stream.aread()
+    sync_content = b"".join([part for part in stream])
+    async_content = b"".join([part async for part in stream])
 
     assert headers == {}
     assert sync_content == b""


### PR DESCRIPTION
We have a leftover bit of API on `SyncByteStream`/`AsyncByteStream` that is a hangover from when we were designing the Transport API.

They both have a convenience method for reading the stream, which was added to make testing at the low-level of the Transport API easier. However the methods are a bit kludgy because they don't actually fit the `read(max_bytes)` that Python file interfaces use.

I think we can just hard-drop these. They're undocumented, and you don't *ever* need them. The convenience methods are on the `Response` class.