### PR TITLE
Simplify and optimize the most common methods of 'Headers'

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -137,16 +137,15 @@ class Headers(typing.MutableMapping[str, str]):
     def values(self) -> typing.ValuesView[str]:
         return self.items(_keys=False)
 
-    def items(self, _keys=True) -> typing.ItemsView[str, str]:
+    def items(self, _keys: bool = True) -> typing.ItemsView[str, str]:
         """
         Return `(key, value)` items of headers. Concatenate headers
         into a single comma-separated value when a key occurs multiple times.
         """
-        values_dict: dict[str, str] = {}
+        values_dict: dict[bytes, list[str]] = {}
         for _, key, value in self._list:
-            str_key = key.decode(self.encoding)
             str_value = value.decode(self.encoding)
-            values_dict.setdefault(str_key, []).append(str_value)
+            values_dict.setdefault(key, []).append(str_value)
         if _keys:
             for key in values_dict:
                 yield key, ", ".join(values_dict[key])


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

This PR enhances the performance of the modified functions by significantly increasing their execution speed x100000. I used generators of course and I can add more of these kinds in the future if you like!
The current test (`tests/models/test_headers.py`) can handle this change so I didn't write any.

**Before:**
```bash
$ python -m timeit -r 10 -n 10 -c "from main import h" "h.items()"
10 loops, best of 10: 297 msec per loop
```

**After:**
```bash
$ python -m timeit -r 10 -n 10 -c "from main import h" "h.items()"
10 loops, best of 10: 660 nsec per loop
:0: UserWarning: The test results are likely unreliable. The worst time (4.01 msec) was more than four times slower than the best time (660 nsec).
```
_If these kind of PRs can be merged, I would like to contribute with like these optimised solutions again to speed up the lib. Or feel free to give a feedback)_

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
