### PR TITLE
Fix client.send() timeout when used with a new Request instance

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -562,6 +562,15 @@ class BaseClient:
 
         return request.stream
 
+    def _set_timeout(self, request: Request) -> None:
+        if "timeout" not in request.extensions:
+            timeout = (
+                self.timeout
+                if isinstance(self.timeout, UseClientDefault)
+                else Timeout(self.timeout)
+            )
+            request.extensions = dict(**request.extensions, timeout=timeout.as_dict())
+
 
 class Client(BaseClient):
     """
@@ -910,6 +919,8 @@ class Client(BaseClient):
             if isinstance(follow_redirects, UseClientDefault)
             else follow_redirects
         )
+
+        self._set_timeout(request)
 
         auth = self._build_request_auth(request, auth)
 
@@ -1657,6 +1668,8 @@ class AsyncClient(BaseClient):
             if isinstance(follow_redirects, UseClientDefault)
             else follow_redirects
         )
+
+        self._set_timeout(request)
 
         auth = self._build_request_auth(request, auth)
 

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -42,3 +42,14 @@ async def test_pool_timeout(server):
         with pytest.raises(httpx.PoolTimeout):
             async with client.stream("GET", server.url):
                 await client.get(server.url)
+
+
+@pytest.mark.anyio
+async def test_async_client_new_request_send_timeout(server):
+    timeout = httpx.Timeout(1e-6)
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        with pytest.raises(httpx.TimeoutException):
+            await client.send(
+                httpx.Request("GET", server.url.copy_with(path="/slow_response"))
+            )


### PR DESCRIPTION
# Summary

Discussion here https://github.com/encode/httpx/discussions/3110

On `httpx.client.send()`, now the timeout of the request is set if not set already.
This is for cases in which `httpx.client.send()` is used with `httpx.Request()` instead of `client.build_request()`

I expected timeout tests for the non-async client too. But since there are only async tests I didn't create a non-async test.

I didn't think a documentation change was needed since this is (for me) the expect behavior.

# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [X] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
