### PR TITLE
📌 pin httpcore==1.*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "certifi",
-    "httpcore>=1.0.0",
+    "httpcore==1.*",
     "anyio",
     "idna",
     "sniffio",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "certifi",
-    "httpcore",
+    "httpcore>=1.0.0",
     "anyio",
     "idna",
     "sniffio",


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Force httpcore dependency to be above `1.0.0` because `httpx>=0.25.0` is not compatible with `httpcore<0.17.2`.
