### PR TITLE
HTTPS proxies support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+* Support HTTPS proxies. (#2845)
 * Add `socket_options` argument to `httpx.HTTPTransport` and `httpx.AsyncHTTPTransport` classes. (#2716)
 
 ### Fixed

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -326,6 +326,7 @@ class Proxy:
         self,
         url: URLTypes,
         *,
+        ssl_context: typing.Optional[ssl.SSLContext] = None,
         auth: typing.Optional[typing.Tuple[str, str]] = None,
         headers: typing.Optional[HeaderTypes] = None,
     ):
@@ -343,6 +344,7 @@ class Proxy:
         self.url = url
         self.auth = auth
         self.headers = headers
+        self.ssl_context = ssl_context
 
     @property
     def raw_auth(self) -> typing.Optional[typing.Tuple[bytes, bytes]]:

--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -156,6 +156,7 @@ class HTTPTransport(BaseTransport):
                 proxy_auth=proxy.raw_auth,
                 proxy_headers=proxy.headers.raw,
                 ssl_context=ssl_context,
+                proxy_ssl_context=proxy.ssl_context,
                 max_connections=limits.max_connections,
                 max_keepalive_connections=limits.max_keepalive_connections,
                 keepalive_expiry=limits.keepalive_expiry,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "certifi",
-    "httpcore>=0.17.2,<0.18.0",
+    "httpcore>=0.18.0,<0.19.0",
     "idna",
     "sniffio",
 ]


### PR DESCRIPTION
Closes #1434

Because HTTPS proxies are now supported by httpcore, this pull request simply provides an API for that feature.
