### PR TITLE
Enabling `ruff` C416

### DIFF
--- a/httpx/_content.py
+++ b/httpx/_content.py
@@ -105,7 +105,7 @@ class UnattachedStream(AsyncByteStream, SyncByteStream):
 
 
 def encode_content(
-    content: Union[str, bytes, Iterable[bytes], AsyncIterable[bytes]]
+    content: Union[str, bytes, Iterable[bytes], AsyncIterable[bytes]],
 ) -> Tuple[Dict[str, str], Union[SyncByteStream, AsyncByteStream]]:
     if isinstance(content, (bytes, str)):
         body = content.encode("utf-8") if isinstance(content, str) else content

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -152,7 +152,7 @@ SENSITIVE_HEADERS = {"authorization", "proxy-authorization"}
 
 
 def obfuscate_sensitive_headers(
-    items: typing.Iterable[typing.Tuple[typing.AnyStr, typing.AnyStr]]
+    items: typing.Iterable[typing.Tuple[typing.AnyStr, typing.AnyStr]],
 ) -> typing.Iterator[typing.Tuple[typing.AnyStr, typing.AnyStr]]:
     for k, v in items:
         if to_str(k.lower()) in SENSITIVE_HEADERS:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ replacement = 'src="https://raw.githubusercontent.com/encode/httpx/master/\1"'
 
 # https://beta.ruff.rs/docs/configuration/#using-rufftoml
 [tool.ruff]
-select = ["E", "F", "I", "B", "PIE"]
+select = ["E", "F", "I", "B", "PIE", "C416"]
 ignore = ["B904", "B028"]
 
 [tool.ruff.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ replacement = 'src="https://raw.githubusercontent.com/encode/httpx/master/\1"'
 
 # https://beta.ruff.rs/docs/configuration/#using-rufftoml
 [tool.ruff]
-select = ["E", "F", "I", "B", "PIE", "C416"]
+select = ["E", "F", "I", "B", "PIE"]
 ignore = ["B904", "B028"]
 
 [tool.ruff.isort]

--- a/tests/client/test_redirects.py
+++ b/tests/client/test_redirects.py
@@ -345,7 +345,7 @@ def test_can_stream_if_no_redirect():
 class ConsumeBodyTransport(httpx.MockTransport):
     def handle_request(self, request: httpx.Request) -> httpx.Response:
         assert isinstance(request.stream, httpx.SyncByteStream)
-        [_ for _ in request.stream]
+        list(request.stream)
         return self.handler(request)  # type: ignore[return-value]
 
 

--- a/tests/models/test_requests.py
+++ b/tests/models/test_requests.py
@@ -82,7 +82,7 @@ def test_read_and_stream_data():
     request.read()
     assert request.stream is not None
     assert isinstance(request.stream, typing.Iterable)
-    content = b"".join([part for part in request.stream])
+    content = b"".join(list(request.stream))
     assert content == request.content
 
 

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -397,19 +397,19 @@ def test_iter_raw():
 
 def test_iter_raw_with_chunksize():
     response = httpx.Response(200, content=streaming_body())
-    parts = [part for part in response.iter_raw(chunk_size=5)]
+    parts = list(response.iter_raw(chunk_size=5))
     assert parts == [b"Hello", b", wor", b"ld!"]
 
     response = httpx.Response(200, content=streaming_body())
-    parts = [part for part in response.iter_raw(chunk_size=7)]
+    parts = list(response.iter_raw(chunk_size=7))
     assert parts == [b"Hello, ", b"world!"]
 
     response = httpx.Response(200, content=streaming_body())
-    parts = [part for part in response.iter_raw(chunk_size=13)]
+    parts = list(response.iter_raw(chunk_size=13))
     assert parts == [b"Hello, world!"]
 
     response = httpx.Response(200, content=streaming_body())
-    parts = [part for part in response.iter_raw(chunk_size=20)]
+    parts = list(response.iter_raw(chunk_size=20))
     assert parts == [b"Hello, world!"]
 
 
@@ -422,7 +422,7 @@ def test_iter_raw_doesnt_return_empty_chunks():
 
     response = httpx.Response(200, content=streaming_body_with_empty_chunks())
 
-    parts = [part for part in response.iter_raw()]
+    parts = list(response.iter_raw())
     assert parts == [b"Hello, ", b"world!"]
 
 
@@ -445,7 +445,7 @@ def test_iter_raw_on_async():
     )
 
     with pytest.raises(RuntimeError):
