### PR TITLE
Add `NetRCAuth()` class.

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -132,18 +132,6 @@ Example:
 SSL_CERT_DIR=/path/to/ca-certs/ python -c "import httpx; httpx.get('https://example.com')"
 ```
 
-## `NETRC`
-
-Valid values: a filename
-
-If this environment variable is set but auth parameter is not defined, HTTPX will add auth information stored in the .netrc file into the request's header. If you do not provide NETRC environment either, HTTPX will use default files. (~/.netrc, ~/_netrc)
-
-Example:
-
-```console
-NETRC=/path/to/netrcfile/.my_netrc python -c "import httpx; httpx.get('https://example.com')"
-```
-
 ## Proxies
 
 The environment variables documented below are used as a convention by various HTTP tooling, including:
@@ -187,4 +175,3 @@ python -c "import httpx; httpx.get('http://example.com')"
 python -c "import httpx; httpx.get('http://127.0.0.1:5000/my-api')"
 python -c "import httpx; httpx.get('https://www.python-httpx.org')"
 ```
-

--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -1,6 +1,6 @@
 from .__version__ import __description__, __title__, __version__
 from ._api import delete, get, head, options, patch, post, put, request, stream
-from ._auth import Auth, BasicAuth, DigestAuth
+from ._auth import Auth, BasicAuth, DigestAuth, NetRCAuth
 from ._client import USE_CLIENT_DEFAULT, AsyncClient, Client
 from ._config import Limits, Proxy, Timeout, create_ssl_context
 from ._content import ByteStream
