### PR TITLE
Remove deprecated 'app' parameter.

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: ["master"]
   pull_request:
-    branches: ["master"]
+    branches: ["master", "version-*"]
 
 jobs:
   tests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-* The deprecated `proxies` argument has now been removed.
 * The deprecated `app` argument has now been removed.
 
 ## 0.27.2 (27th August, 2024)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+* The deprecated `proxies` argument has now been removed.
+* The deprecated `app` argument has now been removed.
+
 ## 0.27.2 (27th August, 2024)
 
 ### Fixed

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -616,8 +616,6 @@ class Client(BaseClient):
     request URLs.
     * **transport** - *(optional)* A transport class to use for sending requests
     over the network.
-    * **app** - *(optional)* An WSGI application to send requests to,
-    rather than sending actual network requests.
     * **trust_env** - *(optional)* Enables or disables usage of environment
     variables for configuration.
     * **default_encoding** - *(optional)* The default encoding to use for decoding
@@ -646,7 +644,6 @@ class Client(BaseClient):
         event_hooks: None | (typing.Mapping[str, list[EventHook]]) = None,
         base_url: URL | str = "",
         transport: BaseTransport | None = None,
-        app: typing.Callable[..., typing.Any] | None = None,
         trust_env: bool = True,
         default_encoding: str | typing.Callable[[bytes], str] = "utf-8",
     ) -> None:
@@ -682,14 +679,7 @@ class Client(BaseClient):
             if proxy:
                 raise RuntimeError("Use either `proxy` or 'proxies', not both.")
 
-        if app:
-            message = (
-                "The 'app' shortcut is now deprecated."
-                " Use the explicit style 'transport=WSGITransport(app=...)' instead."
-            )
-            warnings.warn(message, DeprecationWarning)
-
-        allow_env_proxies = trust_env and app is None and transport is None
+        allow_env_proxies = trust_env and transport is None
         proxy_map = self._get_proxy_map(proxies or proxy, allow_env_proxies)
 
         self._transport = self._init_transport(
@@ -699,7 +689,6 @@ class Client(BaseClient):
             http2=http2,
             limits=limits,
             transport=transport,
-            app=app,
             trust_env=trust_env,
         )
         self._mounts: dict[URLPattern, BaseTransport | None] = {
@@ -731,14 +720,10 @@ class Client(BaseClient):
         http2: bool = False,
         limits: Limits = DEFAULT_LIMITS,
         transport: BaseTransport | None = None,
-        app: typing.Callable[..., typing.Any] | None = None,
         trust_env: bool = True,
     ) -> BaseTransport:
         if transport is not None:
             return transport
-
-        if app is not None:
-            return WSGITransport(app=app)
 
         return HTTPTransport(
             verify=verify,
@@ -1363,8 +1348,6 @@ class AsyncClient(BaseClient):
     request URLs.
     * **transport** - *(optional)* A transport class to use for sending requests
     over the network.
-    * **app** - *(optional)* An ASGI application to send requests to,
-    rather than sending actual network requests.
     * **trust_env** - *(optional)* Enables or disables usage of environment
     variables for configuration.
     * **default_encoding** - *(optional)* The default encoding to use for decoding
@@ -1393,7 +1376,6 @@ class AsyncClient(BaseClient):
         event_hooks: None | (typing.Mapping[str, list[EventHook]]) = None,
         base_url: URL | str = "",
         transport: AsyncBaseTransport | None = None,
-        app: typing.Callable[..., typing.Any] | None = None,
         trust_env: bool = True,
         default_encoding: str | typing.Callable[[bytes], str] = "utf-8",
     ) -> None:
@@ -1429,14 +1411,7 @@ class AsyncClient(BaseClient):
             if proxy:
                 raise RuntimeError("Use either `proxy` or 'proxies', not both.")
 
-        if app:
-            message = (
-                "The 'app' shortcut is now deprecated."
-                " Use the explicit style 'transport=ASGITransport(app=...)' instead."
-            )
-            warnings.warn(message, DeprecationWarning)
-
-        allow_env_proxies = trust_env and app is None and transport is None
+        allow_env_proxies = trust_env and transport is None
         proxy_map = self._get_proxy_map(proxies or proxy, allow_env_proxies)
 
         self._transport = self._init_transport(
@@ -1446,7 +1421,6 @@ class AsyncClient(BaseClient):
             http2=http2,
             limits=limits,
             transport=transport,
-            app=app,
             trust_env=trust_env,
         )
 
@@ -1478,14 +1452,10 @@ class AsyncClient(BaseClient):
         http2: bool = False,
         limits: Limits = DEFAULT_LIMITS,
         transport: AsyncBaseTransport | None = None,
-        app: typing.Callable[..., typing.Any] | None = None,
         trust_env: bool = True,
     ) -> AsyncBaseTransport:
         if transport is not None:
             return transport
-
-        if app is not None:
-            return ASGITransport(app=app)
 
         return AsyncHTTPTransport(
             verify=verify,

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -27,10 +27,8 @@ from ._exceptions import (
 )
 from ._models import Cookies, Headers, Request, Response
 from ._status_codes import codes
-from ._transports.asgi import ASGITransport
 from ._transports.base import AsyncBaseTransport, BaseTransport
 from ._transports.default import AsyncHTTPTransport, HTTPTransport
-from ._transports.wsgi import WSGITransport
 from ._types import (
     AsyncByteStream,
     AuthTypes,

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -222,13 +222,3 @@ async def test_asgi_exc_no_raise():
         response = await client.get("http://www.example.org/")
 
         assert response.status_code == 500
-
-
-@pytest.mark.anyio
-async def test_deprecated_shortcut():
-    """
-    The `app=...` shortcut is now deprecated.
-    Use the explicit transport style instead.
-    """
-    with pytest.warns(DeprecationWarning):
-        httpx.AsyncClient(app=hello_world)

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -201,12 +201,3 @@ def test_wsgi_server_protocol():
     assert response.status_code == 200
     assert response.text == "success"
     assert server_protocol == "HTTP/1.1"
-
-
-def test_deprecated_shortcut():
-    """
-    The `app=...` shortcut is now deprecated.
-    Use the explicit transport style instead.
-    """
-    with pytest.warns(DeprecationWarning):
-        httpx.Client(app=application_factory([b"Hello, World!"]))


### PR DESCRIPTION
This pull request deals with removing the already deprecated `app=...` parameter, which has been dropped in favor of the more explicit `transport = httpx.WSGITransport(...)` and `transport = httpx.ASGITransport()` configurations.

Related: #3314