### PR TITLE
Version 0.23.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.23.3 (4th Jan, 2023)
+
+### Fixed
+
+* Version 0.23.2 accidentally included stricter type checking on query parameters. This shouldn've have been included in a minor version bump, and is now reverted. (#2523, #2539)
+
 ## 0.23.2 (2nd Jan, 2023)
 
 ### Added

--- a/httpx/__version__.py
+++ b/httpx/__version__.py
@@ -1,3 +1,3 @@
 __title__ = "httpx"
 __description__ = "A next generation HTTP client, for Python 3."
-__version__ = "0.23.2"
+__version__ = "0.23.3"


### PR DESCRIPTION
~~Depends on #2539~~

We've now had two recent cases of tidying up edges of the API *in minor point releases* which have led to breakages in user codebases. Both of these have been due to my lead. Calling these out so that we can tighten up our release process, and for me in particular to slow down on hitting go on releases.

Release draft is here... https://github.com/encode/httpx/releases/tag/untagged-9adfb8466a6a6537698a

---

## 0.23.3 (4th Jan, 2023)

### Fixed

* Version 0.23.2 accidentally included stricter type checking on query parameters. This shouldn've have been included in a minor version bump, and is now reverted. (#2523, #2539)