### PR TITLE
Types: Fix type annotation for default_encoding parameter

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -172,7 +172,7 @@ class BaseClient:
         event_hooks: None | (typing.Mapping[str, list[EventHook]]) = None,
         base_url: URLTypes = "",
         trust_env: bool = True,
-        default_encoding: str | typing.Callable[[bytes], str] = "utf-8",
+        default_encoding: str | typing.Callable[[bytes], str | None] = "utf-8",
     ) -> None:
         event_hooks = {} if event_hooks is None else event_hooks
 
@@ -638,7 +638,7 @@ class Client(BaseClient):
         transport: BaseTransport | None = None,
         app: typing.Callable[..., typing.Any] | None = None,
         trust_env: bool = True,
-        default_encoding: str | typing.Callable[[bytes], str] = "utf-8",
+        default_encoding: str | typing.Callable[[bytes], str | None] = "utf-8",
     ) -> None:
         super().__init__(
             auth=auth,
@@ -1377,7 +1377,7 @@ class AsyncClient(BaseClient):
         transport: AsyncBaseTransport | None = None,
         app: typing.Callable[..., typing.Any] | None = None,
         trust_env: bool = True,
-        default_encoding: str | typing.Callable[[bytes], str] = "utf-8",
+        default_encoding: str | typing.Callable[[bytes], str | None] = "utf-8",
     ) -> None:
         super().__init__(
             auth=auth,

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -458,7 +458,7 @@ class Response:
         request: Request | None = None,
         extensions: ResponseExtensions | None = None,
         history: list[Response] | None = None,
-        default_encoding: str | typing.Callable[[bytes], str] = "utf-8",
+        default_encoding: str | typing.Callable[[bytes], str | None] = "utf-8",
     ) -> None:
         self.status_code = status_code
         self.headers = Headers(headers)


### PR DESCRIPTION
The default encoding function is allowed to return None, in which case
the encoding property of httpx.Response defaults to utf-8.

The example in https://www.python-httpx.org/advanced/#using-character-set-auto-detection
that passes a default_encoding function uses a function that may return None.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
