### PR TITLE
Global timeout

### DIFF
--- a/docs/advanced/timeouts.md
+++ b/docs/advanced/timeouts.md
@@ -38,6 +38,15 @@ client = httpx.Client(timeout=10.0)  # Use a default 10s timeout everywhere.
 client = httpx.Client(timeout=None)  # Disable all timeouts by default.
 ```
 
+## Setting a global timeout
+You can set a global timeout for all requests made by HTTPX.
+
+```python
+import httpx
+httpx.DEFAULT_TIMEOUT_CONFIG = httpx.Timeout(10.0)
+```
+
+
 ## Fine tuning the configuration
 
 HTTPX also allows you to specify the timeout behavior in more fine grained detail.

--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -48,6 +48,7 @@ __all__ = [
     "Cookies",
     "create_ssl_context",
     "DecodingError",
+    "DEFAULT_TIMEOUT_CONFIG",
     "delete",
     "DigestAuth",
     "get",

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -14,7 +14,7 @@ from ._types import CertTypes, HeaderTypes, TimeoutTypes, VerifyTypes
 from ._urls import URL
 from ._utils import get_ca_bundle_from_env
 
-__all__ = ["Limits", "Proxy", "Timeout", "create_ssl_context"]
+__all__ = ["DEFAULT_TIMEOUT_CONFIG", "Limits", "Proxy", "Timeout", "create_ssl_context"]
 
 DEFAULT_CIPHERS = ":".join(
     [


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary
This pull request introduces a new, more straightforward way to configure a global default timeout for all clients and requests in `httpx` without needing to access the internal `_config` object. The enhancement is achieved by exposing the `DEFAULT_TIMEOUT_CONFIG` in the main `__init__.py` file (see discussion [here](https://github.com/encode/httpx/discussions/3356)).

This change simplifies the process, allowing developers to set a global timeout directly and elegantly, like so:
```python
import httpx
httpx.DEFAULT_TIMEOUT_CONFIG = httpx.Timeout(10.0)
```

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
