### PR TITLE
Update Typeinfo for extensions in Response class

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -467,7 +467,7 @@ class Response:
         # the client will set `response.next_request`.
         self.next_request: typing.Optional[Request] = None
 
-        self.extensions = {} if extensions is None else extensions
+        self.extensions: ResponseExtensions = {} if extensions is None else extensions
         self.history = [] if history is None else list(history)
 
         self.is_closed = False


### PR DESCRIPTION
To remove the unknown dict type info

(variable) extensions: ResponseExtensions | dict[Unknown, Unknown]

<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Simple add typing information for the extensions variable, as the default dict is "unknown"

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
