### PR TITLE
Ensure that ASGI 'raw_path' does not include query component of URL.

### DIFF
--- a/httpx/_transports/asgi.py
+++ b/httpx/_transports/asgi.py
@@ -103,7 +103,7 @@ class ASGITransport(AsyncBaseTransport):
             "headers": [(k.lower(), v) for (k, v) in request.headers.raw],
             "scheme": request.url.scheme,
             "path": request.url.path,
-            "raw_path": request.url.raw_path,
+            "raw_path": request.url.raw_path.split(b"?")[0],
             "query_string": request.url.query,
             "server": (request.url.host, request.url.port),
             "client": self.client,

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -121,6 +121,19 @@ async def test_asgi_raw_path():
 
 
 @pytest.mark.anyio
+async def test_asgi_raw_path_should_not_include_querystring_portion():
+    """
+    See https://github.com/encode/httpx/issues/2810
+    """
+    async with httpx.AsyncClient(app=echo_raw_path) as client:
+        url = httpx.URL("http://www.example.org/path?query")
+        response = await client.get(url)
+
+    assert response.status_code == 200
+    assert response.json() == {"raw_path": "/path"}
+
+
+@pytest.mark.anyio
 async def test_asgi_upload():
     async with httpx.AsyncClient(app=echo_body) as client:
         response = await client.post("http://www.example.org/", content=b"example")


### PR DESCRIPTION
Closes #2810.

Update the ASGI transport to ensure that `raw_path` does not include the query component.

The spec was originally a little ambiguous here, and ideally it might have made a little more sense for it to include the query portion, since that way around it'd be a direct representation of the HTTP/1.1 target byte string that was received on the wire. But the spec's been clarified since, and we're not matching that correctly at the moment.