### PR TITLE
More robust check for upload files in binary mode

### DIFF
--- a/httpx/_multipart.py
+++ b/httpx/_multipart.py
@@ -122,13 +122,13 @@ class FileField:
             # requests does the opposite (it overwrites the header with the 3rd tuple element)
             headers["Content-Type"] = content_type
 
-        if isinstance(fileobj, io.TextIOBase):
-            raise TypeError(
-                "Multipart file uploads must be opened in binary mode, not text mode."
-            )
         if isinstance(fileobj, io.StringIO):
             raise TypeError(
                 "Multipart file uploads require 'io.BytesIO', not 'io.StringIO'."
+            )
+        if isinstance(fileobj, io.TextIOBase):
+            raise TypeError(
+                "Multipart file uploads must be opened in binary mode, not text mode."
             )
 
         self.filename = filename

--- a/httpx/_multipart.py
+++ b/httpx/_multipart.py
@@ -122,7 +122,7 @@ class FileField:
             # requests does the opposite (it overwrites the header with the 3rd tuple element)
             headers["Content-Type"] = content_type
 
-        if "b" not in getattr(fileobj, "mode", "b"):
+        if isinstance(fileobj, io.TextIOBase):
             raise TypeError(
                 "Multipart file uploads must be opened in binary mode, not text mode."
             )


### PR DESCRIPTION
This is a minor patch proposal fixing fixing an issue with a recently introduced check for binary file objects in multipart uploads. The currently used check
https://github.com/encode/httpx/blob/f1157dbc4102ac8e227a0a0bb12a877f592eff58/httpx/_multipart.py#L125-L128
misses out on file objects that read and write byte-like objects, but have the `mode` attribute set to `r` such as [ZipFile.open()](https://docs.python.org/3/library/zipfile.html#zipfile.ZipFile.open) which is binary-only.