### PR TITLE
Version 0.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+* Support for Python 3.11. (#2420)
 * Allow setting an explicit multipart boundary in `Content-Type` header. (#2278)
 * Allow `tuple` or `list` for multipart values, not just `list`. (#2355)
 * Allow `str` content for multipart upload files. (#2400)
+* Support connection upgrades. See https://www.encode.io/httpcore/extensions/#upgrade-requests
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 
-* Drop `.read`/`.aread` from SyncByteStream/AsyncByteStream (#2407)
+* Drop `.read`/`.aread` from SyncByteStream/AsyncByteStream. (#2407)
 * Drop `RawURL`. (#2241)
 
 ## 0.23.0 (23rd May, 2022)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 
-* Drop `.read`/`.aread` from SyncByteStream/AsyncByteStream. (#2407)
+* Drop `.read`/`.aread` from `SyncByteStream`/`AsyncByteStream`. (#2407)
 * Drop `RawURL`. (#2241)
 
 ## 0.23.0 (23rd May, 2022)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.23.1
+
+### Added
+
+* Allow setting an explicit multipart boundary in `Content-Type` header. (#2278)
+* Allow `tuple` or `list` for multipart values, not just `list`. (#2355)
+* Allow `str` content for multipart upload files. (#2400)
+
+### Fixed
+
+* Don't drop empty query parameters. (#2354)
+
+### Removed
+
+* Drop `.read`/`.aread` from SyncByteStream/AsyncByteStream (#2407)
+* Drop `RawURL`. (#2241)
+
 ## 0.23.0 (23rd May, 2022)
 
 ### Changed

--- a/httpx/__version__.py
+++ b/httpx/__version__.py
@@ -1,3 +1,3 @@
 __title__ = "httpx"
 __description__ = "A next generation HTTP client, for Python 3."
-__version__ = "0.23.0"
+__version__ = "0.23.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "certifi",
-    "httpcore>=0.15.0,<0.16.0",
+    "httpcore>=0.15.0,<0.17.0",
     "rfc3986[idna2008]>=1.3,<2",
     "sniffio",
 ]

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,6 @@ setup(
         "certifi",
         "sniffio",
         "rfc3986[idna2008]>=1.3,<2",
-        "httpcore>=0.15.0,<0.16.0",
+        "httpcore>=0.15.0,<0.17.0",
     ],
 )


### PR DESCRIPTION
I think we should probably roll a 0.23.1 (or a 0.24.0) release here.

We've got a fairly substantial list of work since the latest release.

There are a couple of minor removals included here, but they're only for old undocumented aspects, so I *think* we're probably okay including them in a minor, but I'm happy to go with the group consensus here.

Closes #2443

## 0.23.1

### Added

* Support for Python 3.11. (#2420)
* Allow setting an explicit multipart boundary in `Content-Type` header. (#2278)
* Allow `tuple` or `list` for multipart values, not just `list`. (#2355)
* Allow `str` content for multipart upload files. (#2400)
* Support connection upgrades. See https://www.encode.io/httpcore/extensions/#upgrade-requests

### Fixed

* Don't drop empty query parameters. (#2354)

### Removed

* Drop `.read`/`.aread` from SyncByteStream/AsyncByteStream (#2407)
* Drop `RawURL`. (#2241)
