### PR TITLE
Improve typing for 'method' parameters

### DIFF
--- a/httpx/_api.py
+++ b/httpx/_api.py
@@ -9,6 +9,7 @@ from ._types import (
     CertTypes,
     CookieTypes,
     HeaderTypes,
+    MethodTypes,
     ProxiesTypes,
     QueryParamTypes,
     RequestContent,
@@ -21,7 +22,7 @@ from ._types import (
 
 
 def request(
-    method: str,
+    method: typing.Union[MethodTypes, str],
     url: URLTypes,
     *,
     params: typing.Optional[QueryParamTypes] = None,
@@ -113,7 +114,7 @@ def request(
 
 @contextmanager
 def stream(
-    method: str,
+    method: typing.Union[MethodTypes, str],
     url: URLTypes,
     *,
     params: typing.Optional[QueryParamTypes] = None,

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -35,6 +35,7 @@ from ._types import (
     CertTypes,
     CookieTypes,
     HeaderTypes,
+    MethodTypes,
     ProxiesTypes,
     QueryParamTypes,
     RequestContent,
@@ -319,7 +320,7 @@ class BaseClient:
 
     def build_request(
         self,
-        method: str,
+        method: typing.Union[MethodTypes, str],
         url: URLTypes,
         *,
         content: typing.Optional[RequestContent] = None,
@@ -527,7 +528,9 @@ class BaseClient:
 
         return url
 
-    def _redirect_headers(self, request: Request, url: URL, method: str) -> Headers:
+    def _redirect_headers(
+        self, request: Request, url: URL, method: typing.Union[MethodTypes, str]
+    ) -> Headers:
         """
         Return the headers that should be used for the redirect request.
         """
@@ -555,7 +558,7 @@ class BaseClient:
         return headers
 
     def _redirect_stream(
-        self, request: Request, method: str
+        self, request: Request, method: typing.Union[MethodTypes, str]
     ) -> typing.Optional[typing.Union[SyncByteStream, AsyncByteStream]]:
         """
         Return the body that should be used for the redirect request.
@@ -759,7 +762,7 @@ class Client(BaseClient):
 
     def request(
         self,
-        method: str,
+        method: typing.Union[MethodTypes, str],
         url: URLTypes,
         *,
         content: typing.Optional[RequestContent] = None,
@@ -816,7 +819,7 @@ class Client(BaseClient):
     @contextmanager
     def stream(
         self,
-        method: str,
+        method: typing.Union[MethodTypes, str],
         url: URLTypes,
         *,
         content: typing.Optional[RequestContent] = None,
@@ -1483,7 +1486,7 @@ class AsyncClient(BaseClient):
 
     async def request(
         self,
-        method: str,
+        method: typing.Union[MethodTypes, str],
         url: URLTypes,
         *,
         content: typing.Optional[RequestContent] = None,
@@ -1532,7 +1535,7 @@ class AsyncClient(BaseClient):
     @asynccontextmanager
     async def stream(
         self,
-        method: str,
+        method: typing.Union[MethodTypes, str],
         url: URLTypes,
         *,
         content: typing.Optional[RequestContent] = None,

--- a/httpx/_main.py
+++ b/httpx/_main.py
@@ -17,6 +17,7 @@ from ._client import Client
 from ._exceptions import RequestError
 from ._models import Response
 from ._status_codes import codes
+from ._types import MethodTypes
 
 
 def print_help() -> None:
@@ -446,7 +447,7 @@ def handle_help(
 )
 def main(
     url: str,
-    method: str,
+    method: typing.Union[MethodTypes, str],
     params: typing.List[typing.Tuple[str, str]],
     content: str,
     data: typing.List[typing.Tuple[str, str]],

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -32,6 +32,7 @@ from ._types import (
     AsyncByteStream,
     CookieTypes,
     HeaderTypes,
+    MethodTypes,
     QueryParamTypes,
     RequestContent,
     RequestData,
@@ -307,7 +308,7 @@ class Headers(typing.MutableMapping[str, str]):
 class Request:
     def __init__(
         self,
-        method: typing.Union[str, bytes],
+        method: typing.Union[MethodTypes, str, bytes],
         url: typing.Union["URL", str],
         *,
         params: typing.Optional[QueryParamTypes] = None,

--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -23,6 +23,8 @@ from typing import (
     Union,
 )
 
+from typing_extensions import Literal
+
 if TYPE_CHECKING:  # pragma: no cover
     from ._auth import Auth  # noqa: F401
     from ._config import Proxy, Timeout  # noqa: F401
@@ -43,6 +45,9 @@ RawURL = NamedTuple(
 )
 
 URLTypes = Union["URL", str]
+MethodTypes = Literal[
+    "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE"
+]
 
 QueryParamTypes = Union[
     "QueryParams",


### PR DESCRIPTION
The parameter method previously had the type 'str,' which has now been changed to 'typing. Literal["GET", "POST",..., "DELETE"] | str'

old_signature
``` python
method: str,
```
new_signature
``` python
method: typing.Union[MethodTypes, str],
# where
MethodTypes = Literal[
    "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE"
]
```

The text editor previously displayed method as a type of str, but now it displays acceptable values such as "GET", "POST", and so on.
