### PR TITLE
async file in multipart file upload

### DIFF
--- a/httpx/_compat.py
+++ b/httpx/_compat.py
@@ -1,0 +1,22 @@
+import sys
+
+if sys.version_info >= (3, 10):
+    from contextlib import aclosing
+else:
+    from contextlib import asynccontextmanager
+    from typing import Any, AsyncIterator, Awaitable, Protocol, TypeVar
+
+    class _SupportsAclose(Protocol):
+        def aclose(self) -> Awaitable[object]: ...
+
+    _SupportsAcloseT = TypeVar("_SupportsAcloseT", bound=_SupportsAclose)
+
+    @asynccontextmanager
+    async def aclosing(thing: _SupportsAcloseT) -> AsyncIterator[Any]:
+        try:
+            yield thing
+        finally:
+            await thing.aclose()
+
+
+__all__ = ["aclosing"]

--- a/httpx/_multipart.py
+++ b/httpx/_multipart.py
@@ -226,7 +226,12 @@ class FileField:
             return
 
         async for achunk in self.file:
-            yield to_bytes(achunk)
+            if not isinstance(achunk, bytes):
+                raise TypeError(
+                    "Multipart file uploads must be opened in binary mode,"
+                    " not text mode."
+                )
+            yield achunk
 
     def render(self) -> typing.Iterator[bytes]:
         yield self.render_headers()

--- a/httpx/_multipart.py
+++ b/httpx/_multipart.py
@@ -225,12 +225,22 @@ class FileField:
                 yield chunk
             return
 
-        async for achunk in self.file:
-            if not isinstance(achunk, bytes):
-                raise TypeError(
-                    "Multipart file uploads must be opened in binary mode,"
-                    " not text mode."
-                )
+        file_aiter = self.file.__aiter__()
+
+        try:
+            achunk = await file_aiter.__anext__()
+        except StopIteration:
+            return
+
+        if not isinstance(achunk, bytes):
+            raise TypeError(
+                "Multipart file uploads must be opened in binary mode,"
+                " not text mode."
+            )
+
+        yield achunk
+
+        async for achunk in file_aiter:
             yield achunk
 
     def render(self) -> typing.Iterator[bytes]:

--- a/httpx/_multipart.py
+++ b/httpx/_multipart.py
@@ -229,7 +229,7 @@ class FileField:
 
         try:
             achunk = await file_aiter.__anext__()
-        except StopIteration:
+        except StopAsyncIteration:
             return
 
         if not isinstance(achunk, bytes):

--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -71,7 +71,7 @@ ResponseExtensions = Mapping[str, Any]
 
 RequestData = Mapping[str, Any]
 
-FileContent = Union[IO[bytes], bytes, str]
+FileContent = Union[IO[bytes], bytes, str, AsyncIterable[bytes], AsyncIterable[str]]
 FileTypes = Union[
     # file (or bytes)
     FileContent,

--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -71,7 +71,7 @@ ResponseExtensions = Mapping[str, Any]
 
 RequestData = Mapping[str, Any]
 
-FileContent = Union[IO[bytes], bytes, str, AsyncIterable[bytes], AsyncIterable[str]]
+FileContent = Union[IO[bytes], bytes, str, AsyncIterable[bytes]]
 FileTypes = Union[
     # file (or bytes)
     FileContent,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,5 +128,5 @@ markers = [
 ]
 
 [tool.coverage.run]
-omit = ["venv/*"]
+omit = ["venv/*", "httpx/_compat.py"]
 include = ["httpx/*", "tests/*"]

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -46,68 +46,45 @@ def test_multipart(value, output):
 async def test_async_multipart_streaming(tmp_path, server, anyio_backend):
     to_upload = tmp_path / "test.txt"
     to_upload.write_bytes(b"<file content>")
-    if typing.TYPE_CHECKING:
-        opener_t = typing.Coroutine[  # pragma: no cover
-            typing.Any,
-            typing.Any,
-            typing.Union[
-                anyio.AsyncFile[bytes],
-                anyio.AsyncFile[str],
-                trio.AsyncBinaryIO,
-                trio.AsyncTextIO,
-            ],
-        ]
-    opener: opener_t
-    text_opener: opener_t
+    opener: typing.Any
+    text_opener: typing.Any
     if anyio_backend == "trio":
-        opener = trio.open_file(to_upload, "rb")
-        text_opener = trio.open_file(to_upload, "rt")
+        opener = trio.open_file(to_upload, "b+r")
+        text_opener = trio.open_file(to_upload, "t+r")
     else:
-        opener = anyio.open_file(to_upload, "rb")
-        text_opener = anyio.open_file(to_upload, "rt")
+        opener = anyio.open_file(to_upload, "b+r")
+        text_opener = anyio.open_file(to_upload, "t+r")
     url = server.url.copy_with(path="/echo_body")
-    async with await opener as fp:
+    async with await opener as fp, httpx.AsyncClient() as client:
         files = {"file": fp}
-        async with httpx.AsyncClient() as client:
-            response = await client.post(url, files=files)
-            boundary = response.request.headers["Content-Type"].split("boundary=")[-1]
-            boundary_bytes = boundary.encode("ascii")
+        response = await client.post(url, files=files)
+        boundary = response.request.headers["Content-Type"].split("boundary=")[-1]
+        boundary_bytes = boundary.encode("ascii")
 
-            assert response.status_code == 200
-            assert response.content == b"".join(
-                [
-                    b"--" + boundary_bytes + b"\r\n",
-                    b'Content-Disposition: form-data; name="file";'
-                    b' filename="test.txt"\r\n',
-                    b"Content-Type: text/plain\r\n",
-                    b"\r\n",
-                    b"<file content>\r\n",
-                    b"--" + boundary_bytes + b"--\r\n",
-                ]
-            )
+        assert response.status_code == 200
+        assert response.content == b"".join(
+            [
+                b"--" + boundary_bytes + b"\r\n",
+                b'Content-Disposition: form-data; name="file";'
+                b' filename="test.txt"\r\n',
+                b"Content-Type: text/plain\r\n",
+                b"\r\n",
+                b"<file content>\r\n",
+                b"--" + boundary_bytes + b"--\r\n",
+            ]
+        )
 
         with httpx.Client() as sync_client:
             with pytest.raises(TypeError, match="AsyncIterable is not supported"):
                 sync_client.post(url, files=files)
 
-    async with await text_opener as fp:
+    async with await text_opener as fp, httpx.AsyncClient() as client:
         files = {"file": fp}
-        async with httpx.AsyncClient() as client:
-            response = await client.post(url, files=files)
-            boundary = response.request.headers["Content-Type"].split("boundary=")[-1]
-            boundary_bytes = boundary.encode("ascii")
-            assert response.status_code == 200
-            assert response.content == b"".join(
-                [
-                    b"--" + boundary_bytes + b"\r\n",
-                    b'Content-Disposition: form-data; name="file";'
-                    b' filename="test.txt"\r\n',
-                    b"Content-Type: text/plain\r\n",
-                    b"\r\n",
-                    b"<file content>\r\n",
-                    b"--" + boundary_bytes + b"--\r\n",
-                ]
-            )
+        with pytest.raises(
+            TypeError,
+            match="Multipart file uploads must be opened in binary mode",
+        ):
+            await client.post(url, files=files)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -4,7 +4,9 @@ import io
 import tempfile
 import typing
 
+import anyio
 import pytest
+import trio
 
 import httpx
 
@@ -39,6 +41,50 @@ def test_multipart(value, output):
             b"--" + boundary_bytes + b"--\r\n",
         ]
     )
