### PR TITLE
Default ssl contexts per http versions.

### DIFF
--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -137,7 +137,7 @@ class HTTPTransport(BaseTransport):
         socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
     ) -> None:
         proxy = Proxy(url=proxy) if isinstance(proxy, (str, URL)) else proxy
-        ssl_context = ssl_context or SSLContext()
+        ssl_context = ssl_context or SSLContext.from_defaults(http1=http1, http2=http2)
 
         if proxy is None:
             self._pool = httpcore.ConnectionPool(
@@ -276,7 +276,7 @@ class AsyncHTTPTransport(AsyncBaseTransport):
         socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
     ) -> None:
         proxy = Proxy(url=proxy) if isinstance(proxy, (str, URL)) else proxy
-        ssl_context = ssl_context or SSLContext()
+        ssl_context = ssl_context or SSLContext.from_defaults(http1=http1, http2=http2)
 
         if proxy is None:
             self._pool = httpcore.AsyncConnectionPool(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -121,8 +121,7 @@ def test_logging_redirect_chain(server, caplog):
 
 def test_logging_ssl(caplog):
     caplog.set_level(logging.DEBUG)
-    with httpx.Client():
-        pass
+    _context = httpx.SSLContext()
 
     cafile = certifi.where()
     assert caplog.record_tuples == [


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary
Ref: https://github.com/encode/httpx/pull/3022#pullrequestreview-2350615169

Instead of creating ssl context per client, we now re-use available default contexts for different http versions configurations.

### TODO
- [ ] add logging
- [ ] add tests
- [ ] make it thread safe