### PR TITLE
Remove typeshed iscoroutine workaround

### DIFF
--- a/httpx/_compat.py
+++ b/httpx/_compat.py
@@ -2,13 +2,8 @@
 The _compat module is used for code which requires branching between different
 Python environments. It is excluded from the code coverage checks.
 """
-import asyncio
 import ssl
 import sys
-import typing
-
-if typing.TYPE_CHECKING:  # pragma: no cover
-    import typing_extensions
 
 # Brotli support is optional
 # The C bindings in `brotli` are recommended for CPython.
@@ -43,8 +38,3 @@ else:
         context.options |= ssl.OP_NO_SSLv3
         context.options |= ssl.OP_NO_TLSv1
         context.options |= ssl.OP_NO_TLSv1_1
-
-
-def iscoroutine(coro: object) -> "typing_extensions.TypeGuard[typing.Coroutine]":
-    # Drop when this is resolved: https://github.com/python/typeshed/pull/8104
-    return asyncio.iscoroutine(coro)

--- a/httpx/_transports/mock.py
+++ b/httpx/_transports/mock.py
@@ -1,6 +1,6 @@
+import asyncio
 import typing
 
-from .._compat import iscoroutine
 from .._models import Request, Response
 from .base import AsyncBaseTransport, BaseTransport
 
@@ -28,7 +28,7 @@ class MockTransport(AsyncBaseTransport, BaseTransport):
         # return the result.
 
         # https://simonwillison.net/2020/Sep/2/await-me-maybe/
-        if iscoroutine(response):
+        if asyncio.iscoroutine(response):
             response = await response
 
         return response


### PR DESCRIPTION
This was resolved in typeshed and newer mypy versions have inherited the fix.

pyright reports:
[after.txt](https://github.com/encode/httpx/files/10110416/after.txt)
[before.txt](https://github.com/encode/httpx/files/10110417/before.txt)
