### PR TITLE
Drop redundant 'URL.raw' property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+* The `URL.raw` property has now been removed.
+
 ## 0.27.2 (27th August, 2024)
 
 ### Fixed

--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -17,7 +17,6 @@ from typing import (
     List,
     Mapping,
     MutableMapping,
-    NamedTuple,
     Optional,
     Sequence,
     Tuple,
@@ -32,16 +31,6 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 PrimitiveData = Optional[Union[str, int, float, bool]]
-
-RawURL = NamedTuple(
-    "RawURL",
-    [
-        ("raw_scheme", bytes),
-        ("raw_host", bytes),
-        ("port", Optional[int]),
-        ("raw_path", bytes),
-    ],
-)
 
 URLTypes = Union["URL", str]
 

--- a/httpx/_urls.py
+++ b/httpx/_urls.py
@@ -5,7 +5,7 @@ from urllib.parse import parse_qs, unquote
 
 import idna
 
-from ._types import QueryParamTypes, RawURL
+from ._types import QueryParamTypes
 from ._urlparse import urlencode, urlparse
 from ._utils import primitive_value_to_str
 
@@ -303,22 +303,6 @@ class URL:
         As a string, without the leading '#'.
         """
         return unquote(self._uri_reference.fragment or "")
-
-    @property
-    def raw(self) -> RawURL:
-        """
-        Provides the (scheme, host, port, target) for the outgoing request.
-
-        In older versions of `httpx` this was used in the low-level transport API.
-        We no longer use `RawURL`, and this property will be deprecated
-        in a future release.
-        """
-        return RawURL(
-            self.raw_scheme,
-            self.raw_host,
-            self.port,
-            self.raw_path,
-        )
 
     @property
     def is_absolute_url(self) -> bool:

--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -865,19 +865,3 @@ def test_ipv6_url_copy_with_host(url_str, new_host):
     assert url.host == "::ffff:192.168.0.1"
     assert url.netloc == b"[::ffff:192.168.0.1]:1234"
     assert str(url) == "http://[::ffff:192.168.0.1]:1234"
-
-
-# Test for deprecated API
-
-
-def test_url_raw_compatibility():
-    """
-    Test case for the (to-be-deprecated) `url.raw` accessor.
-    """
-    url = httpx.URL("https://www.example.com/path")
-    scheme, host, port, raw_path = url.raw
-
-    assert scheme == b"https"
-    assert host == b"www.example.com"
-    assert port is None
-    assert raw_path == b"/path"


### PR DESCRIPTION
Remove the redundant `URL.raw` property.

Previously dropped in 0.23.1, and then reintroduced as an interim measure. See #2461 and #2462.

Related: #3314, #3315
