### PR TITLE
Drop unneccessary `binascii` import

### DIFF
--- a/httpx/_multipart.py
+++ b/httpx/_multipart.py
@@ -199,7 +199,7 @@ class MultipartStream(SyncByteStream, AsyncByteStream):
         boundary: typing.Optional[bytes] = None,
     ) -> None:
         if boundary is None:
-            boundary = os.urandom(16).hex()
+            boundary = os.urandom(16).hex().encode("ascii")
 
         self.boundary = boundary
         self.content_type = "multipart/form-data; boundary=%s" % boundary.decode(


### PR DESCRIPTION
This is a minor refactoring that removes an unnecessary import.
We should aim to remove imports and dependencies wherever possible, and aim for a low-overall complexity.

I'm not including this in the `CHANGELOG` since it's a refactoring rather than a user-visible functional change.