### PR TITLE
Use ruff instead of flake8, autoflake and isort

### DIFF
--- a/httpx/_urls.py
+++ b/httpx/_urls.py
@@ -3,7 +3,7 @@ from urllib.parse import parse_qs, unquote
 
 import idna
 
-from ._types import PrimitiveData, QueryParamTypes, RawURL, URLTypes
+from ._types import QueryParamTypes, RawURL, URLTypes
 from ._urlparse import urlencode, urlparse
 from ._utils import primitive_value_to_str
 
@@ -422,7 +422,6 @@ class QueryParams(typing.Mapping[str, str]):
 
         value = args[0] if args else kwargs
 
-        items: typing.Sequence[typing.Tuple[str, PrimitiveData]]
         if value is None or isinstance(value, (str, bytes)):
             value = value.decode("ascii") if isinstance(value, bytes) else value
             self._dict = parse_qs(value, keep_blank_values=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ text = "\n---\n\n[Full changelog](https://github.com/encode/httpx/blob/master/CH
 pattern = 'src="(docs/img/.*?)"'
 replacement = 'src="https://raw.githubusercontent.com/encode/httpx/master/\1"'
 
+# https://beta.ruff.rs/docs/configuration/#using-rufftoml
 [tool.ruff]
 select = ["E", "F", "I", "B", "PIE"]
 ignore = ["B904", "B028"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,3 +90,11 @@ text = "\n---\n\n[Full changelog](https://github.com/encode/httpx/blob/master/CH
 [[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
 pattern = 'src="(docs/img/.*?)"'
 replacement = 'src="https://raw.githubusercontent.com/encode/httpx/master/\1"'
+
+[tool.ruff]
+select = ["E", "F", "I", "B", "PIE"]
+ignore = ["B904", "B028"]
+line-length = 120
+
+[tool.ruff.isort]
+combine-as-imports = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,19 +19,13 @@ build==0.10.0
 twine==4.0.2
 
 # Tests & Linting
-autoflake==1.7.7
 black==23.3.0
 coverage==7.2.1
 cryptography==39.0.1
-flake8==3.9.2
-flake8-bugbear==23.1.20
-flake8-pie==0.16.0; python_version>='3.7'
-importlib-metadata==4.13.0; python_version>='3.7'
-isort==5.11.4; python_version<'3.8'
-isort==5.12.0; python_version>='3.8'
 mypy==1.0.1
 types-certifi==2021.10.8.2
 pytest==7.2.2
+ruff==0.0.260
 trio==0.22.0
 trio-typing==0.7.0
 trustme==0.9.0

--- a/scripts/check
+++ b/scripts/check
@@ -10,6 +10,5 @@ set -x
 
 ./scripts/sync-version
 ${PREFIX}black --check --diff --target-version=py37 $SOURCE_FILES
-${PREFIX}flake8 $SOURCE_FILES
 ${PREFIX}mypy $SOURCE_FILES
-${PREFIX}isort --check --diff --project=httpx $SOURCE_FILES
+${PREFIX}ruff check --diff $SOURCE_FILES

--- a/scripts/lint
+++ b/scripts/lint
@@ -8,6 +8,5 @@ export SOURCE_FILES="httpx tests"
 
 set -x
 
-${PREFIX}autoflake --in-place --recursive $SOURCE_FILES
-${PREFIX}isort --project=httpx $SOURCE_FILES
+${PREFIX}ruff --fix $SOURCE_FILES
 ${PREFIX}black --target-version=py37 $SOURCE_FILES

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,3 @@
-[flake8]
-ignore = W503, E203, B305, PIE801
-max-line-length = 120
-
 [mypy]
 ignore_missing_imports = True
 strict = True
@@ -9,10 +5,6 @@ strict = True
 [mypy-tests.*]
 disallow_untyped_defs = False
 check_untyped_defs = True
-
-[tool:isort]
-profile = black
-combine_as_imports = True
 
 [tool:pytest]
 addopts = -rxXs

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -84,7 +84,7 @@ async def test_access_content_stream_response(server):
 
     assert response.status_code == 200
     with pytest.raises(httpx.ResponseNotRead):
-        response.content
+        response.content  # noqa: B018
 
 
 @pytest.mark.anyio

--- a/tests/models/test_requests.py
+++ b/tests/models/test_requests.py
@@ -105,7 +105,7 @@ def test_cannot_access_streaming_content_without_read():
 
     request = httpx.Request("POST", "http://example.org", content=streaming_body())
     with pytest.raises(httpx.RequestNotRead):
-        request.content
+        request.content  # noqa: B018
 
 
 def test_transfer_encoding_header():
@@ -201,7 +201,7 @@ async def test_request_async_streaming_content_picklable():
     request = httpx.Request("POST", "http://example.org", content=data)
     pickle_request = pickle.loads(pickle.dumps(request))
     with pytest.raises(httpx.RequestNotRead):
-        pickle_request.content
+        pickle_request.content  # noqa: B018
     with pytest.raises(httpx.StreamClosed):
         await pickle_request.aread()
 
@@ -218,7 +218,7 @@ def test_request_generator_content_picklable():
     request = httpx.Request("POST", "http://example.org", content=content())
     pickle_request = pickle.loads(pickle.dumps(request))
     with pytest.raises(httpx.RequestNotRead):
-        pickle_request.content
+        pickle_request.content  # noqa: B018
     with pytest.raises(httpx.StreamClosed):
         pickle_request.read()
 

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -748,7 +748,7 @@ async def test_elapsed_not_available_until_closed():
     )
 
     with pytest.raises(RuntimeError):
-        response.elapsed
+        response.elapsed  # noqa: B018
 
 
 def test_unknown_status_code():
@@ -909,7 +909,7 @@ def test_cannot_access_unset_request():
     response = httpx.Response(200, content=b"Hello, world!")
 
     with pytest.raises(RuntimeError):
-        response.request
+        response.request  # noqa: B018
 
 
 def test_generator_with_transfer_encoding_header():
@@ -952,7 +952,7 @@ async def test_response_async_streaming_picklable():
     response = httpx.Response(200, content=async_streaming_body())
     pickle_response = pickle.loads(pickle.dumps(response))
     with pytest.raises(httpx.ResponseNotRead):
-        pickle_response.content
+        pickle_response.content  # noqa: B018
     with pytest.raises(httpx.StreamClosed):
         await pickle_response.aread()
     assert pickle_response.is_stream_consumed is False

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -53,7 +53,7 @@ def test_request_attribute() -> None:
     # Exception without request attribute
     exc = httpx.ReadTimeout("Read operation timed out")
     with pytest.raises(RuntimeError):
-        exc.request
+        exc.request  # noqa: B018
 
     # Exception with request attribute
     request = httpx.Request("GET", "https://www.example.com")

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -161,7 +161,7 @@ def test_wsgi_server_port(url: str, expected_server_port: str) -> None:
     SERVER_PORT is populated correctly from the requested URL.
     """
     hello_world_app = application_factory([b"Hello, World!"])
-    server_port: str
+    server_port: typing.Optional[str] = None
 
     def app(environ, start_response):
         nonlocal server_port


### PR DESCRIPTION
Ref.: https://github.com/encode/httpx/discussions/2607

