### PR TITLE
Adding ability to raise_for_status with response text rather than generic text

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -70,7 +70,7 @@
   * The amount of time elapsed between sending the request and calling `close()` on the corresponding response received for that request.
   [total_seconds()](https://docs.python.org/3/library/datetime.html#datetime.timedelta.total_seconds) to correctly get
   the total elapsed seconds.
-* `def .raise_for_status()` - **Response**
+* `def .raise_for_status([use_response_text])` - **Response**
 * `def .json()` - **Any**
 * `def .read()` - **bytes**
 * `def .iter_raw([chunk_size])` - **bytes iterator**

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -721,7 +721,7 @@ class Response:
             and "Location" in self.headers
         )
 
-    def raise_for_status(self) -> "Response":
+    def raise_for_status(self, use_response_text: bool = False) -> "Response":
         """
         Raise the `HTTPStatusError` if one occurred.
         """
@@ -734,6 +734,9 @@ class Response:
 
         if self.is_success:
             return self
+
+        if use_response_text:
+            raise HTTPStatusError(self.text, request=request, response=self)
 
         if self.has_redirect_location:
             message = (

--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -126,6 +126,16 @@ async def test_raise_for_status(server):
 
 
 @pytest.mark.anyio
+async def test_raise_for_status_with_text(server):
+    async with httpx.AsyncClient() as client:
+        response = await client.request("GET", server.url.copy_with(path="/status/500"))
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            response.raise_for_status(True)
+
+        assert str(exc_info.value) == "Hello, world!"
+
+
+@pytest.mark.anyio
 async def test_options(server):
     async with httpx.AsyncClient() as client:
         response = await client.options(server.url)

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -144,6 +144,14 @@ def test_raise_for_status(server):
                 assert response.raise_for_status() is response
 
 
+def test_raise_for_status_with_text(server):
+    with httpx.Client() as client:
+        response = client.request("GET", server.url.copy_with(path="/status/404"))
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            response.raise_for_status(True)
+        assert str(exc_info.value) == "Hello, world!"
+
+
 def test_options(server):
     with httpx.Client() as client:
         response = client.options(server.url)

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -139,6 +139,14 @@ def test_raise_for_status():
         "For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500"
     )
 
+    # Use the text from the server if use_response_text is True
+    response = httpx.Response(422, request=request, text="ID is required")
+    assert response.is_client_error
+    assert response.is_error
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        response.raise_for_status(True)
+    assert str(exc_info.value) == "ID is required"
+
     # Calling .raise_for_status without setting a request instance is
     # not valid. Should raise a runtime error.
     response = httpx.Response(200)


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

If a response has information in it that is helpful for the client, then I think that text from the response should be the message in the exception that is raised, not some generic "4xx and 5xx are bad" messages.

For example, today, as I'm using `httpx` against a service I own, I keep getting `422` errors.  In the response is the information that I need to debug, so I want to see that in the error thrown.  For example, a response might say:

```
422: startDate is required
```

```
429: You have surpassed your quota for the day.  If you feel this is in error, please see: xyz.com
```

I recognize that I can get this information if I don't want to use `raise_for_status`, but it is my pattern to write code like:

```python
httpx.get(url).raise_for_status().json()
```

And that is just so convenient.  After this MR, in order to get the text from the response, I can just:

```python
httpx.get(url).raise_for_status(True).json()
```

I have kept the default behavior as-is, with the ability to change it with this boolean flag.  I would think a lot, if not most, people would want this behavior.

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
