### PR TITLE
Keep clients in sync

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -598,6 +598,8 @@ class Client(BaseClient):
     to authenticate the client. Either a path to an SSL certificate file, or
     two-tuple of (certificate file, key file), or a three-tuple of (certificate
     file, key file, password).
+    * **http2** - *(optional)* A boolean indicating if HTTP/2 support should be
+    enabled. Defaults to `False`.
     * **proxy** - *(optional)* A proxy URL where all the traffic should be routed.
     * **proxies** - *(optional)* A dictionary mapping proxy keys to proxy
     URLs.
@@ -1311,6 +1313,8 @@ class AsyncClient(BaseClient):
     An asynchronous HTTP client, with connection pooling, HTTP/2, redirects,
     cookie persistence, etc.
 
+    It can be shared between threads.
+
     Usage:
 
     ```python
@@ -1544,6 +1548,15 @@ class AsyncClient(BaseClient):
 
         [0]: /advanced/#merging-of-configuration
         """
+
+        if cookies is not None:
+            message = (
+                "Setting per-request cookies=<...> is being deprecated, because "
+                "the expected behaviour on cookie persistence is ambiguous. Set "
+                "cookies directly on the client instance instead."
+            )
+            warnings.warn(message, DeprecationWarning)
+
         request = self.build_request(
             method=method,
             url=url,
@@ -1656,7 +1669,7 @@ class AsyncClient(BaseClient):
 
             return response
 
-        except BaseException as exc:  # pragma: no cover
+        except BaseException as exc:
             await response.aclose()
             raise exc
 

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -1549,7 +1549,7 @@ class AsyncClient(BaseClient):
         [0]: /advanced/#merging-of-configuration
         """
 
-        if cookies is not None:
+        if cookies is not None:  # pragma: no cover
             message = (
                 "Setting per-request cookies=<...> is being deprecated, because "
                 "the expected behaviour on cookie persistence is ambiguous. Set "

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -1313,7 +1313,7 @@ class AsyncClient(BaseClient):
     An asynchronous HTTP client, with connection pooling, HTTP/2, redirects,
     cookie persistence, etc.
 
-    It can be shared between threads.
+    It can be shared between tasks.
 
     Usage:
 


### PR DESCRIPTION
Except for the async/await syntax, `AsyncClient` and `Client` are supposed to be the same.

I isolated them into separate files and used `git diff --no-index --word-diff asyncclient.py syncclient.py` to find and fix differences.