### PR TITLE
Fix ruff error and script

### DIFF
--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -472,6 +472,6 @@ def is_ipv4_hostname(hostname: str) -> bool:
 def is_ipv6_hostname(hostname: str) -> bool:
     try:
         ipaddress.IPv6Address(hostname.split("/")[0])
-    except Exception:
+    except ValueError:
         return False
     return True

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -464,7 +464,7 @@ class URLPattern:
 def is_ipv4_hostname(hostname: str) -> bool:
     try:
         ipaddress.IPv4Address(hostname.split("/")[0])
-    except ValueError:
+    except Exception:
         return False
     return True
 
@@ -472,6 +472,6 @@ def is_ipv4_hostname(hostname: str) -> bool:
 def is_ipv6_hostname(hostname: str) -> bool:
     try:
         ipaddress.IPv6Address(hostname.split("/")[0])
-    except ValueError:
+    except Exception:
         return False
     return True

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -464,7 +464,7 @@ class URLPattern:
 def is_ipv4_hostname(hostname: str) -> bool:
     try:
         ipaddress.IPv4Address(hostname.split("/")[0])
-    except:
+    except ValueError:
         return False
     return True
 
@@ -472,6 +472,6 @@ def is_ipv4_hostname(hostname: str) -> bool:
 def is_ipv6_hostname(hostname: str) -> bool:
     try:
         ipaddress.IPv6Address(hostname.split("/")[0])
-    except:
+    except Exception:
         return False
     return True

--- a/scripts/check
+++ b/scripts/check
@@ -11,4 +11,4 @@ set -x
 ./scripts/sync-version
 ${PREFIX}black --check --diff --target-version=py37 $SOURCE_FILES
 ${PREFIX}mypy $SOURCE_FILES
-${PREFIX}ruff check --diff $SOURCE_FILES
+${PREFIX}ruff check $SOURCE_FILES


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

The `ruff` command in `./scripts/check` is not catching the errors, but running `./scripts/lint` does.
This PR will fix both ruff command and the bare exception issue.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
