### PR TITLE
Added __iadd__ magic method to Cookies class

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -1173,6 +1173,14 @@ class Cookies(typing.MutableMapping[str, str]):
         )
 
         return f"<Cookies[{cookies_repr}]>"
+    
+    def __iadd__(self, other):
+        if isinstance(other, self.__class__):
+            self._cookies.update(other._cookies)
+        else:
+            raise ValueError("Cannot add a non-Cookies instance.")
+
+        return self
 
     class _CookieCompatRequest(urllib.request.Request):
         """


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

I have added  __iadd__ magic method to the Cookies class 
Now we got a new interface to update cookies rather than the update method

## simple usage

```bash
from httpx import Cookies, get

cookies = Cookies()
r = httpx.get('example.com")
cookies += r.cookies
print(cookies)
```

Now 'cookies' contains the cookies from the response 'r'
You can use 'cookies' in subsequent requests