### PR TITLE
Using `itertools.chain` and `yield from` in `Response.iter_`

### DIFF
--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -659,25 +659,16 @@ async def test_aiter_text_with_chunk_size():
     assert parts == ["Hello, world!"]
 
 
-def test_iter_lines():
-    response = httpx.Response(
-        200,
-        content=b"Hello,\nworld!",
-    )
+def test_iter_lines() -> None:
+    response = httpx.Response(200, content=b"Hello,\nworld!")
     content = list(response.iter_lines())
     assert content == ["Hello,", "world!"]
 
 
 @pytest.mark.anyio
-async def test_aiter_lines():
-    response = httpx.Response(
-        200,
-        content=b"Hello,\nworld!",
-    )
-
-    content = []
-    async for line in response.aiter_lines():
-        content.append(line)
+async def test_aiter_lines() -> None:
+    response = httpx.Response(200, content=b"Hello,\nworld!")
+    content = [line async for line in response.aiter_lines()]
     assert content == ["Hello,", "world!"]
 
 


### PR DESCRIPTION
# Summary

Minor refactor of `_models` to use `yield from` and `itertools.chain` where possible.  This has two benefits:

- Removes several `pragma: no cover` comments
- Reduces `_models` by about 20 lines

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
