### PR TITLE
Stricter data typechecking

### DIFF
--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -200,7 +200,7 @@ async def test_urlencoded_content():
 
 @pytest.mark.anyio
 async def test_urlencoded_boolean():
-    request = httpx.Request(method, url, data={"example": True})
+    request = httpx.Request(method, url, data={"true": True, "false": False})
     assert isinstance(request.stream, typing.Iterable)
     assert isinstance(request.stream, typing.AsyncIterable)
 
@@ -209,11 +209,11 @@ async def test_urlencoded_boolean():
 
     assert request.headers == {
         "Host": "www.example.com",
-        "Content-Length": "12",
+        "Content-Length": "21",
         "Content-Type": "application/x-www-form-urlencoded",
     }
-    assert sync_content == b"example=true"
-    assert async_content == b"example=true"
+    assert sync_content == b"true=true&false=false"
+    assert async_content == b"true=true&false=false"
 
 
 @pytest.mark.anyio
@@ -250,6 +250,21 @@ async def test_urlencoded_list():
     }
     assert sync_content == b"example=a&example=1&example=true"
     assert async_content == b"example=a&example=1&example=true"
+
+
+def test_urlencoded_invalid_key():
+    with pytest.raises(TypeError) as e:
+        httpx.Request(method, url, data={123: "value"})  # type: ignore
+    assert str(e.value) == "Request data keys must be str. Got type 'int'."
+
+
+def test_urlencoded_invalid_value():
+    with pytest.raises(TypeError) as e:
+        httpx.Request(method, url, data={"key": {"this": "ain't json, buddy"}})
+    assert str(e.value) == (
+        "Request data values must be str, int, float, bool, or None. "
+        "Got type 'dict' for key 'key'."
+    )
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Closes #3127

Before...

```python
>>> import httpx
>>> data = {"key": {"this": "ain't json, buddy"}}
>>> r = httpx.post("https://www.example.com", data=data)
>>> r.request.content
b'key=%7B%27this%27%3A+%22ain%27t+json%2C+buddy%22%7D'
```

After...

```python
>>> import httpx
>>> data = {"key": {"this": "ain't json, buddy"}}
>>> r = httpx.post("https://www.example.com", data=data)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/tom.christie/GitHub/encode/httpx/httpx/_api.py", line 331, in post
    return request(
  File "/Users/tom.christie/GitHub/encode/httpx/httpx/_api.py", line 118, in request
    return client.request(
  File "/Users/tom.christie/GitHub/encode/httpx/httpx/_client.py", line 825, in request
    request = self.build_request(
  File "/Users/tom.christie/GitHub/encode/httpx/httpx/_client.py", line 359, in build_request
    return Request(
  File "/Users/tom.christie/GitHub/encode/httpx/httpx/_models.py", line 342, in __init__
    headers, stream = encode_request(
  File "/Users/tom.christie/GitHub/encode/httpx/httpx/_content.py", line 235, in encode_request
    return encode_urlencoded_data(data)
  File "/Users/tom.christie/GitHub/encode/httpx/httpx/_content.py", line 167, in encode_urlencoded_data
    plain_data.append(_coerce_type(key, value))
  File "/Users/tom.christie/GitHub/encode/httpx/httpx/_content.py", line 153, in _coerce_type
    raise TypeError(
TypeError: Request data values must be str, int, float, bool, or None. Got type 'dict' for key 'key'.
```

I've not changed any type signatures here, and aimed to keep the PR as focused as possible.

Ideally we should be following up with more comprehensive documentation on the behaviour of `content=..., data=..., files=..., json=...`.