### PR TITLE
Docs minor fix

### DIFF
--- a/docs/advanced/transports.md
+++ b/docs/advanced/transports.md
@@ -187,11 +187,11 @@ class HTTPSRedirect(httpx.BaseTransport):
         return httpx.Response(303, headers={"Location": str(url)})
 
 # A client where any `http` requests are always redirected to `https`
-transport = httpx.Mounts({
+mounts = {
     'http://': HTTPSRedirect()
     'https://': httpx.HTTPTransport()
-})
-client = httpx.Client(transport=transport)
+}
+client = httpx.Client(mounts=mounts)
 ```
 
 A useful pattern here is custom transport classes that wrap the default HTTP implementation. For example...


### PR DESCRIPTION
Closes #3349 

Just a minor documentation fix referring to the non-existent `httpx.Mounts`

We also have some undocumented attributes and need to tidy up the API documentation. I believe this will be addressed within the scope of #3091