### PR TITLE
Update URL.__init__ signature in API docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -114,7 +114,7 @@ what gets sent over the wire.*
 'example.org'
 ```
 
-* `def __init__(url, allow_relative=False, params=None)`
+* `def __init__(url, **kwargs)`
 * `.scheme` - **str**
 * `.authority` - **str**
 * `.host` - **str**


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Update `URL.__init__()` signature in the API documentation.

Since version 0.14.0 (August 7th, 2020), via #1073, the `allow_relative` parameter is no longer supported. I removed it and left `**kwargs`. Let me know if you prefer to display the allowed `kwargs` instead.

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
