### PR TITLE
fix docs basic authentication typo

### DIFF
--- a/docs/advanced/authentication.md
+++ b/docs/advanced/authentication.md
@@ -1,7 +1,7 @@
 Authentication can either be included on a per-request basis...
 
 ```pycon
->>> auth = httpx.BasicAuthentication(username="username", password="secret")
+>>> auth = httpx.BasicAuth(username="username", password="secret")
 >>> client = httpx.Client()
 >>> response = client.get("https://www.example.com/", auth=auth)
 ```
@@ -9,7 +9,7 @@ Authentication can either be included on a per-request basis...
 Or configured on the client instance, ensuring that all outgoing requests will include authentication credentials...
 
 ```pycon
->>> auth = httpx.BasicAuthentication(username="username", password="secret")
+>>> auth = httpx.BasicAuth(username="username", password="secret")
 >>> client = httpx.Client(auth=auth)
 >>> response = client.get("https://www.example.com/")
 ```
@@ -19,7 +19,7 @@ Or configured on the client instance, ensuring that all outgoing requests will i
 HTTP basic authentication is an unencrypted authentication scheme that uses a simple encoding of the username and password in the request `Authorization` header. Since it is unencrypted it should typically only be used over `https`, although this is not strictly enforced.
 
 ```pycon
->>> auth = httpx.BasicAuthentication(username="finley", password="secret")
+>>> auth = httpx.BasicAuth(username="finley", password="secret")
 >>> client = httpx.Client(auth=auth)
 >>> response = client.get("https://httpbin.org/basic-auth/finley/secret")
 >>> response


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Fix docs basic authentication typo

```python shell
>>> httpx.__version__
'0.27.0'
>>> httpx.BasicAuthentication
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'httpx' has no attribute 'BasicAuthentication'
>>> httpx.BasicAuth
<class 'httpx.BasicAuth'>
>>> 
```

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
