### PR TITLE
typing improvements

### DIFF
--- a/httpx/__version__.py
+++ b/httpx/__version__.py
@@ -1,3 +1,3 @@
 __title__ = "httpx"
-__description__ = "A next generation HTTP client, for Python 3."
+__description__: str = "A next generation HTTP client, for Python 3."
 __version__ = "0.23.0"

--- a/httpx/_auth.py
+++ b/httpx/_auth.py
@@ -10,6 +10,9 @@ from ._exceptions import ProtocolError
 from ._models import Request, Response
 from ._utils import to_bytes, to_str, unquote
 
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from hashlib import _Hash
+
 
 class Auth:
     """
@@ -139,7 +142,7 @@ class BasicAuth(Auth):
 
 
 class DigestAuth(Auth):
-    _ALGORITHM_TO_HASH_FUNCTION: typing.Dict[str, typing.Callable] = {
+    _ALGORITHM_TO_HASH_FUNCTION: typing.Dict[str, typing.Callable[[bytes], "_Hash"]] = {
         "MD5": hashlib.md5,
         "MD5-SESS": hashlib.md5,
         "SHA": hashlib.sha1,

--- a/httpx/_compat.py
+++ b/httpx/_compat.py
@@ -2,13 +2,8 @@
 The _compat module is used for code which requires branching between different
 Python environments. It is excluded from the code coverage checks.
 """
-import asyncio
 import ssl
 import sys
-import typing
-
-if typing.TYPE_CHECKING:  # pragma: no cover
-    import typing_extensions
 
 # Brotli support is optional
 # The C bindings in `brotli` are recommended for CPython.
@@ -43,8 +38,3 @@ else:
         context.options |= ssl.OP_NO_SSLv3
         context.options |= ssl.OP_NO_TLSv1
         context.options |= ssl.OP_NO_TLSv1_1
-
-
-def iscoroutine(coro: object) -> "typing_extensions.TypeGuard[typing.Coroutine]":
-    # Drop when this is resolved: https://github.com/python/typeshed/pull/8104
-    return asyncio.iscoroutine(coro)

--- a/httpx/_main.py
+++ b/httpx/_main.py
@@ -179,7 +179,12 @@ def print_response(response: Response) -> None:
         console.print(f"<{len(response.content)} bytes of binary data>")
 
 
-def format_certificate(cert: dict) -> str:  # pragma: nocover
+_PCTRTT = typing.Tuple[typing.Tuple[str, str], ...]
+_PCTRTTT = typing.Tuple[_PCTRTT, ...]
+_PeerCertRetDictType = typing.Dict[str, typing.Union[str, _PCTRTTT, _PCTRTT]]
+
+
+def format_certificate(cert: _PeerCertRetDictType) -> str:  # pragma: nocover
     lines = []
     for key, value in cert.items():
         if isinstance(value, (list, tuple)):

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -3,7 +3,7 @@ import email.message
 import json as jsonlib
 import typing
 import urllib.request
-from collections.abc import Mapping, MutableMapping
+from collections.abc import Mapping
 from http.cookiejar import Cookie, CookieJar
 
 from ._content import ByteStream, UnattachedStream, encode_request, encode_response
@@ -1002,7 +1002,7 @@ class Response:
                 await self.stream.aclose()
 
 
-class Cookies(MutableMapping):
+class Cookies(typing.MutableMapping[str, str]):
     """
     HTTP Cookies, as a mutable mapping.
     """

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -305,6 +305,12 @@ class Headers(typing.MutableMapping[str, str]):
 
 
 class Request:
