### PR TITLE
Clean up URL signature.

### DIFF
--- a/httpx/_api.py
+++ b/httpx/_api.py
@@ -18,9 +18,9 @@ from ._types import (
     RequestData,
     RequestFiles,
     TimeoutTypes,
-    URLTypes,
     VerifyTypes,
 )
+from ._urls import URL
 
 __all__ = [
     "delete",
@@ -37,7 +37,7 @@ __all__ = [
 
 def request(
     method: str,
-    url: URLTypes,
+    url: URL | str,
     *,
     params: QueryParamTypes | None = None,
     content: RequestContent | None = None,
@@ -132,7 +132,7 @@ def request(
 @contextmanager
 def stream(
     method: str,
-    url: URLTypes,
+    url: URL | str,
     *,
     params: QueryParamTypes | None = None,
     content: RequestContent | None = None,
@@ -185,7 +185,7 @@ def stream(
 
 
 def get(
-    url: URLTypes,
+    url: URL | str,
     *,
     params: QueryParamTypes | None = None,
     headers: HeaderTypes | None = None,
@@ -225,7 +225,7 @@ def get(
 
 
 def options(
-    url: URLTypes,
+    url: URL | str,
     *,
     params: QueryParamTypes | None = None,
     headers: HeaderTypes | None = None,
@@ -265,7 +265,7 @@ def options(
 
 
 def head(
-    url: URLTypes,
+    url: URL | str,
     *,
     params: QueryParamTypes | None = None,
     headers: HeaderTypes | None = None,
@@ -305,7 +305,7 @@ def head(
 
 
 def post(
-    url: URLTypes,
+    url: URL | str,
     *,
     content: RequestContent | None = None,
     data: RequestData | None = None,
@@ -350,7 +350,7 @@ def post(
 
 
 def put(
-    url: URLTypes,
+    url: URL | str,
     *,
     content: RequestContent | None = None,
     data: RequestData | None = None,
@@ -395,7 +395,7 @@ def put(
 
 
 def patch(
-    url: URLTypes,
+    url: URL | str,
     *,
     content: RequestContent | None = None,
     data: RequestData | None = None,
@@ -440,7 +440,7 @@ def patch(
 
 
 def delete(
-    url: URLTypes,
+    url: URL | str,
     *,
     params: QueryParamTypes | None = None,
     headers: HeaderTypes | None = None,

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -46,7 +46,6 @@ from ._types import (
     RequestFiles,
     SyncByteStream,
     TimeoutTypes,
-    URLTypes,
     VerifyTypes,
 )
 from ._urls import URL, QueryParams
@@ -172,7 +171,7 @@ class BaseClient:
         follow_redirects: bool = False,
         max_redirects: int = DEFAULT_MAX_REDIRECTS,
         event_hooks: None | (typing.Mapping[str, list[EventHook]]) = None,
-        base_url: URLTypes = "",
+        base_url: URL | str = "",
         trust_env: bool = True,
         default_encoding: str | typing.Callable[[bytes], str] = "utf-8",
     ) -> None:
@@ -273,7 +272,7 @@ class BaseClient:
         return self._base_url
 
     @base_url.setter
-    def base_url(self, url: URLTypes) -> None:
+    def base_url(self, url: URL | str) -> None:
         self._base_url = self._enforce_trailing_slash(URL(url))
 
     @property
@@ -321,7 +320,7 @@ class BaseClient:
     def build_request(
         self,
         method: str,
-        url: URLTypes,
+        url: URL | str,
         *,
         content: RequestContent | None = None,
         data: RequestData | None = None,
@@ -369,7 +368,7 @@ class BaseClient:
             extensions=extensions,
         )
 
-    def _merge_url(self, url: URLTypes) -> URL:
+    def _merge_url(self, url: URL | str) -> URL:
         """
         Merge a URL argument together with any 'base_url' on the client,
         to create the URL used for the outgoing request.
@@ -645,7 +644,7 @@ class Client(BaseClient):
         limits: Limits = DEFAULT_LIMITS,
         max_redirects: int = DEFAULT_MAX_REDIRECTS,
         event_hooks: None | (typing.Mapping[str, list[EventHook]]) = None,
-        base_url: URLTypes = "",
+        base_url: URL | str = "",
         transport: BaseTransport | None = None,
         app: typing.Callable[..., typing.Any] | None = None,
         trust_env: bool = True,
@@ -784,7 +783,7 @@ class Client(BaseClient):
     def request(
         self,
         method: str,
-        url: URLTypes,
+        url: URL | str,
         *,
         content: RequestContent | None = None,
         data: RequestData | None = None,
@@ -841,7 +840,7 @@ class Client(BaseClient):
     def stream(
         self,
         method: str,
-        url: URLTypes,
+        url: URL | str,
         *,
         content: RequestContent | None = None,
         data: RequestData | None = None,
@@ -1049,7 +1048,7 @@ class Client(BaseClient):
 
     def get(
         self,
-        url: URLTypes,
+        url: URL | str,
         *,
         params: QueryParamTypes | None = None,
         headers: HeaderTypes | None = None,
@@ -1078,7 +1077,7 @@ class Client(BaseClient):
 
     def options(
         self,
-        url: URLTypes,
+        url: URL | str,
         *,
         params: QueryParamTypes | None = None,
         headers: HeaderTypes | None = None,
@@ -1107,7 +1106,7 @@ class Client(BaseClient):
 
     def head(
         self,
-        url: URLTypes,
+        url: URL | str,
         *,
         params: QueryParamTypes | None = None,
         headers: HeaderTypes | None = None,
@@ -1136,7 +1135,7 @@ class Client(BaseClient):
 
     def post(
         self,
-        url: URLTypes,
+        url: URL | str,
         *,
         content: RequestContent | None = None,
         data: RequestData | None = None,
@@ -1173,7 +1172,7 @@ class Client(BaseClient):
 
     def put(
         self,
-        url: URLTypes,
+        url: URL | str,
         *,
         content: RequestContent | None = None,
         data: RequestData | None = None,
@@ -1210,7 +1209,7 @@ class Client(BaseClient):
 
     def patch(
         self,
-        url: URLTypes,
+        url: URL | str,
         *,
         content: RequestContent | None = None,
         data: RequestData | None = None,
@@ -1247,7 +1246,7 @@ class Client(BaseClient):
 
     def delete(
         self,
-        url: URLTypes,
+        url: URL | str,
         *,
         params: QueryParamTypes | None = None,
         headers: HeaderTypes | None = None,
@@ -1392,7 +1391,7 @@ class AsyncClient(BaseClient):
         limits: Limits = DEFAULT_LIMITS,
         max_redirects: int = DEFAULT_MAX_REDIRECTS,
         event_hooks: None | (typing.Mapping[str, list[EventHook]]) = None,
-        base_url: URLTypes = "",
+        base_url: URL | str = "",
         transport: AsyncBaseTransport | None = None,
         app: typing.Callable[..., typing.Any] | None = None,
         trust_env: bool = True,
@@ -1531,7 +1530,7 @@ class AsyncClient(BaseClient):
     async def request(
         self,
         method: str,
-        url: URLTypes,
+        url: URL | str,
         *,
         content: RequestContent | None = None,
         data: RequestData | None = None,
@@ -1589,7 +1588,7 @@ class AsyncClient(BaseClient):
     async def stream(
         self,
         method: str,
-        url: URLTypes,
+        url: URL | str,
         *,
         content: RequestContent | None = None,
         data: RequestData | None = None,
@@ -1797,7 +1796,7 @@ class AsyncClient(BaseClient):
 
     async def get(
         self,
-        url: URLTypes,
+        url: URL | str,
         *,
         params: QueryParamTypes | None = None,
         headers: HeaderTypes | None = None,
@@ -1826,7 +1825,7 @@ class AsyncClient(BaseClient):
 
     async def options(
         self,
-        url: URLTypes,
+        url: URL | str,
         *,
         params: QueryParamTypes | None = None,
         headers: HeaderTypes | None = None,
@@ -1855,7 +1854,7 @@ class AsyncClient(BaseClient):
 
     async def head(
         self,
-        url: URLTypes,
+        url: URL | str,
         *,
         params: QueryParamTypes | None = None,
         headers: HeaderTypes | None = None,
@@ -1884,7 +1883,7 @@ class AsyncClient(BaseClient):
 
     async def post(
         self,
-        url: URLTypes,
+        url: URL | str,
         *,
         content: RequestContent | None = None,
         data: RequestData | None = None,
@@ -1921,7 +1920,7 @@ class AsyncClient(BaseClient):
 
     async def put(
         self,
-        url: URLTypes,
+        url: URL | str,
         *,
         content: RequestContent | None = None,
         data: RequestData | None = None,
@@ -1958,7 +1957,7 @@ class AsyncClient(BaseClient):
 
     async def patch(
         self,
-        url: URLTypes,
+        url: URL | str,
         *,
         content: RequestContent | None = None,
         data: RequestData | None = None,
@@ -1995,7 +1994,7 @@ class AsyncClient(BaseClient):
 
     async def delete(
         self,
-        url: URLTypes,
+        url: URL | str,
         *,
         params: QueryParamTypes | None = None,
         headers: HeaderTypes | None = None,

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -10,7 +10,7 @@ import certifi
 
 from ._compat import set_minimum_tls_version_1_2
 from ._models import Headers
-from ._types import CertTypes, HeaderTypes, TimeoutTypes, URLTypes, VerifyTypes
+from ._types import CertTypes, HeaderTypes, TimeoutTypes, VerifyTypes
 from ._urls import URL
 from ._utils import get_ca_bundle_from_env
 
@@ -325,7 +325,7 @@ class Limits:
 class Proxy:
     def __init__(
         self,
-        url: URLTypes,
+        url: URL | str,
         *,
         ssl_context: ssl.SSLContext | None = None,
         auth: tuple[str, str] | None = None,

--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -43,8 +43,6 @@ RawURL = NamedTuple(
     ],
 )
 
-URLTypes = Union["URL", str]
-
 QueryParamTypes = Union[
     "QueryParams",
     Mapping[str, Union[PrimitiveData, Sequence[PrimitiveData]]],
@@ -78,8 +76,8 @@ TimeoutTypes = Union[
     Tuple[Optional[float], Optional[float], Optional[float], Optional[float]],
     "Timeout",
 ]
-ProxyTypes = Union[URLTypes, "Proxy"]
-ProxiesTypes = Union[ProxyTypes, Dict[URLTypes, Union[None, ProxyTypes]]]
+ProxyTypes = Union["URL", str, "Proxy"]
+ProxiesTypes = Union[ProxyTypes, Dict[Union["URL", str], Union[None, ProxyTypes]]]
 
 AuthTypes = Union[
     Tuple[Union[str, bytes], Union[str, bytes]],

--- a/httpx/_urls.py
+++ b/httpx/_urls.py
@@ -5,7 +5,7 @@ from urllib.parse import parse_qs, unquote
 
 import idna
 
-from ._types import QueryParamTypes, RawURL, URLTypes
+from ._types import QueryParamTypes, RawURL
 from ._urlparse import urlencode, urlparse
 from ._utils import primitive_value_to_str
 
@@ -367,7 +367,7 @@ class URL:
     def copy_merge_params(self, params: QueryParamTypes) -> URL:
         return self.copy_with(params=self.params.merge(params))
 
-    def join(self, url: URLTypes) -> URL:
+    def join(self, url: URL | str) -> URL:
         """
         Return an absolute URL, using this URL as the base.
 


### PR DESCRIPTION
Refs https://github.com/encode/httpx/issues/3176#issuecomment-2068231852

Our public methods currently include a shortcut type `URLTypes`, which is not public API.
This refactoring removes the shortcut type in favor of explicit typing.

There are also other similar cases, tho one this is an easy refactoring to demonstrate.