### PR TITLE
Typing: enable strict_equality

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ strict_concatenate = True
 disallow_incomplete_defs = True
 no_implicit_reexport = True
 warn_return_any = True
+strict_equality = True
 
 [mypy-tests.*]
 disallow_untyped_defs = False

--- a/tests/test_status_codes.py
+++ b/tests/test_status_codes.py
@@ -2,7 +2,8 @@ import httpx
 
 
 def test_status_code_as_int():
-    assert httpx.codes.NOT_FOUND == 404
+    # mypy doesn't (yet) recognize that IntEnum members are ints, so ignore it here
+    assert httpx.codes.NOT_FOUND == 404  # type: ignore[comparison-overlap]
     assert str(httpx.codes.NOT_FOUND) == "404"
 
 

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -144,7 +144,7 @@ def test_logging():
         pytest.param("http://www.example.org:8000", "8000", id="explicit-port"),
     ],
 )
-def test_wsgi_server_port(url: str, expected_server_port: int) -> None:
+def test_wsgi_server_port(url: str, expected_server_port: str) -> None:
     """
     SERVER_PORT is populated correctly from the requested URL.
     """


### PR DESCRIPTION
- ignore mypy when it comes to comparing an IntEnum member with an int
- Correct type hint for `test_wsgi_server_port`'s `expected_server_port`
  parameter.

Part of the work for #2436

