### PR TITLE
Define and expose the API from the same place

### DIFF
--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -1,48 +1,15 @@
 from .__version__ import __description__, __title__, __version__
-from ._api import delete, get, head, options, patch, post, put, request, stream
-from ._auth import Auth, BasicAuth, DigestAuth, NetRCAuth
-from ._client import USE_CLIENT_DEFAULT, AsyncClient, Client
-from ._config import Limits, Proxy, Timeout, create_ssl_context
-from ._content import ByteStream
-from ._exceptions import (
-    CloseError,
-    ConnectError,
-    ConnectTimeout,
-    CookieConflict,
-    DecodingError,
-    HTTPError,
-    HTTPStatusError,
-    InvalidURL,
-    LocalProtocolError,
-    NetworkError,
-    PoolTimeout,
-    ProtocolError,
-    ProxyError,
-    ReadError,
-    ReadTimeout,
-    RemoteProtocolError,
-    RequestError,
-    RequestNotRead,
-    ResponseNotRead,
-    StreamClosed,
-    StreamConsumed,
-    StreamError,
-    TimeoutException,
-    TooManyRedirects,
-    TransportError,
-    UnsupportedProtocol,
-    WriteError,
-    WriteTimeout,
-)
-from ._models import Cookies, Headers, Request, Response
-from ._status_codes import codes
-from ._transports.asgi import ASGITransport
-from ._transports.base import AsyncBaseTransport, BaseTransport
-from ._transports.default import AsyncHTTPTransport, HTTPTransport
-from ._transports.mock import MockTransport
-from ._transports.wsgi import WSGITransport
-from ._types import AsyncByteStream, SyncByteStream
-from ._urls import URL, QueryParams
+from ._api import *
+from ._auth import *
+from ._client import *
+from ._config import *
+from ._content import *
+from ._exceptions import *
+from ._models import *
+from ._status_codes import *
+from ._transports import *
+from ._types import *
+from ._urls import *
 
 try:
     from ._main import main

--- a/httpx/_api.py
+++ b/httpx/_api.py
@@ -22,6 +22,18 @@ from ._types import (
     VerifyTypes,
 )
 
