### PR TITLE
`types-certifi` and `types-chardet` are no longer needed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@
 # Optional charset auto-detection
 # Used in our test cases
 chardet==5.2.0
-types-chardet==5.0.4.5
 
 # Documentation
 mkdocs==1.5.3
@@ -22,7 +21,6 @@ twine==4.0.2
 coverage[toml]==7.3.0
 cryptography==41.0.7
 mypy==1.5.1
-types-certifi==2021.10.8.2
 pytest==7.4.3
 ruff==0.1.6
 trio==0.22.2


### PR DESCRIPTION
# Summary

Both `certifi` and `chardet` now contains typing info so we no longer need `types-certifi` and `types-chardet`.
See also https://github.com/encode/httpx/discussions/3014

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
