### PR TITLE
Raise `TypeError` on invalid query params.

### DIFF
--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -69,7 +69,9 @@ def primitive_value_to_str(value: "PrimitiveData") -> str:
         return ""
     elif isinstance(value, (str, float, int)):
         return str(value)
-    raise TypeError(f"Expected str, int, float, bool, or None. Got {type(value)!r}.")
+    raise TypeError(
+        f"Expected str, int, float, bool, or None. Got {type(value).__name__!r}."
+    )
 
 
 def is_known_encoding(encoding: str) -> bool:

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -67,7 +67,9 @@ def primitive_value_to_str(value: "PrimitiveData") -> str:
         return "false"
     elif value is None:
         return ""
-    return str(value)
+    elif isinstance(value, (str, float, int)):
+        return str(value)
+    raise TypeError("Expected str, int, float, bool, or None. Got {type(content)!r}.")
 
 
 def is_known_encoding(encoding: str) -> bool:

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -69,7 +69,7 @@ def primitive_value_to_str(value: "PrimitiveData") -> str:
         return ""
     elif isinstance(value, (str, float, int)):
         return str(value)
-    raise TypeError("Expected str, int, float, bool, or None. Got {type(content)!r}.")
+    raise TypeError(f"Expected str, int, float, bool, or None. Got {type(value)!r}.")
 
 
 def is_known_encoding(encoding: str) -> bool:

--- a/tests/models/test_queryparams.py
+++ b/tests/models/test_queryparams.py
@@ -88,7 +88,9 @@ def test_empty_query_params():
 
 
 def test_invalid_query_params():
-    with pytest.raises(TypeError, match=r"Expected str, int, float, bool, or None\. Got 'bytes'\."):
+    with pytest.raises(
+        TypeError, match=r"Expected str, int, float, bool, or None\. Got 'bytes'\."
+    ):
         httpx.QueryParams({"a": b"bytes"})
 
 

--- a/tests/models/test_queryparams.py
+++ b/tests/models/test_queryparams.py
@@ -87,6 +87,11 @@ def test_empty_query_params():
     assert str(q) == "a="
 
 
+def test_invalid_query_params():
+    with pytest.raises(TypeError):
+        httpx.QueryParams({"a": b"bytes"})
+
+
 def test_queryparam_update_is_hard_deprecated():
     q = httpx.QueryParams("a=123")
     with pytest.raises(RuntimeError):

--- a/tests/models/test_queryparams.py
+++ b/tests/models/test_queryparams.py
@@ -88,7 +88,7 @@ def test_empty_query_params():
 
 
 def test_invalid_query_params():
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match=r"Expected str, int, float, bool, or None\. Got 'bytes'\."):
         httpx.QueryParams({"a": b"bytes"})
 
 

--- a/tests/models/test_queryparams.py
+++ b/tests/models/test_queryparams.py
@@ -89,7 +89,7 @@ def test_empty_query_params():
 
 def test_invalid_query_params():
     with pytest.raises(
-        TypeError, match=r"Expected str, int, float, bool, or None\. Got 'bytes'\."
+        TypeError, match=r"Expected str, int, float, bool, or None. Got 'bytes'."
     ):
         httpx.QueryParams({"a": b"bytes"})
 


### PR DESCRIPTION
Prompted by #2515. (Doesn't presume any particular resolution to that case.)

Closes #746 - we don't support bytes (or other unexpected types) as QueryParam values. Let's raise a clear error, rather than coercing an unexpected `str` value.

Before this change...

```python
>>> httpx.URL("http://www.example.com/", params={"query": b"abc"})
URL('http://www.example.com/?query=b%27abc%27')
```

After this change...

```python
>>> httpx.URL("http://www.example.com/", params={"query": b"abc"})
TypeError: Expected str, int, float, bool, or None. Got <class 'bytes'>.
```