### PR TITLE
PyPI readme: fix screenshot links & trim changelog

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,4 +78,15 @@ content-type = "text/markdown"
 path = "README.md"
 
 [[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+text = "\n## Release Information\n\n"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
 path = "CHANGELOG.md"
+pattern = "\n(###.+?\n)## "
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+text = "\n---\n\n[Full changelog](https://github.com/encode/httpx/blob/master/CHANGELOG.md)\n"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = 'src="(docs/img/.*?)"'
+replacement = 'src="https://raw.githubusercontent.com/encode/httpx/master/\1"'


### PR DESCRIPTION
I was super honored to learn that my favorite http library is using my hatch-fancy-pypi-readme!

When adding it to my brag list, I've noticed two problems in your usage and wanted to offer you the simple solutions:

1. Your relative image URLs from the README 404 – this is why I've added the substitutions feature (if the logo is an absolute link just for PyPI, I can also make it relative if you'd like).
2. Your Changelog is _really_ long so I would recommend trimming it. I've added the technique that I use personally.

You can test the result by running `pipx run hatch-fancy-pypi-readme`, but here's how the tail looks like after this PR:

```markdown
...

A huge amount of credit is due to `requests` for the API layout that
much of this work follows, as well as to `urllib3` for plenty of design
inspiration around the lower-level networking details.

---

<p align="center"><i>HTTPX is <a href="https://github.com/encode/httpx/blob/master/LICENSE.md">BSD licensed</a> code.<br/>Designed & crafted with care.</i><br/>&mdash; 🦋 &mdash;</p>

## Release Information

### Added

* Support for Python 3.11. (#2420)
* Allow setting an explicit multipart boundary in `Content-Type` header. (#2278)
* Allow `tuple` or `list` for multipart values, not just `list`. (#2355)
* Allow `str` content for multipart upload files. (#2400)
* Support connection upgrades. See https://www.encode.io/httpcore/extensions/#upgrade-requests

### Fixed

* Don't drop empty query parameters. (#2354)

### Removed

* Upload files *must* always be opened in binary mode. (#2400)
* Drop `.read`/`.aread` from `SyncByteStream`/`AsyncByteStream`. (#2407)
* Drop `RawURL`. (#2241)


---

[Full changelog](https://github.com/encode/httpx/blob/master/CHANGELOG.md)
```

I think that's better, no? I you don't like it, I can remove it again and just contribute the image fix.

P.S. if there's anything else I can help you with the PyPI readme, pls lmk.