### PR TITLE
update requests compatibility docs on query and form params

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -211,6 +211,8 @@ On the other hand, HTTPX uses [HTTPCore](https://github.com/encode/httpcore) as 
 
 `requests` omits `params` whose values are `None` (e.g. `requests.get(..., params={"foo": None})`). This is not supported by HTTPX.
 
+For both query params (`params=`) and form data (`data=`), `requests` supports sending a list of tuples (e.g. `requests.get(..., params=[('key1', 'value1'), ('key1', 'value2')])`). This is not supported by HTTPX. Instead, use a dictionary with lists as values. E.g.: `httpx.get(..., params={'key1': ['value1', 'value2']})` or with form data: `httpx.post(..., data={'key1': ['value1', 'value2']})`.
+
 ## Event Hooks
 
 `requests` allows event hooks to mutate `Request` and `Response` objects. See [examples](https://requests.readthedocs.io/en/master/user/advanced/#event-hooks) given in the documentation for `requests`.


### PR DESCRIPTION
Following up on https://github.com/encode/httpx/discussions/2330#discussioncomment-4167768 I added a note about requests compatibility with form data and query params -- namely that httpx only supports dictionaries whereas requests also supports lists of tuples.

As suggested, I added this note after the Query Parameters section, however, it might also bear mentioning in the Request Content section?