### PR TITLE
Pre encoded path/params/fragments should be kept

### DIFF
--- a/httpx/_urlparse.py
+++ b/httpx/_urlparse.py
@@ -258,16 +258,16 @@ def urlparse(url: str = "", **kwargs: typing.Optional[str]) -> ParseResult:
     # specific component.
 
     # For 'path' we need to drop ? and # from the GEN_DELIMS set.
-    parsed_path: str = quote(path, safe=SUB_DELIMS + ":/[]@")
+    parsed_path: str = quote(path, safe=SUB_DELIMS + ":/[]@%")
     # For 'query' we need to drop '#' from the GEN_DELIMS set.
     # We also exclude '/' because it is more robust to replace it with a percent
     # encoding despite it not being a requirement of the spec.
     parsed_query: typing.Optional[str] = (
-        None if query is None else quote(query, safe=SUB_DELIMS + ":?[]@")
+        None if query is None else quote(query, safe=SUB_DELIMS + ":?[]@%")
     )
     # For 'fragment' we can include all of the GEN_DELIMS set.
     parsed_fragment: typing.Optional[str] = (
-        None if fragment is None else quote(fragment, safe=SUB_DELIMS + ":/?#[]@")
+        None if fragment is None else quote(fragment, safe=SUB_DELIMS + ":/?#[]@%")
     )
 
     # The parsed ASCII bytestrings are our canonical form.


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

URL with pre-encoded segments would end up double encoded when parsed by the URL parser. We must consider the % as a safe value, to avoid encoding it here.

Related to comments in #2883
Related #2723
Duplicate #2929

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
