### PR TITLE
Use Mozilla documentation instead of `httpstatuses.com` for HTTP error reference

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -285,7 +285,7 @@ Traceback (most recent call last):
   File "/Users/tomchristie/GitHub/encode/httpcore/httpx/models.py", line 837, in raise_for_status
     raise HTTPStatusError(message, response=self)
 httpx._exceptions.HTTPStatusError: 404 Client Error: Not Found for url: https://httpbin.org/status/404
-For more information check: https://httpstatuses.com/404
+For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
 ```
 
 Any successful response codes will simply return `None` rather than raising an exception.

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -729,12 +729,12 @@ class Response:
             message = (
                 "{error_type} '{0.status_code} {0.reason_phrase}' for url '{0.url}'\n"
                 "Redirect location: '{0.headers[location]}'\n"
-                "For more information check: https://httpstatuses.com/{0.status_code}"
+                "For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/{0.status_code}"
             )
         else:
             message = (
                 "{error_type} '{0.status_code} {0.reason_phrase}' for url '{0.url}'\n"
-                "For more information check: https://httpstatuses.com/{0.status_code}"
+                "For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/{0.status_code}"
             )
 
         status_class = self.status_code // 100

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -102,7 +102,7 @@ def test_raise_for_status():
         response.raise_for_status()
     assert str(exc_info.value) == (
         "Informational response '101 Switching Protocols' for url 'https://example.org'\n"
-        "For more information check: https://httpstatuses.com/101"
+        "For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/101"
     )
 
     # 3xx status codes are redirections.
@@ -114,7 +114,7 @@ def test_raise_for_status():
     assert str(exc_info.value) == (
         "Redirect response '303 See Other' for url 'https://example.org'\n"
         "Redirect location: 'https://other.org'\n"
-        "For more information check: https://httpstatuses.com/303"
+        "For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303"
     )
 
     # 4xx status codes are a client error.
@@ -125,7 +125,7 @@ def test_raise_for_status():
         response.raise_for_status()
     assert str(exc_info.value) == (
         "Client error '403 Forbidden' for url 'https://example.org'\n"
-        "For more information check: https://httpstatuses.com/403"
+        "For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403"
     )
 
     # 5xx status codes are a server error.
@@ -136,7 +136,7 @@ def test_raise_for_status():
         response.raise_for_status()
     assert str(exc_info.value) == (
         "Server error '500 Internal Server Error' for url 'https://example.org'\n"
-        "For more information check: https://httpstatuses.com/500"
+        "For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500"
     )
 
     # Calling .raise_for_status without setting a request instance is


### PR DESCRIPTION
Discussion at https://github.com/encode/httpx/discussions/2766

httpstatuses.com redirects to https://www.webfx.com/web-development/glossary/http-status-codes/ which has advertisements and is now generally an unpleasant resource — I'll spare you the visit:

<img width="1781" alt="httpstatuses" src="https://github.com/encode/httpx/assets/2586601/fcf3faee-1adb-4abd-b317-5660644de316">

Instead we use the Mozilla documentation which looks like this: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
