### PR TITLE
Fixing missed arguments for pools when init transports

### DIFF
--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -140,9 +140,9 @@ class HTTPTransport(BaseTransport):
                 keepalive_expiry=limits.keepalive_expiry,
                 http1=http1,
                 http2=http2,
-                uds=uds,
-                local_address=local_address,
                 retries=retries,
+                local_address=local_address,
+                uds=uds,
                 socket_options=socket_options,
             )
         elif proxy.url.scheme in ("http", "https"):
@@ -162,6 +162,9 @@ class HTTPTransport(BaseTransport):
                 keepalive_expiry=limits.keepalive_expiry,
                 http1=http1,
                 http2=http2,
+                retries=retries,
+                local_address=local_address,
+                uds=uds,
                 socket_options=socket_options,
             )
         elif proxy.url.scheme == "socks5":
@@ -187,6 +190,7 @@ class HTTPTransport(BaseTransport):
                 keepalive_expiry=limits.keepalive_expiry,
                 http1=http1,
                 http2=http2,
+                retries=retries,
             )
         else:  # pragma: no cover
             raise ValueError(
@@ -280,9 +284,9 @@ class AsyncHTTPTransport(AsyncBaseTransport):
                 keepalive_expiry=limits.keepalive_expiry,
                 http1=http1,
                 http2=http2,
-                uds=uds,
-                local_address=local_address,
                 retries=retries,
+                local_address=local_address,
+                uds=uds,
                 socket_options=socket_options,
             )
         elif proxy.url.scheme in ("http", "https"):
@@ -301,6 +305,9 @@ class AsyncHTTPTransport(AsyncBaseTransport):
                 keepalive_expiry=limits.keepalive_expiry,
                 http1=http1,
                 http2=http2,
+                retries=retries,
+                local_address=local_address,
+                uds=uds,
                 socket_options=socket_options,
             )
         elif proxy.url.scheme == "socks5":
@@ -326,6 +333,7 @@ class AsyncHTTPTransport(AsyncBaseTransport):
                 keepalive_expiry=limits.keepalive_expiry,
                 http1=http1,
                 http2=http2,
+                retries=retries,
             )
         else:  # pragma: no cover
             raise ValueError(


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

https://github.com/encode/httpx/blob/5b5f6d8e172910371b5901f6e21717097274c513/httpx/_transports/default.py#L258-L330
eg.
* in `AsyncHTTPTransport`, `AsyncConnectionPool` has the argument of retries passed in, but `AsyncHTTPProxy` and `AsyncSOCKSProxy` have not;
* in `HTTPTransport`, it has the same issue.

discussion: https://github.com/encode/httpx/discussions/2988

This also requires a fix in https://github.com/encode/httpcore

# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.