### PR TITLE
Add httpx-sse to Third Party Packages

### DIFF
--- a/docs/third_party_packages.md
+++ b/docs/third_party_packages.md
@@ -54,6 +54,12 @@ A utility for record and repeat an http request.
 
 This package adds caching functionality to HTTPX
 
+### httpx-sse
+
+[GitHub](https://github.com/florimondmanca/httpx-sse)
+
+Allows consuming Server-Sent Events (SSE) with HTTPX.
+
 ### robox
 
 [Github](https://github.com/danclaudiupop/robox)


### PR DESCRIPTION
Hello people! Long time no see.

As I just released a new version of [httpx-sse](https://github.com/florimondmanca/httpx-sse) after a contributor fixed an issue there, it came to me that the package was not listed on this page yet. I don't know if there's a particular ordering we adhere to.

Given that it received contributions and my comment here https://github.com/encode/httpx/issues/1278#issuecomment-1304794902 received a fair bunch of traffic, it looks like it's being useful to people. It's mostly "done" and low-maintenance so I'm happy to keep it under my hood for now.

Perhaps this might even... ?

Closes #1278

Edit: oh well, this exact kind of PR was suggested by Tom a few months ago! https://github.com/encode/httpx/issues/304#issuecomment-1332418303