### PR TITLE
Switch `extensions` from `Dict` to `Mapping`.

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -356,7 +356,7 @@ class BaseClient:
                 if isinstance(timeout, UseClientDefault)
                 else Timeout(timeout)
             )
-            extensions["timeout"] = timeout.as_dict()
+            extensions = dict(**extensions, timeout=timeout.as_dict())
         return Request(
             method,
             url,

--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -223,7 +223,7 @@ class HTTPTransport(BaseTransport):
             status_code=resp.status,
             headers=resp.headers,
             stream=ResponseStream(resp.stream),
-            extensions=resp.extensions,
+            extensions=resp.extensions,  # type: ignore
         )
 
     def close(self) -> None:
@@ -358,7 +358,7 @@ class AsyncHTTPTransport(AsyncBaseTransport):
             status_code=resp.status,
             headers=resp.headers,
             stream=AsyncResponseStream(resp.stream),
-            extensions=resp.extensions,
+            extensions=resp.extensions,  # type: ignore
         )
 
     async def aclose(self) -> None:

--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -223,7 +223,7 @@ class HTTPTransport(BaseTransport):
             status_code=resp.status,
             headers=resp.headers,
             stream=ResponseStream(resp.stream),
-            extensions=resp.extensions,  # type: ignore
+            extensions=resp.extensions,
         )
 
     def close(self) -> None:
@@ -358,7 +358,7 @@ class AsyncHTTPTransport(AsyncBaseTransport):
             status_code=resp.status,
             headers=resp.headers,
             stream=AsyncResponseStream(resp.stream),
-            extensions=resp.extensions,  # type: ignore
+            extensions=resp.extensions,
         )
 
     async def aclose(self) -> None:

--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -76,7 +76,7 @@ AuthTypes = Union[
 
 RequestContent = Union[str, bytes, Iterable[bytes], AsyncIterable[bytes]]
 ResponseContent = Union[str, bytes, Iterable[bytes], AsyncIterable[bytes]]
-ResponseExtensions = Dict[str, Any]
+ResponseExtensions = Mapping[str, Any]
 
 RequestData = Mapping[str, Any]
 

--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -93,7 +93,7 @@ FileTypes = Union[
 ]
 RequestFiles = Union[Mapping[str, FileTypes], Sequence[Tuple[str, FileTypes]]]
 
-RequestExtensions = Dict[str, Any]
+RequestExtensions = Mapping[str, Any]
 
 
 class SyncByteStream:


### PR DESCRIPTION
The type change from `Dict` to `Mapping` in the `httpcore` extensions has [caused a CI failure](https://github.com/encode/httpx/actions/runs/3547801638/jobs/5983626106)...

From this PR: https://github.com/encode/httpcore/pull/614

I think we want the same type change in `httpx` as well.