### PR TITLE
Raise ValueError on `Response.encoding` being set after `Response.text` has been accessed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Fixed
+
+* Raise `ValueError` on `Response.encoding` being set after `Response.text` has been accessed. (#2852)
+
 ## 0.25.0 (11th Sep, 2023)
 
 ### Removed

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -1,4 +1,3 @@
-import codecs
 import datetime
 import email.message
 import json as jsonlib
@@ -607,24 +606,13 @@ class Response:
         """
         Set the encoding to use for decoding the byte content into text.
 
-        If the `text` attribute has been accessed, the encoding is not
-        allowed to be changed and will raise a ValueError if doing so.
+        If the `text` attribute has been accessed, attempting to set the
+        encoding will throw a ValueError.
         """
-
         if hasattr(self, "_text"):
-            encoding = self.encoding or "utf-8"
-            if (
-                is_known_encoding(value)
-                and is_known_encoding(encoding)
-                and codecs.lookup(value) == codecs.lookup(encoding)
-            ):
-                self._encoding = value
-                return
-            else:
-                raise ValueError(
-                    f"Attempt to set encoding to '{value}' is not allowed,"
-                    f"because the content has been decoded with encoding '{self.encoding}'"
-                )
+            raise ValueError(
+                "Setting encoding after `text` has been accessed is not allowed."
+            )
         self._encoding = value
 
     @property

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -1,3 +1,4 @@
+import codecs
 import datetime
 import email.message
 import json as jsonlib
@@ -603,6 +604,27 @@ class Response:
 
     @encoding.setter
     def encoding(self, value: str) -> None:
+        """
+        Set the encoding to use for decoding the byte content into text.
+
+        If the `text` attribute has been accessed, the encoding is not
+        allowed to be changed and will raise a ValueError if doing so.
+        """
+
+        if hasattr(self, "_text"):
+            encoding = self.encoding or "utf-8"
+            if (
+                is_known_encoding(value)
+                and is_known_encoding(encoding)
+                and codecs.lookup(value) == codecs.lookup(encoding)
+            ):
+                self._encoding = value
+                return
+            else:
+                raise ValueError(
+                    f"Attempt to set encoding to '{value}' is not allowed,"
+                    f"because the content has been decoded with encoding '{self.encoding}'"
+                )
         self._encoding = value
 
     @property

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -298,6 +298,22 @@ def test_response_force_encoding():
     assert response.encoding == "iso-8859-1"
 
 
+def test_response_force_encoding_after_text_accessed():
+    response = httpx.Response(
+        200,
+        content=b"Hello, world!",
+    )
+    assert response.status_code == 200
+    assert response.reason_phrase == "OK"
+    assert response.text == "Hello, world!"
+    assert response.encoding == "utf-8"
+
+    response.encoding = "UTF8"
+
+    with pytest.raises(ValueError):
+        response.encoding = "iso-8859-1"
+
+
 def test_read():
     response = httpx.Response(
         200,

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -308,7 +308,8 @@ def test_response_force_encoding_after_text_accessed():
     assert response.text == "Hello, world!"
     assert response.encoding == "utf-8"
 
-    response.encoding = "UTF8"
+    with pytest.raises(ValueError):
+        response.encoding = "UTF8"
 
     with pytest.raises(ValueError):
         response.encoding = "iso-8859-1"


### PR DESCRIPTION
Discussed in #2041

<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

After `Response.text` is accessed, if you try to change `Response.encoding`, nothing happens. So just raise an Exception on change to `encoding` after `text` is accessed.

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