-        [part for part in response.iter_raw()]
+        list(response.iter_raw())
 
 
 def test_close_on_async():
@@ -538,21 +538,21 @@ def test_iter_bytes():
 
 def test_iter_bytes_with_chunk_size():
     response = httpx.Response(200, content=streaming_body())
-    parts = [part for part in response.iter_bytes(chunk_size=5)]
+    parts = list(response.iter_bytes(chunk_size=5))
     assert parts == [b"Hello", b", wor", b"ld!"]
 
     response = httpx.Response(200, content=streaming_body())
-    parts = [part for part in response.iter_bytes(chunk_size=13)]
+    parts = list(response.iter_bytes(chunk_size=13))
     assert parts == [b"Hello, world!"]
 
     response = httpx.Response(200, content=streaming_body())
-    parts = [part for part in response.iter_bytes(chunk_size=20)]
+    parts = list(response.iter_bytes(chunk_size=20))
     assert parts == [b"Hello, world!"]
 
 
 def test_iter_bytes_with_empty_response():
     response = httpx.Response(200, content=b"")
-    parts = [part for part in response.iter_bytes()]
+    parts = list(response.iter_bytes())
     assert parts == []
 
 
@@ -565,7 +565,7 @@ def test_iter_bytes_doesnt_return_empty_chunks():
 
     response = httpx.Response(200, content=streaming_body_with_empty_chunks())
 
-    parts = [part for part in response.iter_bytes()]
+    parts = list(response.iter_bytes())
     assert parts == [b"Hello, ", b"world!"]
 
 
@@ -611,23 +611,23 @@ def test_iter_text():
 
 def test_iter_text_with_chunk_size():
     response = httpx.Response(200, content=b"Hello, world!")
-    parts = [part for part in response.iter_text(chunk_size=5)]
+    parts = list(response.iter_text(chunk_size=5))
     assert parts == ["Hello", ", wor", "ld!"]
 
     response = httpx.Response(200, content=b"Hello, world!!")
-    parts = [part for part in response.iter_text(chunk_size=7)]
+    parts = list(response.iter_text(chunk_size=7))
     assert parts == ["Hello, ", "world!!"]
 
     response = httpx.Response(200, content=b"Hello, world!")
-    parts = [part for part in response.iter_text(chunk_size=7)]
+    parts = list(response.iter_text(chunk_size=7))
     assert parts == ["Hello, ", "world!"]
 
     response = httpx.Response(200, content=b"Hello, world!")
-    parts = [part for part in response.iter_text(chunk_size=13)]
+    parts = list(response.iter_text(chunk_size=13))
     assert parts == ["Hello, world!"]
 
     response = httpx.Response(200, content=b"Hello, world!")
-    parts = [part for part in response.iter_text(chunk_size=20)]
+    parts = list(response.iter_text(chunk_size=20))
     assert parts == ["Hello, world!"]
 
 
@@ -664,7 +664,7 @@ def test_iter_lines():
         200,
         content=b"Hello,\nworld!",
     )
-    content = [line for line in response.iter_lines()]
+    content = list(response.iter_lines())
     assert content == ["Hello,", "world!"]
 
 

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -15,7 +15,7 @@ async def test_empty_content():
     assert isinstance(request.stream, httpx.SyncByteStream)
     assert isinstance(request.stream, httpx.AsyncByteStream)
 
