### PR TITLE
Typing: enable disallow_incomplete_defs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ check_untyped_defs = True
 disallow_untyped_decorators = True
 warn_redundant_casts = True
 strict_concatenate = True
+disallow_incomplete_defs = True
 
 [mypy-tests.*]
 disallow_untyped_defs = False

--- a/tests/client/test_proxies.py
+++ b/tests/client/test_proxies.py
@@ -5,7 +5,7 @@ import httpx
 from httpx._utils import URLPattern
 
 
-def url_to_origin(url: str):
+def url_to_origin(url: str) -> httpcore.URL:
     """
     Given a URL string, return the origin in the raw tuple format that
     `httpcore` uses for it's representation.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -290,7 +290,7 @@ class TestServer(Server):
             await self.startup()
 
 
-def serve_in_thread(server: Server):
+def serve_in_thread(server: TestServer) -> typing.Iterator[TestServer]:
     thread = threading.Thread(target=server.run)
     thread.start()
     try:
@@ -303,7 +303,7 @@ def serve_in_thread(server: Server):
 
 
 @pytest.fixture(scope="session")
-def server():
+def server() -> typing.Iterator[TestServer]:
     config = Config(app=app, lifespan="off", loop="asyncio")
     server = TestServer(config=config)
     yield from serve_in_thread(server)

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -67,7 +67,7 @@ async def test_async_bytesio_content():
             self._idx = 0
             self._content = content
 
-        async def aread(self, chunk_size: int):
+        async def aread(self, chunk_size: int) -> bytes:
             chunk = self._content[self._idx : self._idx + chunk_size]
             self._idx = self._idx + chunk_size
             return chunk

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,3 +1,4 @@
+import typing
 from unittest import mock
 
 import httpcore
@@ -5,6 +6,9 @@ import pytest
 
 import httpx
 from httpx._transports.default import HTTPCORE_EXC_MAP
+
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from conftest import TestServer
 
 
 def test_httpcore_all_exceptions_mapped() -> None:
@@ -25,7 +29,7 @@ def test_httpcore_all_exceptions_mapped() -> None:
         pytest.fail(f"Unmapped httpcore exceptions: {not_mapped}")
 
 
-def test_httpcore_exception_mapping(server) -> None:
+def test_httpcore_exception_mapping(server: "TestServer") -> None:
     """
     HTTPCore exception mapping works as expected.
     """

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -152,7 +152,7 @@ def test_multipart_file_tuple():
 
 
 @pytest.mark.parametrize("content_type", [None, "text/plain"])
-def test_multipart_file_tuple_headers(content_type: typing.Optional[str]):
+def test_multipart_file_tuple_headers(content_type: typing.Optional[str]) -> None:
     file_name = "test.txt"
     expected_content_type = "text/plain"
     headers = {"Expires": "0"}

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -144,7 +144,7 @@ def test_logging():
         pytest.param("http://www.example.org:8000", "8000", id="explicit-port"),
     ],
 )
-def test_wsgi_server_port(url: str, expected_server_port: int):
+def test_wsgi_server_port(url: str, expected_server_port: int) -> None:
     """
     SERVER_PORT is populated correctly from the requested URL.
     """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,12 +1,13 @@
 import contextlib
 import logging
 import os
+import typing
 
 from httpx import _utils
 
 
 @contextlib.contextmanager
-def override_log_level(log_level: str):
+def override_log_level(log_level: str) -> typing.Iterator[None]:
     os.environ["HTTPX_LOG_LEVEL"] = log_level
 
     # Force a reload on the logging handlers


### PR DESCRIPTION
The only places mypy reports issues is in the test suite.

Part of the work for #2436
