### PR TITLE
hotfix: `urlparse` keep the existing escape string in query

### DIFF
--- a/httpx/_urlparse.py
+++ b/httpx/_urlparse.py
@@ -263,7 +263,7 @@ def urlparse(url: str = "", **kwargs: typing.Optional[str]) -> ParseResult:
     # We also exclude '/' because it is more robust to replace it with a percent
     # encoding despite it not being a requirement of the spec.
     parsed_query: typing.Optional[str] = (
-        None if query is None else quote(query, safe=SUB_DELIMS + ":?[]@")
+        None if query is None else quote(query, safe=SUB_DELIMS + ":?[]@%")
     )
     # For 'fragment' we can include all of the GEN_DELIMS set.
     parsed_fragment: typing.Optional[str] = (

--- a/tests/test_urlparse.py
+++ b/tests/test_urlparse.py
@@ -150,6 +150,11 @@ def test_param_with_existing_escape_requires_encoding():
     assert str(url) == "http://webservice?u=http%3A%2F%2Fexample.com%3Fq%3Dfoo%252Fa"
 
 
+def test_param_with_existing_escape():
+    url = httpx.URL("https://example.com?sig=iGyXM1mSehS4ONN5%2B2GillQ%2BYawyh5EryToDT/Bzf90%3D")
+    assert str(url) == "https://example.com?sig=iGyXM1mSehS4ONN5%2B2GillQ%2BYawyh5EryToDT%2FBzf90%3D"
+
+
 # Tests for invalid URLs
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

https://github.com/encode/httpx/discussions/2844#discussioncomment-7505285




# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