+    method: str
+    url: URL
+    headers: Headers
+    extensions: RequestExtensions
+    stream: typing.Union[SyncByteStream, AsyncByteStream]
+
     def __init__(
         self,
         method: typing.Union[str, bytes],
@@ -443,6 +449,16 @@ class Request:
 
 
 class Response:
+    status_code: int
+    headers: Headers
+    next_request: typing.Optional[Request]
+    extensions: ResponseExtensions
+    history: typing.List["Response"]
+    is_closed: bool
+    is_stream_consumed: bool
+    default_encoding: typing.Union[str, typing.Callable[[bytes], str]]
+    stream: typing.Union[SyncByteStream, AsyncByteStream]
+
     def __init__(
         self,
         status_code: int,
@@ -1006,6 +1022,8 @@ class Cookies(typing.MutableMapping[str, str]):
     """
     HTTP Cookies, as a mutable mapping.
     """
+
+    jar: CookieJar
 
     def __init__(self, cookies: typing.Optional[CookieTypes] = None) -> None:
         if cookies is None or isinstance(cookies, dict):

--- a/httpx/_transports/mock.py
+++ b/httpx/_transports/mock.py
@@ -1,6 +1,6 @@
+import asyncio
 import typing
 
-from .._compat import iscoroutine
 from .._models import Request, Response
 from .base import AsyncBaseTransport, BaseTransport
 
@@ -28,7 +28,7 @@ class MockTransport(AsyncBaseTransport, BaseTransport):
         # return the result.
 
         # https://simonwillison.net/2020/Sep/2/await-me-maybe/
-        if iscoroutine(response):
+        if asyncio.iscoroutine(response):
             response = await response
 
         return response

--- a/httpx/_transports/mock.py
+++ b/httpx/_transports/mock.py
@@ -6,7 +6,7 @@ from .base import AsyncBaseTransport, BaseTransport
 
 
 class MockTransport(AsyncBaseTransport, BaseTransport):
-    def __init__(self, handler: typing.Callable) -> None:
+    def __init__(self, handler: typing.Callable[[Request], Response]) -> None:
         self.handler = handler
 
     def handle_request(

--- a/httpx/_transports/wsgi.py
+++ b/httpx/_transports/wsgi.py
@@ -87,6 +87,12 @@ class WSGITransport(BaseTransport):
     ```
     """
 
+    app: WSGIApplication
+    raise_app_exceptions: bool
+    script_name: str
+    remote_addr: str
+    wsgi_errors: typing.Optional[typing.TextIO]
+
     def __init__(
         self,
         app: WSGIApplication,

--- a/httpx/_urls.py
+++ b/httpx/_urls.py
@@ -570,7 +570,7 @@ class QueryParams(typing.Mapping[str, str]):
                 for k, v in dict_value.items()
             }
 
-    def keys(self) -> typing.KeysView:
+    def keys(self) -> typing.KeysView[str]:
         """
         Return all the keys in the query params.
 
@@ -581,7 +581,7 @@ class QueryParams(typing.Mapping[str, str]):
         """
         return self._dict.keys()
 
-    def values(self) -> typing.ValuesView:
+    def values(self) -> typing.ValuesView[str]:
         """
         Return all the values in the query params. If a key occurs more than once
         only the first item for that key is returned.
@@ -593,7 +593,7 @@ class QueryParams(typing.Mapping[str, str]):
         """
         return {k: v[0] for k, v in self._dict.items()}.values()
 
-    def items(self) -> typing.ItemsView:
+    def items(self) -> typing.ItemsView[str, str]:
         """
         Return all items in the query params. If a key occurs more than once
         only the first item for that key is returned.

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -508,7 +508,7 @@ class URLPattern:
         return True
 
     @property
-    def priority(self) -> tuple:
+    def priority(self) -> typing.Tuple[int, int, int]:
         """
         The priority allows URLPattern instances to be sortable, so that
         we can match from most specific to least specific.

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ max-line-length = 120
 
 [mypy]
 disallow_untyped_defs = True
+disallow_any_generics = True
 ignore_missing_imports = True
 no_implicit_optional = True
 show_error_codes = True

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -428,7 +428,7 @@ async def test_digest_auth(
     assert response.status_code == 200
     assert len(response.history) == 1
 
-    authorization = typing.cast(dict, response.json())["auth"]
+    authorization = typing.cast(typing.Dict[str, typing.Any], response.json())["auth"]
     scheme, _, fields = authorization.partition(" ")
     assert scheme == "Digest"
 
@@ -459,7 +459,7 @@ async def test_digest_auth_no_specified_qop() -> None:
     assert response.status_code == 200
     assert len(response.history) == 1
 
-    authorization = typing.cast(dict, response.json())["auth"]
+    authorization = typing.cast(typing.Dict[str, typing.Any], response.json())["auth"]
     scheme, _, fields = authorization.partition(" ")
     assert scheme == "Digest"
 


### PR DESCRIPTION
This is a series of patches to improve the quality of the type hints provided
by httpx.  These type hint updates were driven by our use of httpx in a project
with pyright configured in _strict_ mode, which sets a high bar for type hint
completeness in 3rd party libraries such as httpx.

In the process, I found that the WSGITransport implementation had small issues
and fixed those in situ.

Without this patch, the output of [`pyright --verifytypes httpx`][verifytypes] produces:

```
Symbols exported by "httpx": 67
  With known type: 18
  With ambiguous type: 1
  With unknown type: 48
  Functions without docstring: 2
  Functions without default param: 129
  Classes without docstring: 0

Other symbols referenced but not exported by "httpx": 1061
  With known type: 941
  With ambiguous type: 11
  With unknown type: 109

Type completeness score: 26.9%
```

With these patches, the output will became:

```
Symbols exported by "httpx": 67
  With known type: 67
  With ambiguous type: 0
  With unknown type: 0
  Functions without docstring: 2
  Functions without default param: 130
  Classes without docstring: 0

Other symbols referenced but not exported by "httpx": 1060
  With known type: 1060
  With ambiguous type: 0
  With unknown type: 0

Type completeness score: 100%
```

Included commits:

- Remove typeshed iscoroutine workaround
- Typing: use wsgiref.types to validate types and fix issues uncovered
- Typing: always fill in generic type parameters
- Typing: add explicit types for public fields

[verifytypes]: https://github.com/microsoft/pyright/blob/main/docs/typed-libraries.md#verifying-type-completeness

