### PR TITLE
Fix unclosed generator when running on trio

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -142,9 +142,8 @@ class BoundAsyncStream(AsyncByteStream):
         self._response = response
         self._timer = timer
 
-    async def __aiter__(self) -> typing.AsyncIterator[bytes]:
-        async for chunk in self._stream:
-            yield chunk
+    def __aiter__(self) -> typing.AsyncIterator[bytes]:
+        return self._stream.__aiter__()
 
     async def aclose(self) -> None:
         seconds = await self._timer.async_elapsed()

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -3,8 +3,8 @@ import email.message
 import json as jsonlib
 import typing
 import urllib.request
-from contextlib import aclosing
 from collections.abc import Mapping
+from contextlib import aclosing
 from http.cookiejar import Cookie, CookieJar
 
 from ._content import ByteStream, UnattachedStream, encode_request, encode_response

--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -232,12 +232,14 @@ class HTTPTransport(BaseTransport):
 
 class AsyncResponseStream(AsyncByteStream):
     def __init__(self, httpcore_stream: typing.AsyncIterable[bytes]):
-        self._httpcore_stream = httpcore_stream
+        self._httpcore_stream = httpcore_stream.__aiter__()
 
-    async def __aiter__(self) -> typing.AsyncIterator[bytes]:
+    def __aiter__(self) -> typing.AsyncIterator[bytes]:
+        return self
+
+    async def __anext__(self) -> bytes:
         with map_httpcore_exceptions():
-            async for part in self._httpcore_stream:
-                yield part
+            return await self._httpcore_stream.__anext__()
 
     async def aclose(self) -> None:
         if hasattr(self._httpcore_stream, "aclose"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "certifi",
-    "httpcore>=0.15.0,<0.17.0",
+    "httpcore==git+https://github.com/encode/httpcore.git@bug/async-early-stream-break",
     "idna",
     "sniffio",
 ]

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -107,6 +107,19 @@ def test_stream_iterator(server):
     assert body == b"Hello, world!"
 
 
+def test_stream_iterator_partial(server):
+    body = ""
+
+    with httpx.Client() as client:
+        with client.stream("GET", server.url) as response:
+            for chunk in response.iter_text(5):
+                body += chunk
+                break
+
+    assert response.status_code == 200
+    assert body == "Hello"
+
+
 def test_raw_iterator(server):
     body = b""
 


### PR DESCRIPTION
While taking a look at resolving #2186, I came across an issue in the trio variant of `test_asgi_streaming`.

It seems that our usage of generators for `__aiter__` doesn't satisfy trio's strict semantics.

AFAIU, when `__aiter__()` does more than delegating to an underlying async iterable, we should be implementing `__anext__()` so that `aclosing()` is applied to that streaming. Though my understanding is a bit limited so far in the night. 😃 

This comes with a companion PR on httpcore. https://github.com/encode/httpcore/pull/657