### PR TITLE
Add `httpx-socks` to third party packages.

### DIFF
--- a/docs/third_party_packages.md
+++ b/docs/third_party_packages.md
@@ -6,6 +6,12 @@ As HTTPX usage grows, there is an expanding community of developers building too
 
 <!-- NOTE: this list is in alphabetical order. -->
 
+### httpx-socks
+
+[GitHub](https://github.com/romis2012/httpx-socks)
+
+Proxy (HTTP, SOCKS) transports for httpx.
+
 ### Hishel
 
 [GitHub](https://github.com/karpetrosyan/hishel) - [Documentation](https://hishel.com/)


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

This library I personally use instead of _socksio_ (which supported by httpcore).