### PR TITLE
Revert "Raise `TypeError` on invalid query params. (#2523)"

### DIFF
--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -67,11 +67,7 @@ def primitive_value_to_str(value: "PrimitiveData") -> str:
         return "false"
     elif value is None:
         return ""
-    elif isinstance(value, (str, float, int)):
-        return str(value)
-    raise TypeError(
-        f"Expected str, int, float, bool, or None. Got {type(value).__name__!r}."
-    )
+    return str(value)
 
 
 def is_known_encoding(encoding: str) -> bool:

--- a/tests/models/test_queryparams.py
+++ b/tests/models/test_queryparams.py
@@ -87,13 +87,6 @@ def test_empty_query_params():
     assert str(q) == "a="
 
 
-def test_invalid_query_params():
-    with pytest.raises(
-        TypeError, match=r"Expected str, int, float, bool, or None. Got 'bytes'."
-    ):
-        httpx.QueryParams({"a": b"bytes"})
-
-
 def test_queryparam_update_is_hard_deprecated():
     q = httpx.QueryParams("a=123")
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
This reverts commit 4cbf13ece2e584b45b935df0a0c670e1863c4569 / PR #2523

See discussion at https://github.com/encode/httpx/discussions/2538 and in #2523 — this change is potentially breaking and should be considered for a future release instead (i.e. 0.24.0).