### PR TITLE
add overloads to cookies' get method

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -1070,7 +1070,27 @@ class Cookies(typing.MutableMapping[str, str]):
         cookie = Cookie(**kwargs)  # type: ignore
         self.jar.set_cookie(cookie)
 
-    def get(  # type: ignore
+    @typing.overload  # type: ignore
+    def get(
+        self,
+        name: str,
+        default: None = None,
+        domain: typing.Optional[str] = None,
+        path: typing.Optional[str] = None,
+    ) -> typing.Optional[str]:
+        ...
+
+    @typing.overload
+    def get(
+        self,
+        name: str,
+        default: str,
+        domain: typing.Optional[str] = None,
+        path: typing.Optional[str] = None,
+    ) -> str:
+        ...
+
+    def get(
         self,
         name: str,
         default: typing.Optional[str] = None,


### PR DESCRIPTION

# Summary

When using cookies in my project I realised that the get return type does not change when a default is given.
I added overloads so that str is the return type if a default value is given and Optional[str] if not.

# Checklist

- [x ] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x ] I've updated the documentation accordingly.
