### PR TITLE
Add support for custom JSON encoders/decoders.

### DIFF
--- a/docs/advanced/json.md
+++ b/docs/advanced/json.md
@@ -1,0 +1,27 @@
+# JSON encoding/decoding
+
+You can set a custom json encoder and decoder, e.g. if you want to use `msgspec` instead or python's `json` implementation.
+
+Your custom function needs to return `bytes`. 
+
+
+**Custom msgspec implementation:**
+```python
+import httpx
+import msgspec
+import typing
+
+
+encoder = msgspec.json.Encoder()
+def custom_json_encoder(json_data: typing.Any) -> bytes:
+    return encoder.encode(json_data)
+
+httpx.register_json_encoder(custom_json_encoder)
+
+
+decoder = msgspec.json.Decoder()
+def custom_json_decoder(json_data: bytes, **kwargs) -> bytes:
+    return decoder.decode(json_data)
+
+httpx.register_json_decoder(custom_json_decoder)
+```

--- a/docs/advanced/json.md
+++ b/docs/advanced/json.md
@@ -5,6 +5,26 @@ You can set a custom json encoder and decoder, e.g. if you want to use `msgspec`
 Your custom function needs to return `bytes`. 
 
 
+**Custom orjson implementation:**
+```python
+import httpx
+import orjson
+import typing
+
+
+def custom_json_encoder(json_data: typing.Any) -> bytes:
+    return orjson.dumps(json_data)
+
+httpx.register_json_encoder(custom_json_encoder)
+
+
+def custom_json_decoder(json_data: bytes, **kwargs: typing.Any) -> bytes:
+    return orjson.loads(json_data)
+
+httpx.register_json_decoder(custom_json_decoder)
+```
+
+
 **Custom msgspec implementation:**
 ```python
 import httpx
@@ -20,8 +40,9 @@ httpx.register_json_encoder(custom_json_encoder)
 
 
 decoder = msgspec.json.Decoder()
-def custom_json_decoder(json_data: bytes, **kwargs) -> bytes:
+def custom_json_decoder(json_data: bytes, **kwargs: typing.Any) -> bytes:
     return decoder.decode(json_data)
 
 httpx.register_json_decoder(custom_json_decoder)
 ```
+

