### PR TITLE
Fix for #3301: raise an explicit TypeError if `cert` type is unsupported

### DIFF
--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -191,6 +191,8 @@ class SSLConfig:
                     keyfile=self.cert[1],
                     password=self.cert[2],
                 )
+            else:
+                raise TypeError(f"Unsupported type for `cert` (must be 'str' or 'tuple')")
 
 
 class Timeout:

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -192,7 +192,9 @@ class SSLConfig:
                     password=self.cert[2],
                 )
             else:
-                raise TypeError(f"Unsupported type for `cert` (must be 'str' or 'tuple')")
+                raise TypeError(
+                    "Unsupported type for `cert` (must be 'str' or 'tuple')"
+                )
 
 
 class Timeout:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -79,6 +79,12 @@ def test_load_ssl_config_cert_without_key_raises(cert_pem_file):
     with pytest.raises(ssl.SSLError):
         httpx.create_ssl_context(cert=cert_pem_file)
 
+def test_load_ssl_config_with_unsupported_cert_types():
+    with pytest.raises(TypeError):
+        httpx.create_ssl_context(cert=Path("some_path"))
+
+    with pytest.raises(TypeError):
+        httpx.create_ssl_context(cert=42)
 
 def test_load_ssl_config_no_verify():
     context = httpx.create_ssl_context(verify=False)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -82,10 +82,10 @@ def test_load_ssl_config_cert_without_key_raises(cert_pem_file):
 
 def test_load_ssl_config_with_unsupported_cert_types():
     with pytest.raises(TypeError):
-        httpx.create_ssl_context(cert=Path("some_path"))
+        httpx.create_ssl_context(cert=Path("some_path"))  # type: ignore
 
     with pytest.raises(TypeError):
-        httpx.create_ssl_context(cert=42)
+        httpx.create_ssl_context(cert=42)  # type: ignore
 
 
 def test_load_ssl_config_no_verify():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -79,12 +79,14 @@ def test_load_ssl_config_cert_without_key_raises(cert_pem_file):
     with pytest.raises(ssl.SSLError):
         httpx.create_ssl_context(cert=cert_pem_file)
 
+
 def test_load_ssl_config_with_unsupported_cert_types():
     with pytest.raises(TypeError):
         httpx.create_ssl_context(cert=Path("some_path"))
 
     with pytest.raises(TypeError):
         httpx.create_ssl_context(cert=42)
+
 
 def test_load_ssl_config_no_verify():
     context = httpx.create_ssl_context(verify=False)


### PR DESCRIPTION
Fix for 

https://github.com/encode/httpx/issues/3301