### PR TITLE
Reorganise tests in 'test_url.py'

### DIFF
--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -106,6 +106,7 @@ def test_url_invalid_type():
     """
     Ensure that invalid types on `httpx.URL()` raise a `TypeError`.
     """
+
     class ExternalURLClass:  # representing external URL class
         pass
 
@@ -114,6 +115,7 @@ def test_url_invalid_type():
 
 
 # Tests for `QueryParams`.
+
 
 def test_url_params():
     url = httpx.URL("https://example.org:123/path/to/somewhere", params={"a": "123"})
@@ -128,6 +130,7 @@ def test_url_params():
 
 
 # Tests for `URL.join()`.
+
 
 def test_url_join():
     """
@@ -216,6 +219,7 @@ def test_resolution_error_1833():
 
 
 # Tests for `URL.copy_with()`.
+
 
 def test_url_copywith_authority_subcomponents():
     copy_with_kwargs = {
@@ -315,6 +319,7 @@ def test_url_copywith_security():
 # `URL.copy_remove_param()`
 # `URL.copy_merge_params()`
 
+
 def test_url_set_param_manipulation():
     """
     Some basic URL query parameter manipulation.
@@ -348,6 +353,7 @@ def test_url_merge_params_manipulation():
 
 
 # Tests for IDNA hostname support.
+
 
 @pytest.mark.parametrize(
     "given,idna,host,raw_host,scheme,port",
@@ -420,6 +426,7 @@ def test_idna_url(given, idna, host, raw_host, scheme, port):
 
 
 # Tests for IPv6 hostname support.
+
 
 def test_ipv6_url():
     url = httpx.URL("http://[::ffff:192.168.0.1]:5678/")


### PR DESCRIPTION
I would like to deal with https://github.com/encode/httpx/issues/2883.

In order to tackle this comprehensively I'm suggesting we *start by tidying up our existing URL test cases*.
There are two parts to this:

* Reorganise the existing tests in `models/test_url.py` - The current ordering of the tests isn't coherent.
* Remove `test_urlparse.py`, moving test cases into `models/test_url.py` - All the test cases there are now properly against the public `httpx.URL()` interface, tackled previously as part of the #2492.

This pull request deals with the first of these two bullet-points.
I'll follow up with the second part once this is in.

Here's the explanation of the proposed change (assuming I've got it correct 😅)...

* Tests are re-ordered, these no removal, addition, or modifying of test cases.
* Some docstrings have been added.
* Some comments helping claify the structure have been added.

The ordering for the test cases here is...

* General tests for `httpx.URL`.
* General tests for `httpx.QueryParams`.
* Tests for `httpx.URL.join()`.
* Tests for `httpx.URL.copy_with()`.
* Tests for `httpx.URL.copy_<...>.params()` methods.
* Tests for IDNA hostname support.
* Tests for IPv6 hostname support.

