### PR TITLE
Support cookies with value `None`

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -1010,7 +1010,7 @@ class Response:
                 await self.stream.aclose()
 
 
-class Cookies(typing.MutableMapping[str, str | None]):
+class Cookies(typing.MutableMapping[str, typing.Optional[str]]):
     """
     HTTP Cookies, as a mutable mapping.
     """

--- a/tests/models/test_cookies.py
+++ b/tests/models/test_cookies.py
@@ -30,6 +30,16 @@ def test_cookies_update():
     assert cookies.get("name", domain="example.com") == "value"
 
 
+def test_cookie_value_can_be_none():
+    cookies = httpx.Cookies()
+    more_cookies = httpx.Cookies()
+    more_cookies.set("no-value", None, domain="example.com")
+
+    cookies.update(more_cookies)
+    assert dict(cookies) == {"no-value": None}
+    assert cookies.get("no-value", domain="example.com") is None
+
+
 def test_cookies_with_domain():
     cookies = httpx.Cookies()
     cookies.set("name", "value", domain="example.com")
@@ -91,8 +101,18 @@ def test_cookies_repr():
     cookies = httpx.Cookies()
     cookies.set(name="foo", value="bar", domain="http://blah.com")
     cookies.set(name="fizz", value="buzz", domain="http://hello.com")
+    cookies.set(name="only-name", value=None, domain="http://hello.com")
 
     assert repr(cookies) == (
         "<Cookies[<Cookie foo=bar for http://blah.com />,"
-        " <Cookie fizz=buzz for http://hello.com />]>"
+        " <Cookie fizz=buzz for http://hello.com />,"
+        " <Cookie only-name=None for http://hello.com />]>"
     )
+
+
+def test_cookie_headers():
+    cookies = httpx.Cookies()
+    cookies.set("foo", "bar", domain="example.org")
+    cookies.set("no-value", None, domain="example.org")
+    request = httpx.Request("GET", "https://www.example.org", cookies=cookies)
+    assert request.headers["cookie"] == "foo=bar; no-value"

--- a/tests/models/test_cookies.py
+++ b/tests/models/test_cookies.py
@@ -30,6 +30,12 @@ def test_cookies_update():
     assert cookies.get("name", domain="example.com") == "value"
 
 
+def test_get_missing_cookie_raises_exception():
+    cookies = httpx.Cookies()
+    with pytest.raises(KeyError):
+        cookies["missing"]
+
+
 def test_cookie_value_can_be_none():
     cookies = httpx.Cookies()
     more_cookies = httpx.Cookies()
@@ -37,7 +43,7 @@ def test_cookie_value_can_be_none():
 
     cookies.update(more_cookies)
     assert dict(cookies) == {"no-value": None}
-    assert cookies.get("no-value", domain="example.com") is None
+    assert cookies["no-value"] is None
 
 
 def test_cookies_with_domain():


### PR DESCRIPTION
# Summary

There are 3 kinds of request cookie headers.
```py
request = httpx.Request("GET", "https://www.example.org", cookies=cookies)
request.headers["cookie"]  # <== This is the request cookie header we are talking about here
```

### `"name=value"`

This is the classic case, already supported through : 
```py
cookies.set(name="name", value="value", domain="example.org")
```

### `"name="`

Please note the trailing `=` sign here.
This is also supported, by passing an empty string as the cookie value :
```py
cookies.set(name="name", value="", domain="example.org")
```

### `"name"`

Please note there is **no** trailing `=` sign here.
This is not officially supported (yet), but can be achieved with :
```py
cookies.set(name="name", value=None, domain="example.org")
```

It works because the [cookie jar implementation](https://github.com/python/cpython/blob/0e4f73b8e457b1efa57b735205e8e85a3d11d9f2/Lib/http/cookiejar.py#L1335-L1336) in the standard library already deals with it.
Contrary to the `httpx.Cookies.set` method, the standard `Cookie` [doesn't define strict typing](https://github.com/python/cpython/blob/0e4f73b8e457b1efa57b735205e8e85a3d11d9f2/Lib/http/cookiejar.py#L761-L772) for the `value`.

So this PR changes the `httpx._models` in order to support a cookie `value` which is `None`.
Otherwise the typing is incorrect, forcing the `httpx` to add a `# type: ignore` instruction.

The getter functions had to be updated as well, as the `None` was considered as a not found value.

2 new test cases are added in this PR to ensure the proper behavior.

# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [X] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
