### PR TITLE
remove unnecessary black argument

### DIFF
--- a/scripts/check
+++ b/scripts/check
@@ -9,6 +9,6 @@ export SOURCE_FILES="httpx tests"
 set -x
 
 ./scripts/sync-version
-${PREFIX}black --check --diff --target-version=py37 $SOURCE_FILES
+${PREFIX}black --check --diff $SOURCE_FILES
 ${PREFIX}mypy $SOURCE_FILES
 ${PREFIX}ruff check $SOURCE_FILES

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 export PREFIX=""
-if [ -d 'venv' ] ; then
+if [ -d 'venv' ]; then
     export PREFIX="venv/bin/"
 fi
 export SOURCE_FILES="httpx tests"
@@ -9,4 +9,4 @@ export SOURCE_FILES="httpx tests"
 set -x
 
 ${PREFIX}ruff --fix $SOURCE_FILES
-${PREFIX}black --target-version=py37 $SOURCE_FILES
+${PREFIX}black $SOURCE_FILES


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

black can infer `target-version` from project metadata, this argument is not necessary

https://black.readthedocs.io/en/stable/change_log.html#id24

<!-- Write a small summary about what is happening here. -->

# Checklist

- [ ] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
