### PR TITLE
Add sslcontext to the asynclient docstring

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -1311,7 +1311,8 @@ class AsyncClient(BaseClient):
     sending requests.
     * **verify** - *(optional)* SSL certificates (a.k.a CA bundle) used to
     verify the identity of requested hosts. Either `True` (default CA bundle),
-    a path to an SSL certificate file, or `False` (disable verification).
+    a path to an SSL certificate file, an `ssl.SSLContext`, or `False`
+    (which will disable verification).
     * **cert** - *(optional)* An SSL certificate used by the requested host
     to authenticate the client. Either a path to an SSL certificate file, or
     two-tuple of (certificate file, key file), or a three-tuple of (certificate


### PR DESCRIPTION
ASyncClient docstring is not aligned with Client docstring. The sslcontext option for the verify parameter is not present. This PR fix this.