### PR TITLE
Cleanup `trust_env` as property of Client.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+# `BaseClient` no more has `trust_env` property. (#3337)
 * Added `httpx.SSLContext` class and `ssl_context` argument. (#3022)
 * Removed `cert` and `verify` arguments, you should use the `ssl_context=...` instead. (#3022)
 * The deprecated `proxies` argument has now been removed.

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -168,7 +168,6 @@ class BaseClient:
         max_redirects: int = DEFAULT_MAX_REDIRECTS,
         event_hooks: None | (typing.Mapping[str, list[EventHook]]) = None,
         base_url: URL | str = "",
-        trust_env: bool = True,
         default_encoding: str | typing.Callable[[bytes], str] = "utf-8",
     ) -> None:
         event_hooks = {} if event_hooks is None else event_hooks
@@ -186,7 +185,6 @@ class BaseClient:
             "request": list(event_hooks.get("request", [])),
             "response": list(event_hooks.get("response", [])),
         }
-        self._trust_env = trust_env
         self._default_encoding = default_encoding
         self._state = ClientState.UNOPENED
 
@@ -196,10 +194,6 @@ class BaseClient:
         Check if the client being closed
         """
         return self._state == ClientState.CLOSED
-
-    @property
-    def trust_env(self) -> bool:
-        return self._trust_env
 
     def _enforce_trailing_slash(self, url: URL) -> URL:
         if url.raw_path.endswith(b"/"):
@@ -639,7 +633,6 @@ class Client(BaseClient):
             max_redirects=max_redirects,
             event_hooks=event_hooks,
             base_url=base_url,
-            trust_env=trust_env,
             default_encoding=default_encoding,
         )
 
@@ -688,7 +681,6 @@ class Client(BaseClient):
         http2: bool = False,
         limits: Limits = DEFAULT_LIMITS,
         transport: BaseTransport | None = None,
-        trust_env: bool = True,
     ) -> BaseTransport:
         if transport is not None:
             return transport
@@ -698,7 +690,6 @@ class Client(BaseClient):
             http1=http1,
             http2=http2,
             limits=limits,
-            trust_env=trust_env,
         )
 
     def _init_proxy_transport(
@@ -708,14 +699,12 @@ class Client(BaseClient):
         http1: bool = True,
         http2: bool = False,
         limits: Limits = DEFAULT_LIMITS,
-        trust_env: bool = True,
     ) -> BaseTransport:
         return HTTPTransport(
             ssl_context=ssl_context,
             http1=http1,
             http2=http2,
             limits=limits,
-            trust_env=trust_env,
             proxy=proxy,
         )
 
@@ -1344,7 +1333,6 @@ class AsyncClient(BaseClient):
             max_redirects=max_redirects,
             event_hooks=event_hooks,
             base_url=base_url,
-            trust_env=trust_env,
             default_encoding=default_encoding,
         )
 

--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -129,7 +129,6 @@ class HTTPTransport(BaseTransport):
         http1: bool = True,
         http2: bool = False,
         limits: Limits = DEFAULT_LIMITS,
-        trust_env: bool = True,
         proxy: ProxyTypes | None = None,
         uds: str | None = None,
         local_address: str | None = None,

--- a/tests/client/test_properties.py
+++ b/tests/client/test_properties.py
@@ -58,11 +58,3 @@ def test_client_event_hooks():
     client = httpx.Client()
     client.event_hooks = {"request": [on_request]}
     assert client.event_hooks == {"request": [on_request], "response": []}
-
-
-def test_client_trust_env():
-    client = httpx.Client()
-    assert client.trust_env
-
-    client = httpx.Client(trust_env=False)
-    assert not client.trust_env

--- a/tests/client/test_proxies.py
+++ b/tests/client/test_proxies.py
@@ -124,6 +124,22 @@ def test_unsupported_proxy_scheme():
         httpx.Client(proxy="ftp://127.0.0.1")
 
 
+@pytest.mark.parametrize("client_class", [httpx.Client, httpx.AsyncClient])
+def test_proxies_environ_trust(monkeypatch, client_class):
+    url = "http://google.com"
+    proxy_url = "http://example.com"
+
+    monkeypatch.setenv("HTTP_PROXY", proxy_url)
+
+    client = client_class()
+    transport = client._transport_for_url(httpx.URL(url))
+    assert transport._pool._proxy_url == url_to_origin(proxy_url)
+
+    client = client_class(trust_env=False)
+    transport = client._transport_for_url(httpx.URL(url))
+    assert transport == client._transport
+
+
 @pytest.mark.parametrize(
     ["url", "env", "expected"],
     [


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary
No need to have `trust_env` as property since it only used on initialization. I added new test for `trust_env` behavior.
