### PR TITLE
Drop overloaded usage of 'verify' and 'cert'.

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -698,7 +698,6 @@ class Client(BaseClient):
             http1=http1,
             http2=http2,
             limits=limits,
-            trust_env=trust_env,
         )
 
     def _init_proxy_transport(
@@ -715,7 +714,6 @@ class Client(BaseClient):
             http1=http1,
             http2=http2,
             limits=limits,
-            trust_env=trust_env,
             proxy=proxy,
         )
 

--- a/httpx/_compat.py
+++ b/httpx/_compat.py
@@ -4,8 +4,6 @@ Python environments. It is excluded from the code coverage checks.
 """
 
 import re
-import ssl
-import sys
 from types import ModuleType
 from typing import Optional
 
@@ -38,26 +36,4 @@ else:
         zstd = None
 
 
-if sys.version_info >= (3, 10) or ssl.OPENSSL_VERSION_INFO >= (1, 1, 0, 7):
-
-    def set_minimum_tls_version_1_2(context: ssl.SSLContext) -> None:
-        # The OP_NO_SSL* and OP_NO_TLS* become deprecated in favor of
-        # 'SSLContext.minimum_version' from Python 3.7 onwards, however
-        # this attribute is not available unless the ssl module is compiled
-        # with OpenSSL 1.1.0g or newer.
-        # https://docs.python.org/3.10/library/ssl.html#ssl.SSLContext.minimum_version
-        # https://docs.python.org/3.7/library/ssl.html#ssl.SSLContext.minimum_version
-        context.minimum_version = ssl.TLSVersion.TLSv1_2
-
-else:
-
-    def set_minimum_tls_version_1_2(context: ssl.SSLContext) -> None:
-        # If 'minimum_version' isn't available, we configure these options with
-        # the older deprecated variants.
-        context.options |= ssl.OP_NO_SSLv2
-        context.options |= ssl.OP_NO_SSLv3
-        context.options |= ssl.OP_NO_TLSv1
-        context.options |= ssl.OP_NO_TLSv1_1
-
-
-__all__ = ["brotli", "set_minimum_tls_version_1_2"]
+__all__ = ["brotli"]

--- a/httpx/_compat.py
+++ b/httpx/_compat.py
@@ -35,5 +35,4 @@ else:
     if _zstd_version < (0, 18):  # Defensive:
         zstd = None
 
-
-__all__ = ["brotli"]
+__all__ = ["brotli", "zstd"]

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import os
 import ssl
 import sys
@@ -13,28 +12,6 @@ from ._types import HeaderTypes, TimeoutTypes
 from ._urls import URL
 
 __all__ = ["Limits", "Proxy", "SSLContext", "Timeout"]
-
-DEFAULT_CIPHERS = ":".join(
-    [
-        "ECDHE+AESGCM",
-        "ECDHE+CHACHA20",
-        "DHE+AESGCM",
-        "DHE+CHACHA20",
-        "ECDH+AESGCM",
-        "DH+AESGCM",
-        "ECDH+AES",
-        "DH+AES",
-        "RSA+AESGCM",
-        "RSA+AES",
-        "!aNULL",
-        "!eNULL",
-        "!MD5",
-        "!DSS",
-    ]
-)
-
-
-logger = logging.getLogger("httpx")
 
 
 class UnsetType:

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -26,6 +26,9 @@ class SSLContext(ssl.SSLContext):
         self,
         verify: bool = True,
     ) -> None:
+        # ssl.SSLContext sets OP_NO_SSLv2, OP_NO_SSLv3, OP_NO_COMPRESSION,
+        # OP_CIPHER_SERVER_PREFERENCE, OP_SINGLE_DH_USE and OP_SINGLE_ECDH_USE
+        # by default. (from `ssl.create_default_context`)
         super().__init__()
         self._verify = verify
 

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -52,6 +52,8 @@ class SSLContext(ssl.SSLContext):
         super().__init__()
         self._verify = verify
 
+        # Our SSL setup here is similar to the stdlib `ssl.create_default_context()`
+        # implementation, except with `certifi` used for certificate verification.
         if not verify:
             self.check_hostname = False
             self.verify_mode = ssl.CERT_NONE
@@ -61,9 +63,9 @@ class SSLContext(ssl.SSLContext):
         self.check_hostname = True
 
         # Use stricter verify flags where possible.
-        if hasattr(ssl, "VERIFY_X509_PARTIAL_CHAIN"):
+        if hasattr(ssl, "VERIFY_X509_PARTIAL_CHAIN"):  # pragma: nocover
             self.verify_flags |= ssl.VERIFY_X509_PARTIAL_CHAIN
-        if hasattr(ssl, "VERIFY_X509_STRICT"):
+        if hasattr(ssl, "VERIFY_X509_STRICT"):  # pragma: nocover
             self.verify_flags |= ssl.VERIFY_X509_STRICT
 
         # Default to `certifi` for certificiate verification.

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -3,14 +3,13 @@ from __future__ import annotations
 import logging
 import os
 import ssl
+import sys
 import typing
-from pathlib import Path
 
 import certifi
 
-from ._compat import set_minimum_tls_version_1_2
 from ._models import Headers
-from ._types import CertTypes, HeaderTypes, TimeoutTypes, VerifyTypes
+from ._types import HeaderTypes, TimeoutTypes
 from ._urls import URL
 
 __all__ = ["Limits", "Proxy", "SSLContext", "Timeout"]
@@ -46,92 +45,39 @@ UNSET = UnsetType()
 
 
 class SSLContext(ssl.SSLContext):
-    DEFAULT_CA_BUNDLE_PATH = Path(certifi.where())
-
     def __init__(
         self,
-        verify: VerifyTypes = True,
-        cert: CertTypes | None = None,
+        verify: bool = True,
     ) -> None:
-        self.verify = verify
-        set_minimum_tls_version_1_2(self)
-        self.options |= ssl.OP_NO_COMPRESSION
-        self.set_ciphers(DEFAULT_CIPHERS)
-
-        keylogfile = os.environ.get("SSLKEYLOGFILE")
-        if keylogfile:
-            self.keylog_filename = keylogfile
-
-        logger.debug(
-            "load_ssl_context verify=%r cert=%r",
-            verify,
-            cert,
-        )
+        super().__init__()
+        self._verify = verify
 
         if not verify:
             self.check_hostname = False
             self.verify_mode = ssl.CERT_NONE
-            self._load_client_certs(cert)
             return
-
-        if isinstance(verify, bool):
-            ca_bundle_path = self.DEFAULT_CA_BUNDLE_PATH
-        elif Path(verify).exists():
-            ca_bundle_path = Path(verify)
-        else:
-            raise IOError(
-                "Could not find a suitable TLS CA certificate bundle, "
-                "invalid path: {}".format(verify)
-            )
 
         self.verify_mode = ssl.CERT_REQUIRED
         self.check_hostname = True
 
-        # Signal to server support for PHA in TLS 1.3. Raises an
-        # AttributeError if only read-only access is implemented.
-        try:
-            self.post_handshake_auth = True
-        except AttributeError:  # pragma: no cover
-            pass
+        # Use stricter verify flags where possible.
+        if hasattr(ssl, "VERIFY_X509_PARTIAL_CHAIN"):
+            self.verify_flags |= ssl.VERIFY_X509_PARTIAL_CHAIN
+        if hasattr(ssl, "VERIFY_X509_STRICT"):
+            self.verify_flags |= ssl.VERIFY_X509_STRICT
 
-        # Disable using 'commonName' for SSLContext.check_hostname
-        # when the 'subjectAltName' extension isn't available.
-        try:
-            self.hostname_checks_common_name = False
-        except AttributeError:  # pragma: no cover
-            pass
+        # Default to `certifi` for certificiate verification.
+        self.load_verify_locations(cafile=certifi.where())
 
-        if ca_bundle_path.is_file():
-            cafile = str(ca_bundle_path)
-            logger.debug("load_verify_locations cafile=%r", cafile)
-            self.load_verify_locations(cafile=cafile)
-        elif ca_bundle_path.is_dir():
-            capath = str(ca_bundle_path)
-            logger.debug("load_verify_locations capath=%r", capath)
-            self.load_verify_locations(capath=capath)
-
-        self._load_client_certs(cert)
-
-    def _load_client_certs(self, cert: typing.Optional[CertTypes] = None) -> None:
-        """
-        Loads client certificates into our SSLContext object
-        """
-        if cert is not None:
-            if isinstance(cert, str):
-                self.load_cert_chain(certfile=cert)
-            elif isinstance(cert, tuple) and len(cert) == 2:
-                self.load_cert_chain(certfile=cert[0], keyfile=cert[1])
-            elif isinstance(cert, tuple) and len(cert) == 3:
-                self.load_cert_chain(
-                    certfile=cert[0],
-                    keyfile=cert[1],
-                    password=cert[2],
-                )
+        # OpenSSL keylog file support.
+        if hasattr(self, "keylog_filename"):
+            keylogfile = os.environ.get("SSLKEYLOGFILE")
+            if keylogfile and not sys.flags.ignore_environment:
+                self.keylog_filename = keylogfile
 
     def __repr__(self) -> str:
         class_name = self.__class__.__name__
-
-        return f"{class_name}(verify={self.verify!r})"
+        return f"<{class_name}(verify={self._verify!r})>"
 
     def __new__(
         cls,

--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -129,7 +129,6 @@ class HTTPTransport(BaseTransport):
         http1: bool = True,
         http2: bool = False,
         limits: Limits = DEFAULT_LIMITS,
-        trust_env: bool = True,
         proxy: ProxyTypes | None = None,
         uds: str | None = None,
         local_address: str | None = None,

--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -52,15 +52,6 @@ HeaderTypes = Union[
 
 CookieTypes = Union["Cookies", CookieJar, Dict[str, str], List[Tuple[str, str]]]
 
-CertTypes = Union[
-    # certfile
-    str,
-    # (certfile, keyfile)
-    Tuple[str, Optional[str]],
-    # (certfile, keyfile, password)
-    Tuple[str, Optional[str], Optional[str]],
-]
-VerifyTypes = Union[str, bool]
 TimeoutTypes = Union[
     Optional[float],
     Tuple[Optional[float], Optional[float], Optional[float], Optional[float]],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,6 @@ import logging
 import os
 import random
 
-import certifi
 import pytest
 
 import httpx
@@ -115,26 +114,6 @@ def test_logging_redirect_chain(server, caplog):
             "httpx",
             logging.INFO,
             'HTTP Request: GET http://127.0.0.1:8000/ "HTTP/1.1 200 OK"',
-        ),
-    ]
-
-
-def test_logging_ssl(caplog):
-    caplog.set_level(logging.DEBUG)
-    with httpx.Client():
-        pass
-
-    cafile = certifi.where()
-    assert caplog.record_tuples == [
-        (
-            "httpx",
-            logging.DEBUG,
-            "load_ssl_context verify=True cert=None",
-        ),
-        (
-            "httpx",
-            logging.DEBUG,
-            f"load_verify_locations cafile='{cafile}'",
         ),
     ]
 


### PR DESCRIPTION
This PR follows up on #3022, and...

* Drops the overloaded style of `verify=str`, in favor of the existing `.load_verify_locations(...)` API.
* Drops the `cert` parameter, in favor of the existing `.load_cert_chain(...)` API.
* Simplifies the internal `SSLContext` setup [in line with stdlib](https://github.com/python/cpython/blob/8b9a8e0e082f849f6db03b2ed9074a86813b3b77/Lib/ssl.py#L735-L757).
* Removes the certificate debug logging, which was odd as the single debug case in `httpx` and which is defunct now that we're using a more explicit style.

At this point we have a nice simple `httpx.SSLContext(verify: bool)` API, with an uncomplicated implementation.

We do also still need to include release notes / migration / rationale, hopefully clear to all why this is an improvement over the previous API.