### PR TITLE
Add cookies to the retried request when performing digest authentication.

### DIFF
--- a/httpx/_auth.py
+++ b/httpx/_auth.py
@@ -217,7 +217,8 @@ class DigestAuth(Auth):
         request.headers["Authorization"] = self._build_auth_header(
             request, self._last_challenge
         )
-        Cookies(response.cookies).set_cookie_header(request=request)
+        if response.cookies:
+            Cookies(response.cookies).set_cookie_header(request=request)
         yield request
 
     def _parse_challenge(

--- a/httpx/_auth.py
+++ b/httpx/_auth.py
@@ -8,7 +8,7 @@ from base64 import b64encode
 from urllib.request import parse_http_list
 
 from ._exceptions import ProtocolError
-from ._models import Request, Response
+from ._models import Request, Response, Cookies
 from ._utils import to_bytes, to_str, unquote
 
 if typing.TYPE_CHECKING:  # pragma: no cover
@@ -217,6 +217,7 @@ class DigestAuth(Auth):
         request.headers["Authorization"] = self._build_auth_header(
             request, self._last_challenge
         )
+        Cookies(response.cookies).set_cookie_header(request=request)
         yield request
 
     def _parse_challenge(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -54,7 +54,7 @@ def test_digest_auth_with_401():
         "WWW-Authenticate": 'Digest realm="...", qop="auth", nonce="...", opaque="..."'
     }
     response = httpx.Response(
-        content=b"Auth required", status_code=401, headers=headers
+        content=b"Auth required", status_code=401, headers=headers, request=request
     )
     request = flow.send(response)
     assert request.headers["Authorization"].startswith("Digest")
@@ -79,7 +79,7 @@ def test_digest_auth_with_401_nonce_counting():
         "WWW-Authenticate": 'Digest realm="...", qop="auth", nonce="...", opaque="..."'
     }
     response = httpx.Response(
-        content=b"Auth required", status_code=401, headers=headers
+        content=b"Auth required", status_code=401, headers=headers, request=request
     )
     first_request = flow.send(response)
     assert first_request.headers["Authorization"].startswith("Digest")


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary
Adding the cookies from the response in the first request into the follow up request. The server expects a cookie to be set. This is however not highlighted in the RFC. Supporting [SO answer](https://stackoverflow.com/a/25743837/4444629) and discussions by @robin-blanchard https://github.com/encode/httpx/issues/2788#issuecomment-1677015264.
<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
