### PR TITLE
Ensure all WSGITransport environs have a SERVER_PROTOCOL

### DIFF
--- a/httpx/_transports/wsgi.py
+++ b/httpx/_transports/wsgi.py
@@ -102,6 +102,7 @@ class WSGITransport(BaseTransport):
             "QUERY_STRING": request.url.query.decode("ascii"),
             "SERVER_NAME": request.url.host,
             "SERVER_PORT": str(port),
+            "SERVER_PROTOCOL": "HTTP/1.1",
             "REMOTE_ADDR": self.remote_addr,
         }
         for header_key, header_value in request.headers.raw:

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -173,3 +173,20 @@ def test_wsgi_server_port(url: str, expected_server_port: str) -> None:
     assert response.status_code == 200
     assert response.text == "Hello, World!"
     assert server_port == expected_server_port
+
+
+def test_wsgi_server_protocol():
+    server_protocol = None
+
+    def app(environ, start_response):
+        nonlocal server_protocol
+        server_protocol = environ["SERVER_PROTOCOL"]
+        start_response("200 OK", [("Content-Type", "text/plain")])
+        return [b"success"]
+
+    with httpx.Client(app=app, base_url="http://testserver") as client:
+        response = client.get("/")
+
+    assert response.status_code == 200
+    assert response.text == "success"
+    assert server_protocol == "HTTP/1.1"


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

- I noticed that WSGI environs sent to applications with `httpx.Client(app=app)` did not contain a SERVER_PROTOCOL
- [PEP-3333](https://peps.python.org/pep-3333/#environ-variables) indicates that this key must be present in the WSGI environ, and popular WSGI frameworks (such as [webob](https://github.com/Pylons/webob)) assume it will be as well
- It looks like httpx defaults to using `HTTP/1.1` for a nearly identical case in the ASGITransport, so I did the same here
- I'm more than happy to discuss any of this further!

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
  - _to my knowledge, this does not require a documentation update_
