### PR TITLE
[docs] Remove `chunk_size` arg from `iter_lines()` & `aiter_lines()` in documentation.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -76,14 +76,14 @@
 * `def .iter_raw([chunk_size])` - **bytes iterator**
 * `def .iter_bytes([chunk_size])` - **bytes iterator**
 * `def .iter_text([chunk_size])` - **text iterator**
-* `def .iter_lines([chunk_size])` - **text iterator**
+* `def .iter_lines()` - **text iterator**
 * `def .close()` - **None**
 * `def .next()` - **Response**
 * `def .aread()` - **bytes**
 * `def .aiter_raw([chunk_size])` - **async bytes iterator**
 * `def .aiter_bytes([chunk_size])` - **async bytes iterator**
 * `def .aiter_text([chunk_size])` - **async text iterator**
-* `def .aiter_lines([chunk_size])` - **async text iterator**
+* `def .aiter_lines()` - **async text iterator**
 * `def .aclose()` - **None**
 * `def .anext()` - **Response**
 


### PR DESCRIPTION
Hi, looking at the docs while wrapping the `Response` object a few minor discrepancies exist.  Both `iter_lines()` & `aiter_lines()` do not accept an optional `chunk_size` argument, just updating that.  I _think_ this is the right place for this change.

Thanks for your time and a great library.