+__all__ = [
+    "delete",
+    "get",
+    "head",
+    "options",
+    "patch",
+    "post",
+    "put",
+    "request",
+    "stream",
+]
+
 
 def request(
     method: str,

--- a/httpx/_auth.py
+++ b/httpx/_auth.py
@@ -16,6 +16,9 @@ if typing.TYPE_CHECKING:  # pragma: no cover
     from hashlib import _Hash
 
 
+__all__ = ["Auth", "BasicAuth", "DigestAuth", "NetRCAuth"]
+
+
 class Auth:
     """
     Base class for all authentication schemes.

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -58,6 +58,8 @@ from ._utils import (
     same_origin,
 )
 
+__all__ = ["USE_CLIENT_DEFAULT", "AsyncClient", "Client"]
+
 # The type annotation for @classmethod and context managers here follows PEP 484
 # https://www.python.org/dev/peps/pep-0484/#annotating-instance-and-class-methods
 T = typing.TypeVar("T", bound="Client")

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -14,6 +14,8 @@ from ._types import CertTypes, HeaderTypes, TimeoutTypes, URLTypes, VerifyTypes
 from ._urls import URL
 from ._utils import get_ca_bundle_from_env
 
+__all__ = ["Limits", "Proxy", "Timeout", "create_ssl_context"]
+
 DEFAULT_CIPHERS = ":".join(
     [
         "ECDHE+AESGCM",

--- a/httpx/_content.py
+++ b/httpx/_content.py
@@ -25,6 +25,8 @@ from ._types import (
 )
 from ._utils import peek_filelike_length, primitive_value_to_str
 
+__all__ = ["ByteStream"]
+
 
 class ByteStream(AsyncByteStream, SyncByteStream):
     def __init__(self, stream: bytes) -> None:

--- a/httpx/_exceptions.py
+++ b/httpx/_exceptions.py
@@ -38,6 +38,37 @@ import typing
 if typing.TYPE_CHECKING:
     from ._models import Request, Response  # pragma: no cover
 
+__all__ = [
+    "CloseError",
+    "ConnectError",
+    "ConnectTimeout",
+    "CookieConflict",
+    "DecodingError",
+    "HTTPError",
+    "HTTPStatusError",
+    "InvalidURL",
+    "LocalProtocolError",
+    "NetworkError",
+    "PoolTimeout",
+    "ProtocolError",
+    "ProxyError",
+    "ReadError",
+    "ReadTimeout",
+    "RemoteProtocolError",
+    "RequestError",
+    "RequestNotRead",
+    "ResponseNotRead",
+    "StreamClosed",
+    "StreamConsumed",
+    "StreamError",
+    "TimeoutException",
+    "TooManyRedirects",
+    "TransportError",
+    "UnsupportedProtocol",
+    "WriteError",
+    "WriteTimeout",
+]
+
 
 class HTTPError(Exception):
     """

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -53,6 +53,8 @@ from ._utils import (
     parse_header_links,
 )
 
+__all__ = ["Cookies", "Headers", "Request", "Response"]
+
 
 class Headers(typing.MutableMapping[str, str]):
     """

--- a/httpx/_status_codes.py
+++ b/httpx/_status_codes.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from enum import IntEnum
 
+__all__ = ["codes"]
+
 
 class codes(IntEnum):
     """HTTP status codes and reason phrases

--- a/httpx/_transports/__init__.py
+++ b/httpx/_transports/__init__.py
@@ -1,0 +1,15 @@
+from .asgi import *
+from .base import *
+from .default import *
+from .mock import *
+from .wsgi import *
+
+__all__ = [
+    "ASGITransport",
+    "AsyncBaseTransport",
+    "BaseTransport",
+    "AsyncHTTPTransport",
+    "HTTPTransport",
+    "MockTransport",
+    "WSGITransport",
+]

--- a/httpx/_transports/asgi.py
+++ b/httpx/_transports/asgi.py
@@ -25,6 +25,8 @@ _ASGIApp = typing.Callable[
     [typing.Dict[str, typing.Any], _Receive, _Send], typing.Coroutine[None, None, None]
 ]
 
+__all__ = ["ASGITransport"]
+
 
 def create_event() -> Event:
     if sniffio.current_async_library() == "trio":

--- a/httpx/_transports/base.py
+++ b/httpx/_transports/base.py
@@ -8,6 +8,8 @@ from .._models import Request, Response
 T = typing.TypeVar("T", bound="BaseTransport")
 A = typing.TypeVar("A", bound="AsyncBaseTransport")
 
+__all__ = ["AsyncBaseTransport", "BaseTransport"]
+
 
 class BaseTransport:
     def __enter__(self: T) -> T:

--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -62,6 +62,8 @@ SOCKET_OPTION = typing.Union[
     typing.Tuple[int, int, None, int],
 ]
 
+__all__ = ["AsyncHTTPTransport", "HTTPTransport"]
+
 
 @contextlib.contextmanager
 def map_httpcore_exceptions() -> typing.Iterator[None]:

--- a/httpx/_transports/mock.py
+++ b/httpx/_transports/mock.py
@@ -9,6 +9,9 @@ SyncHandler = typing.Callable[[Request], Response]
 AsyncHandler = typing.Callable[[Request], typing.Coroutine[None, None, Response]]
 
 
+__all__ = ["MockTransport"]
+
+
 class MockTransport(AsyncBaseTransport, BaseTransport):
     def __init__(self, handler: SyncHandler | AsyncHandler) -> None:
         self.handler = handler

--- a/httpx/_transports/wsgi.py
+++ b/httpx/_transports/wsgi.py
@@ -16,6 +16,9 @@ if typing.TYPE_CHECKING:
 _T = typing.TypeVar("_T")
 
 
+__all__ = ["WSGITransport"]
+
+
 def _skip_leading_empty_chunks(body: typing.Iterable[_T]) -> typing.Iterable[_T]:
     body = iter(body)
     for chunk in body:

--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -108,6 +108,8 @@ RequestFiles = Union[Mapping[str, FileTypes], Sequence[Tuple[str, FileTypes]]]
 
 RequestExtensions = MutableMapping[str, Any]
 
+__all__ = ["AsyncByteStream", "SyncByteStream"]
+
 
 class SyncByteStream:
     def __iter__(self) -> Iterator[bytes]:

--- a/httpx/_urls.py
+++ b/httpx/_urls.py
@@ -9,6 +9,8 @@ from ._types import QueryParamTypes, RawURL, URLTypes
 from ._urlparse import urlencode, urlparse
 from ._utils import primitive_value_to_str
 
+__all__ = ["URL", "QueryParams"]
+
 
 class URL:
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,9 @@ ignore = ["B904", "B028"]
 [tool.ruff.isort]
 combine-as-imports = true
 
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F403", "F405"]
+
 [tool.mypy]
 ignore_missing_imports = true
 strict = true

--- a/tests/test_exported_members.py
+++ b/tests/test_exported_members.py
@@ -3,16 +3,6 @@ import httpx
 
 def test_all_imports_are_exported() -> None:
     included_private_members = ["__description__", "__title__", "__version__"]
-    print(
-        sorted(
-            (
-                member
-                for member in vars(httpx).keys()
-                if not member.startswith("_") or member in included_private_members
-            ),
-            key=str.casefold,
-        )
-    )
     assert httpx.__all__ == sorted(
         (
             member

--- a/tests/test_exported_members.py
+++ b/tests/test_exported_members.py
@@ -3,6 +3,16 @@ import httpx
 
 def test_all_imports_are_exported() -> None:
     included_private_members = ["__description__", "__title__", "__version__"]
+    print(
+        sorted(
+            (
+                member
+                for member in vars(httpx).keys()
+                if not member.startswith("_") or member in included_private_members
+            ),
+            key=str.casefold,
+        )
+    )
     assert httpx.__all__ == sorted(
         (
             member


### PR DESCRIPTION
This is a little refactor of our import strategy.

Now the main `__init__.py` file contains a lot of imports to deliver the public API that we want to expose in httpx.
It's actually working perfectly, but we can make it even simpler by splitting that logic and exposing the API from each module.

So in each module, we should define the variable `__all__`, which will contain the names of the classes that we want to expose at one level higher.

And each time we want to introduce a new public API, we will just modify the variable `__all__` from the module that class belongs to, rather than modifying the main `__init__.py` module of the httpx library.
