### PR TITLE
Support context manager in Response object

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -441,6 +441,7 @@ class Request:
         self.extensions = {}
         self.stream = UnattachedStream()
 
+U = typing.TypeVar("U", bound="Response")
 
 class Response:
     def __init__(
@@ -1005,16 +1006,16 @@ class Response:
             with request_context(request=self._request):
                 await self.stream.aclose()
 
-    def __entter__(self) -> "Response":
+    def __entter__(self: U) -> U:
         return self
 
-    def __exit__(self) -> None:
+    def __exit__(self, *args) -> None:
         self.close()
 
-    async def __aenter__(self) -> "Response":
+    async def __aenter__(self: U) -> U:
         await self
 
-    async def __aexit__(self) -> None:
+    async def __aexit__(self, *args) -> None:
         await self.aclose()
 
 

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -441,7 +441,9 @@ class Request:
         self.extensions = {}
         self.stream = UnattachedStream()
 
+
 U = typing.TypeVar("U", bound="Response")
+
 
 class Response:
     def __init__(

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -1005,6 +1005,18 @@ class Response:
             with request_context(request=self._request):
                 await self.stream.aclose()
 
+    def __entter__(self) -> "Response":
+        return self
+
+    def __exit__(self) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "Response":
+        await self
+
+    async def __aexit__(self) -> None:
+        await self.aclose()
+
 
 class Cookies(typing.MutableMapping[str, str]):
     """

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -77,6 +77,14 @@ async def test_stream_response(server):
 
 
 @pytest.mark.anyio
+async def test_context_manager(server):
+    url = server.url
+    async with httpx.AsyncClient() as client:
+        async with client.post(url, json={"text": "Hello, world!"}) as response:
+            assert response.status_code == 200
+
+
+@pytest.mark.anyio
 async def test_access_content_stream_response(server):
     async with httpx.AsyncClient() as client:
         async with client.stream("GET", server.url) as response:

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -187,6 +187,14 @@ def test_base_url(server):
     assert response.url == base_url
 
 
+def test_context_manager(server):
+    base_url = server.url
+    with httpx.Client(base_url=base_url) as client:
+        with client.get("/") as response:
+            assert response.status_code == 200
+            assert response.url == base_url
+
+
 def test_merge_absolute_url():
     client = httpx.Client(base_url="https://www.example.com/")
     request = client.build_request("GET", "http://www.example.com/")


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->
For now, the context manager has been supported in requests lib, FYI https://github.com/psf/requests/blob/main/requests/models.py#L706-L711

So the people can use it more easy like

```python
with requests.get('https://httpbin.org/get') as r:
        # Do things with the response here.
        r.raise_for_status()
```

So I think it would be great to support context manager in httpx

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