-    sync_content = b"".join([part for part in request.stream])
+    sync_content = b"".join(list(request.stream))
     async_content = b"".join([part async for part in request.stream])
 
     assert request.headers == {"Host": "www.example.com", "Content-Length": "0"}
@@ -29,7 +29,7 @@ async def test_bytes_content():
     assert isinstance(request.stream, typing.Iterable)
     assert isinstance(request.stream, typing.AsyncIterable)
 
-    sync_content = b"".join([part for part in request.stream])
+    sync_content = b"".join(list(request.stream))
     async_content = b"".join([part async for part in request.stream])
 
     assert request.headers == {"Host": "www.example.com", "Content-Length": "13"}
@@ -42,7 +42,7 @@ async def test_bytes_content():
     assert isinstance(request.stream, typing.Iterable)
     assert isinstance(request.stream, typing.AsyncIterable)
 
-    sync_content = b"".join([part for part in request.stream])
+    sync_content = b"".join(list(request.stream))
     async_content = b"".join([part async for part in request.stream])
 
     assert request.headers == {"Host": "www.example.com", "Content-Length": "13"}
@@ -56,7 +56,7 @@ async def test_bytesio_content():
     assert isinstance(request.stream, typing.Iterable)
     assert not isinstance(request.stream, typing.AsyncIterable)
 
-    content = b"".join([part for part in request.stream])
+    content = b"".join(list(request.stream))
 
     assert request.headers == {"Host": "www.example.com", "Content-Length": "13"}
     assert content == b"Hello, world!"
@@ -100,7 +100,7 @@ async def test_iterator_content():
     assert isinstance(request.stream, typing.Iterable)
     assert not isinstance(request.stream, typing.AsyncIterable)
 
