### PR TITLE
Fix client response stalling, exception handling, and disconnects in ASGI Transport

### DIFF
--- a/httpx/_transports/asgi.py
+++ b/httpx/_transports/asgi.py
@@ -187,7 +187,7 @@ async def run_asgi(
             await app(scope, receive, send)
         except Exception:  # noqa: PIE-786
             cancel_scope.cancel()
-            
+
             if raise_app_exceptions or not response_complete.is_set():
                 raise
 
@@ -211,6 +211,9 @@ async def run_asgi(
         nonlocal status_code, response_headers
 
         if disconnected.is_set():
+            await anyio.sleep(
+                0
+            )  # temp fix - yield control for disconnect watcher when loop is tight
             return
 
         if message["type"] == "http.response.start":

--- a/httpx/_transports/asgi.py
+++ b/httpx/_transports/asgi.py
@@ -186,6 +186,8 @@ async def run_asgi(
         try:
             await app(scope, receive, send)
         except Exception:  # noqa: PIE-786
+            cancel_scope.cancel()
+            
             if raise_app_exceptions or not response_complete.is_set():
                 raise
 

--- a/httpx/_transports/asgi.py
+++ b/httpx/_transports/asgi.py
@@ -252,6 +252,5 @@ async def run_asgi(
     except ExceptionGroup as exc_group:
         raise exc_group.exceptions[0]  # only run_app should raise exceptions
     finally:
-        disconnected.set()
         await send_stream.aclose()
         await receive_stream.aclose()

--- a/httpx/_transports/asgi.py
+++ b/httpx/_transports/asgi.py
@@ -179,6 +179,8 @@ async def run_asgi(
     async def watch_disconnect(cancel_scope: anyio.CancelScope) -> None:
         await disconnected.wait()
         cancel_scope.cancel()
+        await send_stream.aclose()
+        await receive_stream.aclose()
 
     async def run_app(cancel_scope: anyio.CancelScope) -> None:
         try:
@@ -227,6 +229,7 @@ async def run_asgi(
 
             if not more_body:
                 response_complete.set()
+                await send_stream.aclose()
 
     async with anyio.create_task_group() as tg:
         tg.start_soon(watch_disconnect, tg.cancel_scope)


### PR DESCRIPTION
ASGI transport layer would stall indefinitely due to improper stop signaling of the send stream, now close them when client closes response or stream is exhausted.
It also would not raise exceptions correctly from run_app.

This happens because the receive stream expects to receive more values after send stream stopped producing values, and the async for loop stalls - leading the client to wait for the response content indefinitely.
To amend this, we now close the send stream after more body is False.

Whenever the response is closed, cancel the run_app task if still running, and aclose the send and receive memory streams.

in the case of an exception from run_app, raise it, and then also aclose the send and receive memory streams.

Added tests for exhausting the stream, interrupting it and disconnecting the response, and interrupting it without disconnecting the response and continuing to consume it

# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [X] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [X] I've updated the documentation accordingly.

Fixes #2186 