### PR TITLE
Drop `multipart` requirement from tests.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,6 @@ flake8-bugbear==22.7.1
 flake8-pie==0.16.0; python_version>='3.7'
 importlib-metadata==4.13.0; python_version>='3.7'
 isort==5.10.1
-multipart==0.2.4
 mypy==0.982
 types-certifi==2021.10.8.2
 pytest==7.1.2

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -5,7 +5,6 @@ import typing
 from unittest import mock
 
 import pytest
-from multipart import MultipartParser
 
 import httpx
 from httpx._content import encode_request
@@ -24,21 +23,24 @@ def test_multipart(value, output):
     data = {"text": value}
     files = {"file": io.BytesIO(b"<file content>")}
     response = client.post("http://127.0.0.1:8000/", data=data, files=files)
-    assert response.status_code == 200
-
     boundary = response.request.headers["Content-Type"].split("boundary=")[-1]
-    content_length = int(response.request.headers["Content-Length"])
+    boundary_bytes = boundary.encode("ascii")
 
-    multipart = {}
-    for part in MultipartParser(
-        io.BytesIO(response.content), boundary=boundary, content_length=content_length
-    ):
-        multipart[part.name] = [part.raw]
-
-    # Note that the expected return type for text fields
-    # appears to differs from 3.6 to 3.7+
-    assert multipart["text"] == [output.decode()] or multipart["text"] == [output]
-    assert multipart["file"] == [b"<file content>"]
+    assert response.status_code == 200
+    assert response.content == b"".join(
+        [
+            b"--" + boundary_bytes + b"\r\n",
+            b'Content-Disposition: form-data; name="text"\r\n',
+            b"\r\n",
+            b"abc\r\n",
+            b"--" + boundary_bytes + b"\r\n",
+            b'Content-Disposition: form-data; name="file"; filename="upload"\r\n',
+            b"Content-Type: application/octet-stream\r\n",
+            b"\r\n",
+            b"<file content>\r\n",
+            b"--" + boundary_bytes + b"--\r\n",
+        ]
+    )
 
 
 @pytest.mark.parametrize(
@@ -60,18 +62,20 @@ def test_multipart_explicit_boundary(header: str) -> None:
     files = {"file": io.BytesIO(b"<file content>")}
     headers = {"content-type": header}
     response = client.post("http://127.0.0.1:8000/", files=files, headers=headers)
+    boundary_bytes = b"+++"
+
     assert response.status_code == 200
-
     assert response.request.headers["Content-Type"] == header
-    content_length = int(response.request.headers["Content-Length"])
-
-    multipart = {}
-    for part in MultipartParser(
-        io.BytesIO(response.content), boundary="+++", content_length=content_length
-    ):
-        multipart[part.name] = [part.raw]
-
-    assert multipart["file"] == [b"<file content>"]
+    assert response.content == b"".join(
+        [
+            b"--" + boundary_bytes + b"\r\n",
+            b'Content-Disposition: form-data; name="file"; filename="upload"\r\n',
+            b"Content-Type: application/octet-stream\r\n",
+            b"\r\n",
+            b"<file content>\r\n",
+            b"--" + boundary_bytes + b"--\r\n",
+        ]
+    )
 
 
 @pytest.mark.parametrize(
@@ -127,21 +131,24 @@ def test_multipart_file_tuple():
     data = {"text": ["abc"]}
     files = {"file": ("name.txt", io.BytesIO(b"<file content>"))}
     response = client.post("http://127.0.0.1:8000/", data=data, files=files)
-    assert response.status_code == 200
-
     boundary = response.request.headers["Content-Type"].split("boundary=")[-1]
-    content_length = int(response.request.headers["Content-Length"])
+    boundary_bytes = boundary.encode("ascii")
 
-    multipart = {}
-    for part in MultipartParser(
-        io.BytesIO(response.content), boundary=boundary, content_length=content_length
-    ):
-        multipart[part.name] = [part.raw]
-
-    # Note that the expected return type for text fields
-    # appears to differs from 3.6 to 3.7+
-    assert multipart["text"] == ["abc"] or multipart["text"] == [b"abc"]
-    assert multipart["file"] == [b"<file content>"]
+    assert response.status_code == 200
+    assert response.content == b"".join(
+        [
+            b"--" + boundary_bytes + b"\r\n",
+            b'Content-Disposition: form-data; name="text"\r\n',
+            b"\r\n",
+            b"abc\r\n",
+            b"--" + boundary_bytes + b"\r\n",
+            b'Content-Disposition: form-data; name="file"; filename="name.txt"\r\n',
+            b"Content-Type: text/plain\r\n",
+            b"\r\n",
+            b"<file content>\r\n",
+            b"--" + boundary_bytes + b"--\r\n",
+        ]
+    )
 
 
 @pytest.mark.parametrize("content_type", [None, "text/plain"])


### PR DESCRIPTION
Prompted by https://github.com/encode/starlette/discussions/1960

We don't actually need to parse the multipart content in order for us to test the expected behaviour, so...
Let's instead assert that the response body looks as expected, directly.
Drops a test requirement for us, and actually makes the tests clearer & more explicit.