### PR TITLE
Removed leading $ from cli code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ and async APIs**.
 Install HTTPX using pip:
 
 ```shell
-$ pip install httpx
+pip install httpx
 ```
 
 Now, let's get started:
@@ -43,7 +43,7 @@ Now, let's get started:
 Or, using the command-line client.
 
 ```shell
-$ pip install 'httpx[cli]'  # The command line client is an optional dependency.
+pip install 'httpx[cli]'  # The command line client is an optional dependency.
 ```
 
 Which now allows us to use HTTPX directly from the command-line...
@@ -94,13 +94,13 @@ Plus all the standard features of `requests`...
 Install with pip:
 
 ```shell
-$ pip install httpx
+pip install httpx
 ```
 
 Or, to include the optional HTTP/2 support, use:
 
 ```shell
-$ pip install httpx[http2]
+pip install httpx[http2]
 ```
 
 HTTPX requires Python 3.8+.

--- a/docs/advanced/proxies.md
+++ b/docs/advanced/proxies.md
@@ -73,7 +73,7 @@ This is an optional feature that requires an additional third-party library be i
 You can install SOCKS support using `pip`:
 
 ```shell
-$ pip install httpx[socks]
+pip install httpx[socks]
 ```
 
 You can now configure a client to make requests via a proxy using the SOCKS protocol:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -46,14 +46,14 @@ Then clone your fork with the following command replacing `YOUR-USERNAME` with
 your GitHub username:
 
 ```shell
-$ git clone https://github.com/YOUR-USERNAME/httpx
+git clone https://github.com/YOUR-USERNAME/httpx
 ```
 
 You can now install the project and its dependencies using:
 
 ```shell
-$ cd httpx
-$ scripts/install
+cd httpx
+scripts/install
 ```
 
 ## Testing and Linting
@@ -64,7 +64,7 @@ and documentation building workflow.
 To run the tests, use:
 
 ```shell
-$ scripts/test
+scripts/test
 ```
 
 !!! warning
@@ -76,19 +76,19 @@ Any additional arguments will be passed to `pytest`. See the [pytest documentati
 For example, to run a single test script:
 
 ```shell
-$ scripts/test tests/test_multipart.py
+scripts/test tests/test_multipart.py
 ```
 
 To run the code auto-formatting:
 
 ```shell
-$ scripts/lint
+scripts/lint
 ```
 
 Lastly, to run code checks separately (they are also run as part of `scripts/test`), run:
 
 ```shell
-$ scripts/check
+scripts/check
 ```
 
 ## Documenting
@@ -98,7 +98,7 @@ Documentation pages are located under the `docs/` folder.
 To run the documentation site locally (useful for previewing changes), use:
 
 ```shell
-$ scripts/docs
+scripts/docs
 ```
 
 ## Resolving Build / CI Failures
@@ -122,7 +122,7 @@ This job failing means there is either a code formatting issue or type-annotatio
 You can look at the job output to figure out why it's failed or within a shell run:
 
 ```shell
-$ scripts/check
+scripts/check
 ```
 
 It may be worth it to run `$ scripts/lint` to attempt auto-formatting the code

--- a/docs/http2.md
+++ b/docs/http2.md
@@ -28,7 +28,7 @@ trying out our HTTP/2 support. You can do so by first making sure to install
 the optional HTTP/2 dependencies...
 
 ```shell
-$ pip install httpx[http2]
+pip install httpx[http2]
 ```
 
 And then instantiating a client with HTTP/2 support enabled:

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ HTTPX is a fully featured HTTP client for Python 3, which provides sync and asyn
 Install HTTPX using pip:
 
 ```shell
-$ pip install httpx
+pip install httpx
 ```
 
 Now, let's get started:
@@ -50,7 +50,7 @@ Or, using the command-line client.
 
 ```shell
 # The command line client is an optional dependency.
-$ pip install 'httpx[cli]'
+pip install 'httpx[cli]'
 ```
 
 Which now allows us to use HTTPX directly from the command-line...
@@ -130,19 +130,19 @@ inspiration around the lower-level networking details.
 Install with pip:
 
 ```shell
-$ pip install httpx
+pip install httpx
 ```
 
 Or, to include the optional HTTP/2 support, use:
 
 ```shell
-$ pip install httpx[http2]
+pip install httpx[http2]
 ```
 
 To include the optional brotli and zstandard decoders support, use:
 
 ```shell
-$ pip install httpx[brotli,zstd]
+pip install httpx[brotli,zstd]
 ```
 
 HTTPX requires Python 3.8+


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

This fix would reduce typing when copying cli codes from the docs. Now you can just click the copy button then without any modify to paste to your cli.

For example, if the cli code comes with a $, when I copied it I need remove the leading $ in my cli.

The normal code blocks are not changed. :)

Hope this could improve the experience.

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