--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -74,6 +74,8 @@ __all__ = [
     "QueryParams",
     "ReadError",
     "ReadTimeout",
+    "register_json_decoder",
+    "register_json_encoder",
     "RemoteProtocolError",
     "request",
     "Request",

--- a/httpx/_content.py
+++ b/httpx/_content.py
@@ -41,7 +41,7 @@ def register_json_encoder(
     json_encode_callable: Callable[[Any], bytes],
 ) -> None:
     global json_encoder
-    json_encoder = json_encode_callable
+    json_encoder = json_encode_callable  # type: ignore
 
 
 def register_json_decoder(
@@ -51,7 +51,7 @@ def register_json_decoder(
     ],
 ) -> None:
     global json_decoder
-    json_decoder = json_decode_callable
+    json_decoder = json_decode_callable  # type: ignore
 
 
 class ByteStream(AsyncByteStream, SyncByteStream):

--- a/httpx/_content.py
+++ b/httpx/_content.py
@@ -7,10 +7,10 @@ from typing import (
     Any,
     AsyncIterable,
     AsyncIterator,
+    Callable,
     Iterable,
     Iterator,
     Mapping,
-    Callable,
 )
 from urllib.parse import urlencode
 
@@ -29,16 +29,27 @@ from ._utils import peek_filelike_length, primitive_value_to_str
 __all__ = ["ByteStream", "register_json_decoder", "register_json_encoder"]
 
 
-json_encoder = lambda json_data: json_dumps(json_data).encode("utf-8")
-json_decoder = lambda json_data, **kwargs: json_loads(json_data, **kwargs)
+def json_encoder(json_data: Any) -> bytes:
+    return json_dumps(json_data).encode("utf-8")
 
 
-def register_json_encoder(json_encode_callable: Callable) -> None:
+def json_decoder(json_data: bytes, **kwargs: Any) -> Any:
+    return json_loads(json_data, **kwargs)
+
+
+def register_json_encoder(
+    json_encode_callable: Callable[[Any], bytes],
+) -> None:
     global json_encoder
     json_encoder = json_encode_callable
 
 
-def register_json_decoder(json_decode_callable: Callable) -> None:
+def register_json_decoder(
+    json_decode_callable: Callable[
+        [bytes, Any],
+        Any,
+    ],
+) -> None:
     global json_decoder
     json_decoder = json_decode_callable
 
@@ -148,7 +159,7 @@ def encode_content(
     raise TypeError(f"Unexpected type for 'content', {type(content)!r}")
 
 
-def decode_json(json_data: bytes, **kwargs) -> Any:
+def decode_json(json_data: bytes, **kwargs: Any) -> Any:
     return json_decoder(json_data, **kwargs)
 
 

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -10,9 +10,9 @@ from http.cookiejar import Cookie, CookieJar
 from ._content import (
     ByteStream,
     UnattachedStream,
+    decode_json,
     encode_request,
     encode_response,
-    decode_json,
 )
 from ._decoders import (
     SUPPORTED_DECODERS,

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -2,13 +2,18 @@ from __future__ import annotations
 
 import datetime
 import email.message
-import json as jsonlib
 import typing
 import urllib.request
 from collections.abc import Mapping
 from http.cookiejar import Cookie, CookieJar
 
-from ._content import ByteStream, UnattachedStream, encode_request, encode_response
+from ._content import (
+    ByteStream,
+    UnattachedStream,
+    encode_request,
+    encode_response,
+    decode_json,
+)
 from ._decoders import (
     SUPPORTED_DECODERS,
     ByteChunker,
@@ -763,7 +768,7 @@ class Response:
         raise HTTPStatusError(message, request=request, response=self)
 
     def json(self, **kwargs: typing.Any) -> typing.Any:
-        return jsonlib.loads(self.content, **kwargs)
+        return decode_json(self.content, **kwargs)
 
     @property
     def cookies(self) -> Cookies:

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -199,7 +199,7 @@ def test_json_content_register_custom_encoder():
 def test_json_content_register_custom_decoder():
     try:
 
-        def test_decoder(json_content, **kwargs):
+        def test_decoder(json_content: bytes, **kwargs: typing.Any) -> typing.Any:
             raise Exception("Decoder raise")
 
         httpx.register_json_decoder(test_decoder)

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -202,7 +202,7 @@ def test_json_content_register_custom_decoder():
         def test_decoder(json_content: bytes, **kwargs: typing.Any) -> typing.Any:
             raise Exception("Decoder raise")
 
-        httpx.register_json_decoder(test_decoder)
+        httpx.register_json_decoder(test_decoder)  # type: ignore
 
         with pytest.raises(Exception, match="Decoder raise"):
             response = httpx.Response(200, content='{"Hello": "world!"}')

--- a/tests/test_exported_members.py
+++ b/tests/test_exported_members.py
@@ -2,7 +2,7 @@ import httpx
 
 
 def test_all_imports_are_exported() -> None:
-    included_private_members = ["__description__", "__title__", "__version__"]
+    included_private_members = {"__description__", "__title__", "__version__"}
     assert httpx.__all__ == sorted(
         (
             member


### PR DESCRIPTION
# Summary
Added customizable JSON encoder/decoder.

Working example (also provided in docs):

```python
import httpx
import msgspec
import typing


encoder = msgspec.json.Encoder()
def custom_json_encoder(json_data: typing.Any) -> bytes:
    return encoder.encode(json_data)

httpx.register_json_encoder(custom_json_encoder)


decoder = msgspec.json.Decoder()
def custom_json_decoder(json_data: bytes, **kwargs: Any) -> bytes:
    return decoder.decode(json_data)

httpx.register_json_decoder(custom_json_decoder)
```

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
