### PR TITLE
Run tests against Python 3.11 stable

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: "actions/checkout@v3"


### PR DESCRIPTION
Python 3.11 stable was released on 2022-10-24, see https://pythoninsider.blogspot.com/2022/10/python-3110-is-now-available.html