### PR TITLE
Drop `sniffio` requirement.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * The deprecated `proxies` argument has now been removed.
 * The deprecated `app` argument has now been removed.
 * The `URL.raw` property has now been removed.
+* The `sniffio` project dependency has now been removed.
 
 ## 0.27.2 (27th August, 2024)
 

--- a/httpx/_transports/asgi.py
+++ b/httpx/_transports/asgi.py
@@ -35,7 +35,7 @@ def is_running_trio() -> bool:
 
         if sniffio.current_async_library() == "trio":
             return True
-    except ImportError:
+    except ImportError:  # pragma: nocover
         pass
 
     return False

--- a/httpx/_transports/asgi.py
+++ b/httpx/_transports/asgi.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import typing
 
-import sniffio
-
 from .._models import Request, Response
 from .._types import AsyncByteStream
 from .base import AsyncBaseTransport
@@ -28,15 +26,27 @@ _ASGIApp = typing.Callable[
 __all__ = ["ASGITransport"]
 
 
+def is_running_trio() -> bool:
+    try:
+        # sniffio is a dependency of trio.
+
+        # See https://github.com/python-trio/trio/issues/2802
+        import sniffio
+        if sniffio.current_async_library() == "trio":
+            return True
+    except ImportError:
+        pass
+
+    return False
+
+
 def create_event() -> Event:
-    if sniffio.current_async_library() == "trio":
+    if is_running_trio():
         import trio
-
         return trio.Event()
-    else:
-        import asyncio
 
-        return asyncio.Event()
+    import asyncio
+    return asyncio.Event()
 
 
 class ASGIResponseStream(AsyncByteStream):

--- a/httpx/_transports/asgi.py
+++ b/httpx/_transports/asgi.py
@@ -32,6 +32,7 @@ def is_running_trio() -> bool:
 
         # See https://github.com/python-trio/trio/issues/2802
         import sniffio
+
         if sniffio.current_async_library() == "trio":
             return True
     except ImportError:
@@ -43,9 +44,11 @@ def is_running_trio() -> bool:
 def create_event() -> Event:
     if is_running_trio():
         import trio
+
         return trio.Event()
 
     import asyncio
+
     return asyncio.Event()
 
 

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -11,8 +11,6 @@ import typing
 from pathlib import Path
 from urllib.request import getproxies
 
-import sniffio
-
 from ._types import PrimitiveData
 
 if typing.TYPE_CHECKING:  # pragma: no cover
@@ -289,29 +287,18 @@ def peek_filelike_length(stream: typing.Any) -> int | None:
 
 
 class Timer:
-    async def _get_time(self) -> float:
-        library = sniffio.current_async_library()
-        if library == "trio":
-            import trio
-
-            return trio.current_time()
-        else:
-            import asyncio
-
-            return asyncio.get_event_loop().time()
-
     def sync_start(self) -> None:
         self.started = time.perf_counter()
 
     async def async_start(self) -> None:
-        self.started = await self._get_time()
+        self.started = time.perf_counter()
 
     def sync_elapsed(self) -> float:
         now = time.perf_counter()
         return now - self.started
 
     async def async_elapsed(self) -> float:
-        now = await self._get_time()
+        now = time.perf_counter()
         return now - self.started
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     "httpcore==1.*",
     "anyio",
     "idna",
-    "sniffio",
 ]
 dynamic = ["readme", "version"]
 


### PR DESCRIPTION
Prompted by https://github.com/encode/httpx/pull/2858#pullrequestreview-2332409048, thanks @T-256.

This is a more constrained part of #2858. I'll follow up with the remainder of that PR seperately.

Removes the `sniffio` requirement.

* Where async detection is used in `ASGI` we can use a lazy optional import.
* Usage in the `_utils` is overkill. The async implements just use `time.perf_counter()` anyway so let's switch to that.
