### PR TITLE
Typing: always fill in generic type parameters

### DIFF
--- a/httpx/_auth.py
+++ b/httpx/_auth.py
@@ -10,6 +10,9 @@ from ._exceptions import ProtocolError
 from ._models import Request, Response
 from ._utils import to_bytes, to_str, unquote
 
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from hashlib import _Hash
+
 
 class Auth:
     """
@@ -139,7 +142,7 @@ class BasicAuth(Auth):
 
 
 class DigestAuth(Auth):
-    _ALGORITHM_TO_HASH_FUNCTION: typing.Dict[str, typing.Callable] = {
+    _ALGORITHM_TO_HASH_FUNCTION: typing.Dict[str, typing.Callable[[bytes], "_Hash"]] = {
         "MD5": hashlib.md5,
         "MD5-SESS": hashlib.md5,
         "SHA": hashlib.sha1,

--- a/httpx/_compat.py
+++ b/httpx/_compat.py
@@ -38,4 +38,3 @@ else:
         context.options |= ssl.OP_NO_SSLv3
         context.options |= ssl.OP_NO_TLSv1
         context.options |= ssl.OP_NO_TLSv1_1
-

--- a/httpx/_compat.py
+++ b/httpx/_compat.py
@@ -45,6 +45,8 @@ else:
         context.options |= ssl.OP_NO_TLSv1_1
 
 
-def iscoroutine(coro: object) -> "typing_extensions.TypeGuard[typing.Coroutine]":
+def iscoroutine(
+    coro: object,
+) -> "typing_extensions.TypeGuard[typing.Coroutine[typing.Any, typing.Any, None]]":
     # Drop when this is resolved: https://github.com/python/typeshed/pull/8104
     return asyncio.iscoroutine(coro)

--- a/httpx/_main.py
+++ b/httpx/_main.py
@@ -179,7 +179,12 @@ def print_response(response: Response) -> None:
         console.print(f"<{len(response.content)} bytes of binary data>")
 
 
-def format_certificate(cert: dict) -> str:  # pragma: nocover
+_PCTRTT = typing.Tuple[typing.Tuple[str, str], ...]
+_PCTRTTT = typing.Tuple[_PCTRTT, ...]
+_PeerCertRetDictType = typing.Dict[str, typing.Union[str, _PCTRTTT, _PCTRTT]]
+
+
+def format_certificate(cert: _PeerCertRetDictType) -> str:  # pragma: nocover
     lines = []
     for key, value in cert.items():
         if isinstance(value, (list, tuple)):

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -3,7 +3,7 @@ import email.message
 import json as jsonlib
 import typing
 import urllib.request
-from collections.abc import Mapping, MutableMapping
+from collections.abc import Mapping
 from http.cookiejar import Cookie, CookieJar
 
 from ._content import ByteStream, UnattachedStream, encode_request, encode_response
@@ -1002,7 +1002,7 @@ class Response:
                 await self.stream.aclose()
 
 
-class Cookies(MutableMapping):
+class Cookies(typing.MutableMapping[str, str]):
     """
     HTTP Cookies, as a mutable mapping.
     """

--- a/httpx/_transports/mock.py
+++ b/httpx/_transports/mock.py
@@ -6,7 +6,7 @@ from .base import AsyncBaseTransport, BaseTransport
 
 
 class MockTransport(AsyncBaseTransport, BaseTransport):
-    def __init__(self, handler: typing.Callable) -> None:
+    def __init__(self, handler: typing.Callable[[Request], Response]) -> None:
         self.handler = handler
 
     def handle_request(

--- a/httpx/_transports/mock.py
+++ b/httpx/_transports/mock.py
@@ -29,6 +29,6 @@ class MockTransport(AsyncBaseTransport, BaseTransport):
 
         # https://simonwillison.net/2020/Sep/2/await-me-maybe/
         if iscoroutine(response):
-            response = await response
+            response = await response  # type: ignore[func-returns-value,assignment]
 
         return response

--- a/httpx/_transports/wsgi.py
+++ b/httpx/_transports/wsgi.py
@@ -8,7 +8,7 @@ from .._types import SyncByteStream
 from .base import BaseTransport
 
 
-def _skip_leading_empty_chunks(body: typing.Iterable) -> typing.Iterable:
+def _skip_leading_empty_chunks(body: typing.Iterable[bytes]) -> typing.Iterable[bytes]:
     body = iter(body)
     for chunk in body:
         if chunk:
@@ -65,7 +65,7 @@ class WSGITransport(BaseTransport):
 
     def __init__(
         self,
-        app: typing.Callable,
+        app: typing.Callable[..., typing.Any],
         raise_app_exceptions: bool = True,
         script_name: str = "",
         remote_addr: str = "127.0.0.1",
@@ -109,7 +109,9 @@ class WSGITransport(BaseTransport):
         seen_exc_info = None
 
         def start_response(
-            status: str, response_headers: list, exc_info: typing.Any = None
+            status: str,
+            response_headers: typing.List[typing.Tuple[str, str]],
+            exc_info: typing.Any = None,
         ) -> None:
             nonlocal seen_status, seen_response_headers, seen_exc_info
             seen_status = status

--- a/httpx/_urls.py
+++ b/httpx/_urls.py
@@ -570,7 +570,7 @@ class QueryParams(typing.Mapping[str, str]):
                 for k, v in dict_value.items()
             }
 
-    def keys(self) -> typing.KeysView:
+    def keys(self) -> typing.KeysView[str]:
         """
         Return all the keys in the query params.
 
@@ -581,7 +581,7 @@ class QueryParams(typing.Mapping[str, str]):
         """
         return self._dict.keys()
 
-    def values(self) -> typing.ValuesView:
+    def values(self) -> typing.ValuesView[str]:
         """
         Return all the values in the query params. If a key occurs more than once
         only the first item for that key is returned.
@@ -593,7 +593,7 @@ class QueryParams(typing.Mapping[str, str]):
         """
         return {k: v[0] for k, v in self._dict.items()}.values()
 
-    def items(self) -> typing.ItemsView:
+    def items(self) -> typing.ItemsView[str, str]:
         """
         Return all items in the query params. If a key occurs more than once
         only the first item for that key is returned.

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -508,7 +508,7 @@ class URLPattern:
         return True
 
     @property
-    def priority(self) -> tuple:
+    def priority(self) -> typing.Tuple[int, int, int]:
         """
         The priority allows URLPattern instances to be sortable, so that
         we can match from most specific to least specific.

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ max-line-length = 120
 
 [mypy]
 disallow_untyped_defs = True
+disallow_any_generics = True
 ignore_missing_imports = True
 no_implicit_optional = True
 show_error_codes = True

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -428,7 +428,7 @@ async def test_digest_auth(
     assert response.status_code == 200
     assert len(response.history) == 1
 
-    authorization = typing.cast(dict, response.json())["auth"]
+    authorization = typing.cast(typing.Dict[str, typing.Any], response.json())["auth"]
     scheme, _, fields = authorization.partition(" ")
     assert scheme == "Digest"
 
@@ -459,7 +459,7 @@ async def test_digest_auth_no_specified_qop() -> None:
     assert response.status_code == 200
     assert len(response.history) == 1
 
-    authorization = typing.cast(dict, response.json())["auth"]
+    authorization = typing.cast(typing.Dict[str, typing.Any], response.json())["auth"]
     scheme, _, fields = authorization.partition(" ")
     assert scheme == "Digest"
 


### PR DESCRIPTION
Being explicit about the parameters helps find bugs and makes the library easier to use for users.

- Tell mypy to disallow generics without parameter values
- Give all generic types parameters values
