### PR TITLE
Typing: add explicit types for public fields

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -305,6 +305,12 @@ class Headers(typing.MutableMapping[str, str]):
 
 
 class Request:
+    method: str
+    url: URL
+    headers: Headers
+    extensions: RequestExtensions
+    stream: typing.Union[SyncByteStream, AsyncByteStream]
+
     def __init__(
         self,
         method: typing.Union[str, bytes],
@@ -443,6 +449,16 @@ class Request:
 
 
 class Response:
+    status_code: int
+    headers: Headers
+    next_request: typing.Optional[Request]
+    extensions: ResponseExtensions
+    history: typing.List["Response"]
+    is_closed: bool
+    is_stream_consumed: bool
+    default_encoding: typing.Union[str, typing.Callable[[bytes], str]]
+    stream: typing.Union[SyncByteStream, AsyncByteStream]
+
     def __init__(
         self,
         status_code: int,
@@ -1006,6 +1022,8 @@ class Cookies(MutableMapping):
     """
     HTTP Cookies, as a mutable mapping.
     """
+
+    jar: CookieJar
 
     def __init__(self, cookies: typing.Optional[CookieTypes] = None) -> None:
         if cookies is None or isinstance(cookies, dict):

--- a/httpx/_transports/wsgi.py
+++ b/httpx/_transports/wsgi.py
@@ -63,6 +63,12 @@ class WSGITransport(BaseTransport):
     ```
     """
 
+    app: WSGIApplication
+    raise_app_exceptions: bool
+    script_name: str
+    remote_addr: str
+    wsgi_errors: typing.Optional[typing.TextIO]
+
     def __init__(
         self,
         app: typing.Callable,


### PR DESCRIPTION
Without these, type inference would be required, the output of which can differ between type checkers. Explict fields also serves as documentation and can be a place to add explicit field descriptions in future.
