### PR TITLE
Differenctiate between encoded form and element form for url

### DIFF
--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -360,10 +360,10 @@ def test_url_query_encoding():
     and https://github.com/encode/httpx/discussions/2460
     """
     url = httpx.URL("https://www.example.com/?a=b c&d=e/f")
-    assert url.raw_path == b"/?a=b%20c&d=e%2Ff"
+    assert url.raw_path == b"/?a=b%20c&d=e/f"
 
     url = httpx.URL("https://www.example.com/", params={"a": "b c", "d": "e/f"})
-    assert url.raw_path == b"/?a=b%20c&d=e%2Ff"
+    assert url.raw_path == b"/?a=b%20c&d=e/f"
 
 
 def test_url_with_url_encoded_path():


### PR DESCRIPTION

<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

* Allow quote and is_safe to take sets as input to speed up calculations
* Differenciate between reencoding raw url data, and piece wise constructed query parameters
* Revert always encoding of forward slashes in query

Fixes #2883
Pertially reverts: #2721

Related #2723, #2929

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
