### PR TITLE
Add An Importable `default_user_agent` Function

### DIFF
--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -48,6 +48,7 @@ __all__ = [
     "Cookies",
     "create_ssl_context",
     "DecodingError",
+    "default_user_agent",
     "delete",
     "DigestAuth",
     "get",

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -58,7 +58,7 @@ from ._utils import (
     same_origin,
 )
 
-__all__ = ["USE_CLIENT_DEFAULT", "AsyncClient", "Client"]
+__all__ = ["USE_CLIENT_DEFAULT", "AsyncClient", "Client", "default_user_agent"]
 
 # The type annotation for @classmethod and context managers here follows PEP 484
 # https://www.python.org/dev/peps/pep-0484/#annotating-instance-and-class-methods
@@ -91,10 +91,16 @@ USE_CLIENT_DEFAULT = UseClientDefault()
 
 logger = logging.getLogger("httpx")
 
-USER_AGENT = f"python-httpx/{__version__}"
 ACCEPT_ENCODING = ", ".join(
     [key for key in SUPPORTED_DECODERS.keys() if key != "identity"]
 )
+
+
+def default_user_agent() -> str:
+    """
+    Return the default User-Agent string.
+    """
+    return f"python-httpx/{__version__}"
 
 
 class ClientState(enum.Enum):
@@ -290,7 +296,7 @@ class BaseClient:
                 b"Accept": b"*/*",
                 b"Accept-Encoding": ACCEPT_ENCODING.encode("ascii"),
                 b"Connection": b"keep-alive",
-                b"User-Agent": USER_AGENT.encode("ascii"),
+                b"User-Agent": default_user_agent().encode("ascii"),
             }
         )
         client_headers.update(headers)


### PR DESCRIPTION
# Summary
This PR adds a `default_user_agent` function (corresponding to [requests.utils.default_user_agent](https://github.com/psf/requests/blob/main/src/requests/utils.py#L891-L897)) and allows it to be imported using `from httpx import default_user_agent` to allow different projects to check what user-agent should be expected by default from the clients they're using (for unit-tests, for example).

This value existed as a constant variable named `USER_AGENT` (accessible only using `httpx._client.USER_AGENT`) which I didn't necessarily have to convert to a function, but I thought it would be better as a function both because it will be implemented similarly to `requests`, and because it will allow more flexibility in the future, in case it will need to be dynamically calculated (changing it to a function from a variable if needed in the future will break backwards compatibility).

Don't think this change requires any unit-tests or docs to be updated (didn't find any matching section), but if you think it does, let me know and I'll try to add those.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
