### PR TITLE
Reintroduce `URLTypes`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.27.2 (27th August, 2024)
+
+### Fixed
+
+* Reintroduced supposedly-private `URLTypes` shortcut. (#2673)
+
 ## 0.27.1 (27th August, 2024)
 
-## Added
+### Added
 
 * Support for `zstd` content decoding using the python `zstandard` package is added. Installable using `httpx[zstd]`. (#3139)
 

--- a/httpx/__version__.py
+++ b/httpx/__version__.py
@@ -1,3 +1,3 @@
 __title__ = "httpx"
 __description__ = "A next generation HTTP client, for Python 3."
-__version__ = "0.27.1"
+__version__ = "0.27.2"

--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -43,6 +43,8 @@ RawURL = NamedTuple(
     ],
 )
 
+URLTypes = Union["URL", str]
+
 QueryParamTypes = Union[
     "QueryParams",
     Mapping[str, Union[PrimitiveData, Sequence[PrimitiveData]]],


### PR DESCRIPTION
See https://github.com/encode/httpx/discussions/3287.

I guess we want to roll a minor point release based on this.
