### PR TITLE
Drop `anyio` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "certifi",
-    "httpcore==1.*",
-    "anyio",
+    "httpcore[asyncio]>=1",
     "idna",
     "sniffio",
 ]


### PR DESCRIPTION
It is currently used indirectly by httpcore's _asyncio_ feature.
There is no usage of `anyio` in httpx's codebase.