+
+
+@pytest.mark.parametrize(("value,output"), (("abc", b"abc"), (b"abc", b"abc")))
+async def test_async_multipart_streaming(
+    value, output, tmp_path, server, anyio_backend
+):
+    data = {"text": value}
+    to_upload = tmp_path / "test.txt"
+    to_upload.write_bytes(b"<file content>")
+    opener: typing.Coroutine[
+        typing.Any, typing.Any, typing.Union[anyio.AsyncFile[bytes], trio.AsyncBinaryIO]
+    ]
+    if anyio_backend == "trio":
+        opener = trio.open_file(to_upload, "rb")
+    else:
+        opener = anyio.open_file(to_upload, "rb")
+    url = server.url.copy_with(path="/echo_body")
+    async with await opener as fp:
+        files = {"file": fp}
+        async with httpx.AsyncClient() as client:
+            response = await client.post(url, data=data, files=files)
+            boundary = response.request.headers["Content-Type"].split("boundary=")[-1]
+            boundary_bytes = boundary.encode("ascii")
+
+            assert response.status_code == 200
+            assert response.content == b"".join(
+                [
+                    b"--" + boundary_bytes + b"\r\n",
+                    b'Content-Disposition: form-data; name="text"\r\n',
+                    b"\r\n",
+                    b"abc\r\n",
+                    b"--" + boundary_bytes + b"\r\n",
+                    b'Content-Disposition: form-data; name="file";'
+                    b' filename="test.txt"\r\n',
+                    b"Content-Type: text/plain\r\n",
+                    b"\r\n",
+                    b"<file content>\r\n",
+                    b"--" + boundary_bytes + b"--\r\n",
+                ]
+            )
+
+        with httpx.Client() as sync_client:
+            with pytest.raises(TypeError, match="AsyncIterable is not supported"):
+                sync_client.post(url, data=data, files=files)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -44,8 +44,9 @@ def test_multipart(value, output):
 
 
 async def test_async_multipart_streaming(tmp_path, server, anyio_backend):
+    content = b"\n".join([b"a" * io.DEFAULT_BUFFER_SIZE] * 3)
     to_upload = tmp_path / "test.txt"
-    to_upload.write_bytes(b"<file content>")
+    to_upload.write_bytes(content)
     empty_file = tmp_path / "empty.txt"
     empty_file.write_bytes(b"")
     opener: typing.Any
@@ -74,7 +75,8 @@ async def test_async_multipart_streaming(tmp_path, server, anyio_backend):
                 b' filename="test.txt"\r\n',
                 b"Content-Type: text/plain\r\n",
                 b"\r\n",
-                b"<file content>\r\n",
+                content,
+                b"\r\n",
                 b"--" + boundary_bytes + b"--\r\n",
             ]
         )


### PR DESCRIPTION
# Summary

Trying to implement support for async files (any AsyncIterable[bytes | str]) multipart file upload. Partially fixes https://github.com/encode/httpx/issues/1620

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly. (not sure if update is needed)