-    content = b"".join([part for part in request.stream])
+    content = b"".join(list(request.stream))
 
     assert request.headers == {
         "Host": "www.example.com",
@@ -109,7 +109,7 @@ async def test_iterator_content():
     assert content == b"Hello, world!"
 
     with pytest.raises(httpx.StreamConsumed):
-        [part for part in request.stream]
+        list(request.stream)
 
     # Support 'data' for compat with requests.
     with pytest.warns(DeprecationWarning):
@@ -117,7 +117,7 @@ async def test_iterator_content():
     assert isinstance(request.stream, typing.Iterable)
     assert not isinstance(request.stream, typing.AsyncIterable)
 
-    content = b"".join([part for part in request.stream])
+    content = b"".join(list(request.stream))
 
     assert request.headers == {
         "Host": "www.example.com",
@@ -168,7 +168,7 @@ async def test_json_content():
     assert isinstance(request.stream, typing.Iterable)
     assert isinstance(request.stream, typing.AsyncIterable)
 
-    sync_content = b"".join([part for part in request.stream])
+    sync_content = b"".join(list(request.stream))
     async_content = b"".join([part async for part in request.stream])
 
     assert request.headers == {
@@ -186,7 +186,7 @@ async def test_urlencoded_content():
     assert isinstance(request.stream, typing.Iterable)
     assert isinstance(request.stream, typing.AsyncIterable)
 
-    sync_content = b"".join([part for part in request.stream])
+    sync_content = b"".join(list(request.stream))
     async_content = b"".join([part async for part in request.stream])
 
     assert request.headers == {
@@ -204,7 +204,7 @@ async def test_urlencoded_boolean():
     assert isinstance(request.stream, typing.Iterable)
     assert isinstance(request.stream, typing.AsyncIterable)
 
-    sync_content = b"".join([part for part in request.stream])
+    sync_content = b"".join(list(request.stream))
     async_content = b"".join([part async for part in request.stream])
 
     assert request.headers == {
@@ -222,7 +222,7 @@ async def test_urlencoded_none():
     assert isinstance(request.stream, typing.Iterable)
     assert isinstance(request.stream, typing.AsyncIterable)
 
-    sync_content = b"".join([part for part in request.stream])
+    sync_content = b"".join(list(request.stream))
     async_content = b"".join([part async for part in request.stream])
 
     assert request.headers == {
@@ -240,7 +240,7 @@ async def test_urlencoded_list():
     assert isinstance(request.stream, typing.Iterable)
     assert isinstance(request.stream, typing.AsyncIterable)
 
-    sync_content = b"".join([part for part in request.stream])
+    sync_content = b"".join(list(request.stream))
     async_content = b"".join([part async for part in request.stream])
 
     assert request.headers == {
@@ -265,7 +265,7 @@ async def test_multipart_files_content():
     assert isinstance(request.stream, typing.Iterable)
     assert isinstance(request.stream, typing.AsyncIterable)
 
-    sync_content = b"".join([part for part in request.stream])
+    sync_content = b"".join(list(request.stream))
     async_content = b"".join([part async for part in request.stream])
 
     assert request.headers == {
@@ -304,7 +304,7 @@ async def test_multipart_data_and_files_content():
     assert isinstance(request.stream, typing.Iterable)
     assert isinstance(request.stream, typing.AsyncIterable)
 
-    sync_content = b"".join([part for part in request.stream])
+    sync_content = b"".join(list(request.stream))
     async_content = b"".join([part async for part in request.stream])
 
     assert request.headers == {
@@ -348,7 +348,7 @@ async def test_empty_request():
     assert isinstance(request.stream, typing.Iterable)
     assert isinstance(request.stream, typing.AsyncIterable)
 
-    sync_content = b"".join([part for part in request.stream])
+    sync_content = b"".join(list(request.stream))
     async_content = b"".join([part async for part in request.stream])
 
     assert request.headers == {"Host": "www.example.com", "Content-Length": "0"}
@@ -375,7 +375,7 @@ async def test_multipart_multiple_files_single_input_content():
     assert isinstance(request.stream, typing.Iterable)
     assert isinstance(request.stream, typing.AsyncIterable)
 
-    sync_content = b"".join([part for part in request.stream])
+    sync_content = b"".join(list(request.stream))
     async_content = b"".join([part async for part in request.stream])
 
     assert request.headers == {
@@ -421,7 +421,7 @@ async def test_response_empty_content():
     assert isinstance(response.stream, typing.Iterable)
     assert isinstance(response.stream, typing.AsyncIterable)
 
-    sync_content = b"".join([part for part in response.stream])
+    sync_content = b"".join(list(response.stream))
     async_content = b"".join([part async for part in response.stream])
 
     assert response.headers == {}
@@ -435,7 +435,7 @@ async def test_response_bytes_content():
     assert isinstance(response.stream, typing.Iterable)
     assert isinstance(response.stream, typing.AsyncIterable)
 
-    sync_content = b"".join([part for part in response.stream])
+    sync_content = b"".join(list(response.stream))
     async_content = b"".join([part async for part in response.stream])
 
     assert response.headers == {"Content-Length": "13"}
@@ -453,13 +453,13 @@ async def test_response_iterator_content():
     assert isinstance(response.stream, typing.Iterable)
     assert not isinstance(response.stream, typing.AsyncIterable)
 
-    content = b"".join([part for part in response.stream])
+    content = b"".join(list(response.stream))
 
     assert response.headers == {"Transfer-Encoding": "chunked"}
     assert content == b"Hello, world!"
 
     with pytest.raises(httpx.StreamConsumed):
-        [part for part in response.stream]
+        list(response.stream)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
# Summary

I decided to decompose my PR on incorporating `itertools.chain` a bit, and some of it can be automated by [C416](https://docs.astral.sh/ruff/rules/unnecessary-comprehension/). So this PR enables [C416](https://docs.astral.sh/ruff/rules/unnecessary-comprehension/) in `ruff` to simplify code.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
