### PR TITLE
Use ruff format

### DIFF
--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -64,7 +64,7 @@ SOCKET_OPTION = typing.Union[
 def map_httpcore_exceptions() -> typing.Iterator[None]:
     try:
         yield
-    except Exception as exc:  # noqa: PIE-786
+    except Exception as exc:
         mapped_exc = None
 
         for from_exc, to_exc in HTTPCORE_EXC_MAP.items():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,10 @@ replacement = 'src="https://raw.githubusercontent.com/encode/httpx/master/\1"'
 [tool.ruff]
 select = ["E", "F", "I", "B", "PIE"]
 ignore = ["B904", "B028"]
-line-length = 120
+line-length = 88
+
+[tool.ruff.pycodestyle]
+max-line-length = 120
 
 [tool.ruff.isort]
 combine-as-imports = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,13 +19,12 @@ build==0.10.0
 twine==4.0.2
 
 # Tests & Linting
-black==23.9.1
 coverage[toml]==7.3.0
 cryptography==41.0.4
 mypy==1.5.1
 types-certifi==2021.10.8.2
 pytest==7.4.3
-ruff==0.0.291
+ruff==0.1.3
 trio==0.22.2
 trio-typing==0.9.0
 trustme==1.1.0

--- a/scripts/check
+++ b/scripts/check
@@ -9,6 +9,6 @@ export SOURCE_FILES="httpx tests"
 set -x
 
 ./scripts/sync-version
-${PREFIX}black --check --diff $SOURCE_FILES
+${PREFIX}ruff format $SOURCE_FILES --diff
 ${PREFIX}mypy $SOURCE_FILES
 ${PREFIX}ruff check $SOURCE_FILES

--- a/scripts/lint
+++ b/scripts/lint
@@ -9,4 +9,4 @@ export SOURCE_FILES="httpx tests"
 set -x
 
 ${PREFIX}ruff --fix $SOURCE_FILES
-${PREFIX}black $SOURCE_FILES
+${PREFIX}ruff format $SOURCE_FILES


### PR DESCRIPTION
[Ruff](https://docs.astral.sh/ruff/) introduced a new formatter that can completely replace black, allowing us to use ruff instead of ruff + black.

Ruff formatter, like ruff linter, is extremely fast.