### PR TITLE
Socks5h

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -678,6 +678,10 @@ You can now configure a client to make requests via a proxy using the SOCKS prot
 httpx.Client(proxies='socks5://user:pass@host:port')
 ```
 
+```python
+httpx.Client(proxies='socks5h://user:pass@host:port')
+```
+
 ## Timeout Configuration
 
 HTTPX is careful to enforce timeouts everywhere by default.

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -332,7 +332,7 @@ class Proxy:
         url = URL(url)
         headers = Headers(headers)
 
-        if url.scheme not in ("http", "https", "socks5"):
+        if url.scheme not in ("http", "https", "socks5", "socks5h"):
             raise ValueError(f"Unknown scheme for proxy URL {url!r}")
 
         if url.username or url.password:

--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -315,7 +315,7 @@ class AsyncHTTPTransport(AsyncBaseTransport):
             )
         else:  # pragma: no cover
             raise ValueError(
-                f"Proxy protocol must be either 'http', 'https', 'socks5', or 'socks5h, but got {proxy.url.scheme!r}."
+                f"Proxy protocol must be either 'http', 'https', 'socks5', or 'socks5h', but got {proxy.url.scheme!r}."
             )
 
     async def __aenter__(self: A) -> A:  # Use generics for subclass support.

--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -154,7 +154,7 @@ class HTTPTransport(BaseTransport):
                 http1=http1,
                 http2=http2,
             )
-        elif proxy.url.scheme == "socks5":
+        elif proxy.url.scheme in ("socks5", "socks5h"):
             try:
                 import socksio  # noqa
             except ImportError:  # pragma: no cover
@@ -180,7 +180,7 @@ class HTTPTransport(BaseTransport):
             )
         else:  # pragma: no cover
             raise ValueError(
-                f"Proxy protocol must be either 'http', 'https', or 'socks5', but got {proxy.url.scheme!r}."
+                f"Proxy protocol must be either 'http', 'https', 'socks5', or 'socks5h', but got {proxy.url.scheme!r}."
             )
 
     def __enter__(self: T) -> T:  # Use generics for subclass support.
@@ -289,7 +289,7 @@ class AsyncHTTPTransport(AsyncBaseTransport):
                 http1=http1,
                 http2=http2,
             )
-        elif proxy.url.scheme == "socks5":
+        elif proxy.url.scheme in ("socks5", "socks5h"):
             try:
                 import socksio  # noqa
             except ImportError:  # pragma: no cover
@@ -315,7 +315,7 @@ class AsyncHTTPTransport(AsyncBaseTransport):
             )
         else:  # pragma: no cover
             raise ValueError(
-                f"Proxy protocol must be either 'http', 'https', or 'socks5', but got {proxy.url.scheme!r}."
+                f"Proxy protocol must be either 'http', 'https', 'socks5', or 'socks5h, but got {proxy.url.scheme!r}."
             )
 
     async def __aenter__(self: A) -> A:  # Use generics for subclass support.

--- a/tests/client/test_proxies.py
+++ b/tests/client/test_proxies.py
@@ -61,6 +61,20 @@ def test_socks_proxy():
     assert isinstance(async_transport._pool, httpcore.AsyncSOCKSProxy)
 
 
+def test_socks5h_proxy():
+    url = httpx.URL("http://www.example.com")
+
+    client = httpx.Client(proxies="socks5h://localhost/")
+    transport = client._transport_for_url(url)
+    assert isinstance(transport, httpx.HTTPTransport)
+    assert isinstance(transport._pool, httpcore.SOCKSProxy)
+
+    async_client = httpx.AsyncClient(proxies="socks5h://localhost/")
+    async_transport = async_client._transport_for_url(url)
+    assert isinstance(async_transport, httpx.AsyncHTTPTransport)
+    assert isinstance(async_transport._pool, httpcore.AsyncSOCKSProxy)
+
+
 PROXY_URL = "http://[::1]"
 
 


### PR DESCRIPTION
# Summary

Allow socks5h proxies. Manual testing screenshot below. Unit tests also updated.

This depends on https://github.com/encode/httpcore/pull/672

![Screenshot 2023-04-24 at 4 08 02 PM](https://user-images.githubusercontent.com/63059772/234104761-a95ffff8-7135-489a-b7ee-dc0e1d6e7a6d.png)

Your [contributing guides](https://github.com/encode/.github/blob/a785584b6ebd8619120712076d445b3bcefc20cd/CONTRIBUTING.md) say to talk it over via chat or discussion group, however the register link for the chat always takes me to a blank page, and the discussion group link 404s.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
