### PR TITLE
test: Drop private imports from `test_proxies.py`

### DIFF
--- a/tests/client/test_proxies.py
+++ b/tests/client/test_proxies.py
@@ -2,7 +2,6 @@ import httpcore
 import pytest
 
 import httpx
-from httpx._utils import URLPattern
 
 
 def url_to_origin(url: str) -> httpcore.URL:
@@ -35,11 +34,12 @@ def url_to_origin(url: str) -> httpcore.URL:
 )
 def test_proxies_parameter(proxies, expected_proxies):
     client = httpx.Client(proxies=proxies)
+    client_patterns = [p.pattern for p in client._mounts.keys()]
+    client_proxies = list(client._mounts.values())
 
     for proxy_key, url in expected_proxies:
-        pattern = URLPattern(proxy_key)
-        assert pattern in client._mounts
-        proxy = client._mounts[pattern]
+        assert proxy_key in client_patterns
+        proxy = client_proxies[client_patterns.index(proxy_key)]
         assert isinstance(proxy, httpx.HTTPTransport)
         assert isinstance(proxy._pool, httpcore.HTTPProxy)
         assert proxy._pool._proxy_url == url_to_origin(url)


### PR DESCRIPTION
# Summary

Refactor a test case that imports from private namespace, as suggested in #2492.

The original version constructs `URLPattern`s to compare. This PR destructs them.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change. (This is a test refactor)
- [x] I've updated the documentation accordingly. (No code changed)