@@ -94,6 +94,7 @@ __all__ = [
     "LocalProtocolError",
     "main",
     "MockTransport",
+    "NetRCAuth",
     "NetworkError",
     "options",
     "patch",

--- a/httpx/_auth.py
+++ b/httpx/_auth.py
@@ -1,4 +1,5 @@
 import hashlib
+import netrc
 import os
 import re
 import time
@@ -132,6 +133,34 @@ class BasicAuth(Auth):
     def auth_flow(self, request: Request) -> typing.Generator[Request, Response, None]:
         request.headers["Authorization"] = self._auth_header
         yield request
+
+    def _build_auth_header(
+        self, username: typing.Union[str, bytes], password: typing.Union[str, bytes]
+    ) -> str:
+        userpass = b":".join((to_bytes(username), to_bytes(password)))
+        token = b64encode(userpass).decode()
+        return f"Basic {token}"
+
+
+class NetRCAuth(Auth):
+    """
+    Use a 'netrc' file to lookup basic auth credentials based on the url host.
+    """
+
+    def __init__(self, file: typing.Optional[str]):
+        self._netrc_info = netrc.netrc(file)
+
+    def auth_flow(self, request: Request) -> typing.Generator[Request, Response, None]:
+        auth_info = self._netrc_info.authenticators(request.url.host)
+        if auth_info is None or auth_info[2] is None:
+            # The netrc file did not have authentication credentials for this host.
+            yield request
+        else:
+            # Build a basic auth header with credentials from the netrc file.
+            request.headers["Authorization"] = self._build_auth_header(
+                username=auth_info[0], password=auth_info[2]
+            )
+            yield request
 
     def _build_auth_header(
         self, username: typing.Union[str, bytes], password: typing.Union[str, bytes]

--- a/httpx/_auth.py
+++ b/httpx/_auth.py
@@ -152,7 +152,7 @@ class NetRCAuth(Auth):
 
     def auth_flow(self, request: Request) -> typing.Generator[Request, Response, None]:
         auth_info = self._netrc_info.authenticators(request.url.host)
-        if auth_info is None or auth_info[2] is None:
+        if auth_info is None or not auth_info[2]:
             # The netrc file did not have authentication credentials for this host.
             yield request
         else:

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -47,7 +47,6 @@ from ._types import (
 )
 from ._urls import URL, QueryParams
 from ._utils import (
-    NetRCInfo,
     Timer,
     URLPattern,
     get_environment_proxies,
@@ -191,7 +190,6 @@ class BaseClient:
         }
         self._trust_env = trust_env
         self._default_encoding = default_encoding
-        self._netrc = NetRCInfo()
         self._state = ClientState.UNOPENED
 
     @property
@@ -455,11 +453,6 @@ class BaseClient:
         username, password = request.url.username, request.url.password
         if username or password:
             return BasicAuth(username=username, password=password)
-
-        if self.trust_env and "Authorization" not in request.headers:
-            credentials = self._netrc.get_credentials(request.url.host)
-            if credentials is not None:
-                return BasicAuth(username=credentials[0], password=credentials[1])
 
         return Auth()
 

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -2,7 +2,6 @@ import codecs
 import email.message
 import logging
 import mimetypes
-import netrc
 import os
 import re
 import sys
@@ -130,37 +129,6 @@ def guess_json_utf(data: bytes) -> typing.Optional[str]:
             return "utf-32-le"
         # Did not detect a valid UTF-32 ascii-range character
     return None
-
-
-class NetRCInfo:
-    def __init__(self, files: typing.Optional[typing.List[str]] = None) -> None:
-        if files is None:
-            files = [os.getenv("NETRC", ""), "~/.netrc", "~/_netrc"]
-        self.netrc_files = files
-
-    @property
-    def netrc_info(self) -> typing.Optional[netrc.netrc]:
-        if not hasattr(self, "_netrc_info"):
-            self._netrc_info = None
-            for file_path in self.netrc_files:
-                expanded_path = Path(file_path).expanduser()
-                try:
-                    if expanded_path.is_file():
-                        self._netrc_info = netrc.netrc(str(expanded_path))
-                        break
-                except (netrc.NetrcParseError, IOError):  # pragma: no cover
-                    # Issue while reading the netrc file, ignore...
-                    pass
-        return self._netrc_info
-
-    def get_credentials(self, host: str) -> typing.Optional[typing.Tuple[str, str]]:
-        if self.netrc_info is None:
-            return None
-
-        auth_info = self.netrc_info.authenticators(host)
-        if auth_info is None or auth_info[2] is None:
-            return None
-        return (auth_info[0], auth_info[2])
 
 
 def get_ca_bundle_from_env() -> typing.Optional[str]:

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -4,7 +4,9 @@ Integration tests for authentication.
 Unit tests for auth classes also exist in tests/test_auth.py
 """
 import hashlib
+import netrc
 import os
+import sys
 import threading
 import typing
 from urllib.request import parse_keqv_list
@@ -250,7 +252,7 @@ def test_netrc_auth_credentials_exist() -> None:
     }
 
 
-def test_netrc_auth_auth_credentials_do_not_exist() -> None:
+def test_netrc_auth_credentials_do_not_exist() -> None:
     """
     When netrc auth is being used and a request is made to a host that is
     not in the netrc file, then no credentials should be applied.
@@ -265,6 +267,44 @@ def test_netrc_auth_auth_credentials_do_not_exist() -> None:
 
     assert response.status_code == 200
     assert response.json() == {"auth": None}
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="netrc files without a password are invalid with Python < 3.11",
+)
+def test_netrc_auth_nopassword() -> None:  # pragma: no cover
+    """
+    Python has different netrc parsing behaviours with different versions.
+    For Python 3.11+ a netrc file with no password is valid. In this case
+    we want to check that we allow the netrc auth, and simply don't provide
+    any credentials in the request.
+    """
+    netrc_file = str(FIXTURES_DIR / ".netrc-nopassword")
+    url = "http://example.org"
+    app = App()
+    auth = httpx.NetRCAuth(netrc_file)
+
+    with httpx.Client(transport=httpx.MockTransport(app), auth=auth) as client:
+        response = client.get(url)
+
+    assert response.status_code == 200
+    assert response.json() == {"auth": None}
+
+
+@pytest.mark.skipif(
+    sys.version_info >= (3, 11),
+    reason="netrc files without a password are valid from Python >= 3.11",
+)
+def test_netrc_auth_nopassword_parse_error() -> None:  # pragma: no cover
+    """
+    Python has different netrc parsing behaviours with different versions.
+    For Python < 3.11 a netrc file with no password is invalid. In this case
+    we want to allow the parse error to be raised.
+    """
+    netrc_file = str(FIXTURES_DIR / ".netrc-nopassword")
+    with pytest.raises(netrc.NetrcParseError):
+        httpx.NetRCAuth(netrc_file)
 
 
 @pytest.mark.anyio

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -287,28 +287,6 @@ def test_netrc_auth_auth_credentials_do_not_exist() -> None:
     assert response.json() == {"auth": None}
 
 
-def test_netrc_auth_cross_domain_redirect() -> None:
-    """
-    When a request is made that redirects to a new host,
-    the netrc credentials for the new host should be applied.
-
-    https://github.com/encode/httpx/issues/2088
-    """
-    netrc_file = str(FIXTURES_DIR / ".netrc")
-    url = "http://example.org"
-    app = CrossDomainRedirect("netrcexample.org")
-    auth = httpx.NetRCAuth(netrc_file)
-
-    with httpx.Client(transport=httpx.MockTransport(app), auth=auth) as client:
-        response = client.get(url, follow_redirects=True)
-
-    assert len(response.history) == 1
-    assert response.status_code == 200
-    assert response.json() == {
-        "auth": "Basic ZXhhbXBsZS11c2VybmFtZTpleGFtcGxlLXBhc3N3b3Jk"
-    }
-
-
 @pytest.mark.anyio
 async def test_auth_disable_per_request() -> None:
     url = "https://example.org/"

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -32,26 +32,6 @@ class App:
         return httpx.Response(self.status_code, headers=headers, json=data)
 
 
-class CrossDomainRedirect:
-    """
-    A mock app to test cross domain redirects and auth credentials.
-    """
-
-    def __init__(self, host: str) -> None:
-        self.host = host
-
-    def __call__(self, request: httpx.Request) -> httpx.Response:
-        if request.url.host == self.host:
-            # Echo the authorization header back in the response.
-            data = {"auth": request.headers.get("Authorization")}
-            return httpx.Response(200, json=data)
-        else:
-            # Redirect to the given host.
-            status_code = httpx.codes.SEE_OTHER
-            headers = {"location": f"https://{self.host}"}
-            return httpx.Response(status_code, headers=headers)
-
-
 class DigestApp:
     def __init__(
         self,

--- a/tests/client/test_properties.py
+++ b/tests/client/test_properties.py
@@ -58,3 +58,11 @@ def test_client_event_hooks():
     client = httpx.Client()
     client.event_hooks = {"request": [on_request]}
     assert client.event_hooks == {"request": [on_request], "response": []}
+
+
+def test_client_trust_env():
+    client = httpx.Client()
+    assert client.trust_env
+
+    client = httpx.Client(trust_env=False)
+    assert not client.trust_env

--- a/tests/fixtures/.netrc-nopassword
+++ b/tests/fixtures/.netrc-nopassword
@@ -1,0 +1,2 @@
+machine netrcexample.org
+login example-username

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,6 @@ import pytest
 
 import httpx
 from httpx._utils import (
-    NetRCInfo,
     URLPattern,
     get_ca_bundle_from_env,
     get_environment_proxies,
@@ -17,7 +16,7 @@ from httpx._utils import (
 )
 from tests.utils import override_log_level
 
-from .common import FIXTURES_DIR, TESTS_DIR
+from .common import TESTS_DIR
 
 
 @pytest.mark.parametrize(
@@ -54,25 +53,6 @@ def test_bad_utf_like_encoding():
 def test_guess_by_bom(encoding, expected):
     data = "\ufeff{}".encode(encoding)
     assert guess_json_utf(data) == expected
-
-
-def test_bad_get_netrc_login():
-    netrc_info = NetRCInfo([str(FIXTURES_DIR / "does-not-exist")])
-    assert netrc_info.get_credentials("netrcexample.org") is None
-
-
-def test_get_netrc_login():
-    netrc_info = NetRCInfo([str(FIXTURES_DIR / ".netrc")])
-    expected_credentials = (
-        "example-username",
-        "example-password",
-    )
-    assert netrc_info.get_credentials("netrcexample.org") == expected_credentials
-
-
-def test_get_netrc_unknown():
-    netrc_info = NetRCInfo([str(FIXTURES_DIR / ".netrc")])
-    assert netrc_info.get_credentials("nonexistent.org") is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #2532

Prompted by https://github.com/encode/httpx/issues/2532#issuecomment-1368907498

We currently automatically handle [`netrc` authentication](https://docs.python.org/3/library/netrc.html), which is baked directly into the `Client`, and which is enabled unless the developer sets `trust_env=False`.

* Browsers, which do *not* use `netrc` authentication.
* The `curl` command line client, which *only* uses `netrc` authentication if explicitly enabled.

The suggest here is that we should make a behavioural change, and *no longer* bake `netrc` authentication directly into the client, in favor of providing an explicit `NetRCAuth()` class.

Some usage examples...

```python
# Use default netrc file
auth = httpx.NetRCAuth()
client = httpx.Client(auth=auth)

# Use explicit netrc file
auth = httpx.NetRCAuth(file="/path/to/netrc")
client = httpx.Client(auth=auth)

# Optional environ override, fallback to default netrc file otherwise
auth = httpx.NetRCAuth(file=os.environ.get('NETRC'))
client = httpx.Client(auth=auth)

# Mandatory environ override
auth = httpx.NetRCAuth(file=os.environ['NETRC'])
client = httpx.Client(auth=auth)

# Optional netrc auth, depending on if the "~/.netrc" file exists
try:
    auth = httpx.NetRCAuth()
except FileNotFound:
    auth = None
client = httpx.Client(auth=auth)
```

This would be a behavioral change and need to be part of a 0.24.0 release, but I think it's obviously more consistent and neater than our existing "netrc is a special case" behaviour.

*(I had also assumed that this change would resolve issue #2088, and added a test case for this, which showed me that my assumption there was incorrect. Failing test case for that now dropped in commits https://github.com/encode/httpx/pull/2535/commits/ebcf77ae4959f0e67c7fce070e7b79ab5b5bad2a and https://github.com/encode/httpx/pull/2535/commits/02120cccecf905a0f142b36a31cebf68974e9528.)*

**TODO:**

- [x] Drop baked-in client `netrc` auth class.
- [x] Implement `NetRCAuth` class.
- [x] Tests.
- [x] Update documentation.

Documentation link, for easier review... https://github.com/encode/httpx/blob/02120cccecf905a0f142b36a31cebf68974e9528/docs/advanced.md#netrc-support