### PR TITLE
Fix encode host

### DIFF
--- a/httpx/_urlparse.py
+++ b/httpx/_urlparse.py
@@ -87,7 +87,7 @@ COMPONENT_REGEX = {
 
 # We use these simple regexs as a first pass before handing off to
 # the stdlib 'ipaddress' module for IP address validation.
-IPv4_STYLE_HOSTNAME = re.compile(r"^[0-9]+.[0-9]+.[0-9]+.[0-9]+$")
+IPv4_STYLE_HOSTNAME = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$")
 IPv6_STYLE_HOSTNAME = re.compile(r"^\[.*\]$")
 
 

--- a/tests/test_urlparse.py
+++ b/tests/test_urlparse.py
@@ -45,6 +45,12 @@ def test_urlparse_normalized_host():
     assert url.host == "example.com"
 
 
+def test_urlparse_ipv4_like_host():
+    """rare host names used to quality as IPv4"""
+    url = httpx.URL("https://023b76x43144/")
+    assert url.host == "023b76x43144"
+
+
 def test_urlparse_valid_ipv4():
     url = httpx.URL("https://1.2.3.4/")
     assert url.host == "1.2.3.4"


### PR DESCRIPTION
# Summary

The ``encode_host`` method used the regular expression in the variable IPv4_STYLE_HOSTNAME. This was before:
``r"^[0-9]+.[0-9]+.[0-9]+.[0-9]+$"`` which wrongly allows hostnames like ``023b76x43144`` to pas as a ipv4 address. This is now fixed by changed the url to ``r"^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$"``

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.: Not applicable IMHO
