### PR TITLE
Add `Hishel` into the `Third Party Packages`

### DIFF
--- a/docs/third_party_packages.md
+++ b/docs/third_party_packages.md
@@ -6,6 +6,12 @@ As HTTPX usage grows, there is an expanding community of developers building too
 
 <!-- NOTE: this list is in alphabetical order. -->
 
+### Hishel
+
+[GitHub](https://github.com/karosis88/hishel) - [Documentation](https://karosis88.github.io/hishel/)
+
+An elegant HTTP Cache implementation for HTTPX and HTTP Core.
+
 ### Authlib
 
 [GitHub](https://github.com/lepture/authlib) - [Documentation](https://docs.authlib.org/en/latest/)


### PR DESCRIPTION
Discussed in https://github.com/encode/httpx/discussions/2797

[`Hishel`](https://github.com/karosis88/hishel) is an elegant HTTP Cache implementation library for the [HTTPX](https://github.com/encode/httpx) and [HTTP Core](https://github.com/encode/httpcore)  projects.

## Motivation and Philosophy

The philosophy is to provide a library that is **fully integrated into the `HTTPX` and `HTTP Core` ecosystems**, as well as a **single and powerful way** to add an HTTP Cache layer on top of **`HTTPX`'s Transports and `HTTP Core`'s connection pulls**.

Due to its very similar code base and compatibility with these two diamonds, `Hishel` is meant to be the little brother to `HTTPX` and `HTTP Core`.

## Example

```python
import hishel

cl = hishel.CacheClient()  # instead of httpx.Client()

resp = cl.get('https://www.encode.io')  # takes 0.5222692489624023 seconds
resp = cl.get('https://www.encode.io')  # takes 0.001004934310913086 seconds (520x faster!)
assert resp.extensions['from_cache']
```

`Hishel` is a new library, so we welcome contributions 💗 (and github stars ⭐).