### PR TITLE
Typing: Enable no_implicit_reexport

### DIFF
--- a/httpx/_compat.py
+++ b/httpx/_compat.py
@@ -38,3 +38,6 @@ else:
         context.options |= ssl.OP_NO_SSLv3
         context.options |= ssl.OP_NO_TLSv1
         context.options |= ssl.OP_NO_TLSv1_1
+
+
+__all__ = ["brotli", "set_minimum_tls_version_1_2"]

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -7,8 +7,9 @@ from pathlib import Path
 import certifi
 
 from ._compat import set_minimum_tls_version_1_2
-from ._models import URL, Headers
+from ._models import Headers
 from ._types import CertTypes, HeaderTypes, TimeoutTypes, URLTypes, VerifyTypes
+from ._urls import URL
 from ._utils import get_ca_bundle_from_env, get_logger
 
 DEFAULT_CIPHERS = ":".join(

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -16,7 +16,7 @@ import sniffio
 from ._types import PrimitiveData
 
 if typing.TYPE_CHECKING:  # pragma: no cover
-    from ._models import URL
+    from ._urls import URL
 
 
 _HTML5_FORM_ENCODING_REPLACEMENTS = {'"': "%22", "\\": "\\\\"}
@@ -465,7 +465,7 @@ class URLPattern:
     """
 
     def __init__(self, pattern: str) -> None:
-        from ._models import URL
+        from ._urls import URL
 
         if pattern and ":" not in pattern:
             raise ValueError(

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ disallow_untyped_decorators = True
 warn_redundant_casts = True
 strict_concatenate = True
 disallow_incomplete_defs = True
+no_implicit_reexport = True
 
 [mypy-tests.*]
 disallow_untyped_defs = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from cryptography.hazmat.primitives.serialization import (
     load_pem_private_key,
 )
 from uvicorn.config import Config
-from uvicorn.main import Server
+from uvicorn.server import Server
 
 from httpx import URL
 from tests.concurrency import sleep


### PR DESCRIPTION
- Add explicit exports for names imported from _compat and _models
- Correct import of the uvicorn Server class

Part of #2436
