### PR TITLE
Allow deprecated `verify=<...>` and `cert=<...>`.

### DIFF
--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -46,6 +46,7 @@ __all__ = [
     "ConnectTimeout",
     "CookieConflict",
     "Cookies",
+    "create_ssl_context",
     "DecodingError",
     "delete",
     "DigestAuth",

--- a/httpx/_api.py
+++ b/httpx/_api.py
@@ -50,6 +50,9 @@ def request(
     follow_redirects: bool = False,
     ssl_context: ssl.SSLContext | None = None,
     trust_env: bool = True,
+    # Deprecated in favor of `ssl_context`...
+    verify: typing.Any = None,
+    cert: typing.Any = None,
 ) -> Response:
     """
     Sends an HTTP request.
@@ -101,6 +104,8 @@ def request(
         ssl_context=ssl_context,
         timeout=timeout,
         trust_env=trust_env,
+        verify=verify,
+        cert=cert,
     ) as client:
         return client.request(
             method=method,
@@ -134,6 +139,9 @@ def stream(
     follow_redirects: bool = False,
     ssl_context: ssl.SSLContext | None = None,
     trust_env: bool = True,
+    # Deprecated in favor of `ssl_context`...
+    verify: typing.Any = None,
+    cert: typing.Any = None,
 ) -> typing.Iterator[Response]:
     """
     Alternative to `httpx.request()` that streams the response body
@@ -151,6 +159,8 @@ def stream(
         ssl_context=ssl_context,
         timeout=timeout,
         trust_env=trust_env,
+        verify=verify,
+        cert=cert,
     ) as client:
         with client.stream(
             method=method,
@@ -179,6 +189,9 @@ def get(
     ssl_context: ssl.SSLContext | None = None,
     timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
     trust_env: bool = True,
+    # Deprecated in favor of `ssl_context`...
+    verify: typing.Any = None,
+    cert: typing.Any = None,
 ) -> Response:
     """
     Sends a `GET` request.
@@ -200,6 +213,8 @@ def get(
         ssl_context=ssl_context,
         timeout=timeout,
         trust_env=trust_env,
+        verify=verify,
+        cert=cert,
     )
 
 
@@ -215,6 +230,9 @@ def options(
     ssl_context: ssl.SSLContext | None = None,
     timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
     trust_env: bool = True,
+    # Deprecated in favor of `ssl_context`...
+    verify: typing.Any = None,
+    cert: typing.Any = None,
 ) -> Response:
     """
     Sends an `OPTIONS` request.
@@ -236,6 +254,8 @@ def options(
         ssl_context=ssl_context,
         timeout=timeout,
         trust_env=trust_env,
+        verify=verify,
+        cert=cert,
     )
 
 
@@ -251,6 +271,9 @@ def head(
     ssl_context: ssl.SSLContext | None = None,
     timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
     trust_env: bool = True,
+    # Deprecated in favor of `ssl_context`...
+    verify: typing.Any = None,
+    cert: typing.Any = None,
 ) -> Response:
     """
     Sends a `HEAD` request.
@@ -272,6 +295,8 @@ def head(
         ssl_context=ssl_context,
         timeout=timeout,
         trust_env=trust_env,
+        verify=verify,
+        cert=cert,
     )
 
 
@@ -291,6 +316,9 @@ def post(
     ssl_context: ssl.SSLContext | None = None,
     timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
     trust_env: bool = True,
+    # Deprecated in favor of `ssl_context`...
+    verify: typing.Any = None,
+    cert: typing.Any = None,
 ) -> Response:
     """
     Sends a `POST` request.
@@ -313,6 +341,8 @@ def post(
         ssl_context=ssl_context,
         timeout=timeout,
         trust_env=trust_env,
+        verify=verify,
+        cert=cert,
     )
 
 
@@ -332,6 +362,9 @@ def put(
     ssl_context: ssl.SSLContext | None = None,
     timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
     trust_env: bool = True,
+    # Deprecated in favor of `ssl_context`...
+    verify: typing.Any = None,
+    cert: typing.Any = None,
 ) -> Response:
     """
     Sends a `PUT` request.
@@ -354,6 +387,8 @@ def put(
         ssl_context=ssl_context,
         timeout=timeout,
         trust_env=trust_env,
+        verify=verify,
+        cert=cert,
     )
 
 
@@ -373,6 +408,9 @@ def patch(
     ssl_context: ssl.SSLContext | None = None,
     timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
     trust_env: bool = True,
+    # Deprecated in favor of `ssl_context`...
+    verify: typing.Any = None,
+    cert: typing.Any = None,
 ) -> Response:
     """
     Sends a `PATCH` request.
@@ -395,6 +433,8 @@ def patch(
         ssl_context=ssl_context,
         timeout=timeout,
         trust_env=trust_env,
+        verify=verify,
+        cert=cert,
     )
 
 
@@ -410,6 +450,9 @@ def delete(
     timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
     ssl_context: ssl.SSLContext | None = None,
     trust_env: bool = True,
+    # Deprecated in favor of `ssl_context`...
+    verify: typing.Any = None,
+    cert: typing.Any = None,
 ) -> Response:
     """
     Sends a `DELETE` request.
@@ -431,4 +474,6 @@ def delete(
         ssl_context=ssl_context,
         timeout=timeout,
         trust_env=trust_env,
+        verify=verify,
+        cert=cert,
     )

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -628,6 +628,9 @@ class Client(BaseClient):
         transport: BaseTransport | None = None,
         trust_env: bool = True,
         default_encoding: str | typing.Callable[[bytes], str] = "utf-8",
+        # Deprecated in favor of `ssl_context`...
+        verify: typing.Any = None,
+        cert: typing.Any = None,
     ) -> None:
         super().__init__(
             auth=auth,
@@ -661,6 +664,10 @@ class Client(BaseClient):
             http2=http2,
             limits=limits,
             transport=transport,
+            trust_env=trust_env,
+            # Deprecated in favor of ssl_context...
+            verify=verify,
+            cert=cert,
         )
         self._mounts: dict[URLPattern, BaseTransport | None] = {
             URLPattern(key): None
@@ -671,6 +678,9 @@ class Client(BaseClient):
                 http1=http1,
                 http2=http2,
                 limits=limits,
+                # Deprecated in favor of ssl_context...
+                verify=verify,
+                cert=cert,
             )
             for key, proxy in proxy_map.items()
         }
@@ -689,6 +699,9 @@ class Client(BaseClient):
         limits: Limits = DEFAULT_LIMITS,
         transport: BaseTransport | None = None,
         trust_env: bool = True,
+        # Deprecated in favor of `ssl_context`...
+        verify: typing.Any = None,
+        cert: typing.Any = None,
     ) -> BaseTransport:
         if transport is not None:
             return transport
@@ -698,6 +711,8 @@ class Client(BaseClient):
             http1=http1,
             http2=http2,
             limits=limits,
+            verify=verify,
+            cert=cert,
         )
 
     def _init_proxy_transport(
@@ -708,6 +723,9 @@ class Client(BaseClient):
         http2: bool = False,
         limits: Limits = DEFAULT_LIMITS,
         trust_env: bool = True,
+        # Deprecated in favor of `ssl_context`...
+        verify: typing.Any = None,
+        cert: typing.Any = None,
     ) -> BaseTransport:
         return HTTPTransport(
             ssl_context=ssl_context,
@@ -715,6 +733,8 @@ class Client(BaseClient):
             http2=http2,
             limits=limits,
             proxy=proxy,
+            verify=verify,
+            cert=cert,
         )
 
     def _transport_for_url(self, url: URL) -> BaseTransport:
@@ -1330,6 +1350,9 @@ class AsyncClient(BaseClient):
         transport: AsyncBaseTransport | None = None,
         trust_env: bool = True,
         default_encoding: str | typing.Callable[[bytes], str] = "utf-8",
+        # Deprecated in favor of `ssl_context`...
+        verify: typing.Any = None,
+        cert: typing.Any = None,
     ) -> None:
         super().__init__(
             auth=auth,
@@ -1363,6 +1386,9 @@ class AsyncClient(BaseClient):
             http2=http2,
             limits=limits,
             transport=transport,
+            # Deprecated in favor of ssl_context
+            verify=verify,
+            cert=cert,
         )
 
         self._mounts: dict[URLPattern, AsyncBaseTransport | None] = {
@@ -1374,6 +1400,9 @@ class AsyncClient(BaseClient):
                 http1=http1,
                 http2=http2,
                 limits=limits,
+                # Deprecated in favor of `ssl_context`...
+                verify=verify,
+                cert=cert,
             )
             for key, proxy in proxy_map.items()
         }
@@ -1390,6 +1419,9 @@ class AsyncClient(BaseClient):
         http2: bool = False,
         limits: Limits = DEFAULT_LIMITS,
         transport: AsyncBaseTransport | None = None,
+        # Deprecated in favor of `ssl_context`...
+        verify: typing.Any = None,
+        cert: typing.Any = None,
     ) -> AsyncBaseTransport:
         if transport is not None:
             return transport
@@ -1399,6 +1431,8 @@ class AsyncClient(BaseClient):
             http1=http1,
             http2=http2,
             limits=limits,
+            verify=verify,
+            cert=cert,
         )
 
     def _init_proxy_transport(
@@ -1408,6 +1442,9 @@ class AsyncClient(BaseClient):
         http1: bool = True,
         http2: bool = False,
         limits: Limits = DEFAULT_LIMITS,
+        # Deprecated in favor of `ssl_context`...
+        verify: typing.Any = None,
+        cert: typing.Any = None,
     ) -> AsyncBaseTransport:
         return AsyncHTTPTransport(
             ssl_context=ssl_context,
@@ -1415,6 +1452,8 @@ class AsyncClient(BaseClient):
             http2=http2,
             limits=limits,
             proxy=proxy,
+            verify=verify,
+            cert=cert,
         )
 
     def _transport_for_url(self, url: URL) -> AsyncBaseTransport:

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -4,6 +4,7 @@ import os
 import ssl
 import sys
 import typing
+import warnings
 
 import certifi
 
@@ -11,7 +12,7 @@ from ._models import Headers
 from ._types import HeaderTypes, TimeoutTypes
 from ._urls import URL
 
-__all__ = ["Limits", "Proxy", "SSLContext", "Timeout"]
+__all__ = ["Limits", "Proxy", "SSLContext", "Timeout", "create_ssl_context"]
 
 
 class UnsetType:
@@ -22,21 +23,45 @@ UNSET = UnsetType()
 
 
 def create_ssl_context(
-    verify: typing.Any, cert: typing.Any
+    verify: typing.Any = None,
+    cert: typing.Any = None,
+    trust_env: bool = True,
+    http2: bool = False,
 ) -> ssl.SSLContext:  # pragma: nocover
-    # TODO: deprecation warning.
     if isinstance(verify, bool):
-        ssl_context = SSLContext(verify=verify)
-    elif isinstance(verify, ssl.SSLContext):
-        ssl_context = ssl_context
-    else:
+        ssl_context: ssl.SSLContext = SSLContext(verify=verify)
+        warnings.warn(
+            "The verify=<bool> parameter is deprecated since 0.28.0. "
+            "Use `ssl_context=httpx.SSLContext(verify=<bool>)`."
+        )
+    elif isinstance(verify, str):
+        warnings.warn(
+            "The verify=<str> parameter is deprecated since 0.28.0. "
+            "Use `ssl_context=httpx.SSLContext()` and `.load_verify_locations()`."
+        )
         ssl_context = SSLContext()
         if os.path.isfile(verify):
             ssl_context.load_verify_locations(cafile=verify)
         elif os.path.isdir(verify):
             ssl_context.load_verify_locations(capath=verify)
+    elif isinstance(verify, ssl.SSLContext):
+        warnings.warn(
+            "The verify=<ssl context> parameter is deprecated since 0.28.0. "
+            "Use `ssl_context = httpx.SSLContext()`."
+        )
+        ssl_context = verify
+    else:
+        warnings.warn(
+            "`create_ssl_context()` is deprecated since 0.28.0."
+            "Use `ssl_context = httpx.SSLContext()`."
+        )
+        ssl_context = SSLContext()
 
     if cert is not None:
+        warnings.warn(
+            "The `cert=<...>` parameter is deprecated since 0.28.0. "
+            "Use `ssl_context = httpx.SSLContext()` and `.load_cert_chain()`."
+        )
         if isinstance(cert, str):
             ssl_context.load_cert_chain(cert)
         else:

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -21,6 +21,30 @@ class UnsetType:
 UNSET = UnsetType()
 
 
+def create_ssl_context(
+    verify: typing.Any, cert: typing.Any
+) -> ssl.SSLContext:  # pragma: nocover
+    # TODO: deprecation warning.
+    if isinstance(verify, bool):
+        ssl_context = SSLContext(verify=verify)
+    elif isinstance(verify, ssl.SSLContext):
+        ssl_context = ssl_context
+    else:
+        ssl_context = SSLContext()
+        if os.path.isfile(verify):
+            ssl_context.load_verify_locations(cafile=verify)
+        elif os.path.isdir(verify):
+            ssl_context.load_verify_locations(capath=verify)
+
+    if cert is not None:
+        if isinstance(cert, str):
+            ssl_context.load_cert_chain(cert)
+        else:
+            ssl_context.load_cert_chain(*cert)
+
+    return ssl_context
+
+
 class SSLContext(ssl.SSLContext):
     def __init__(
         self,

--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -33,7 +33,7 @@ from types import TracebackType
 
 import httpcore
 
-from .._config import DEFAULT_LIMITS, Limits, Proxy, SSLContext
+from .._config import DEFAULT_LIMITS, Limits, Proxy, SSLContext, create_ssl_context
 from .._exceptions import (
     ConnectError,
     ConnectTimeout,
@@ -134,9 +134,15 @@ class HTTPTransport(BaseTransport):
         local_address: str | None = None,
         retries: int = 0,
         socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
+        # Deprecated...
+        verify: typing.Any = None,
+        cert: typing.Any = None,
     ) -> None:
         proxy = Proxy(url=proxy) if isinstance(proxy, (str, URL)) else proxy
-        ssl_context = ssl_context or SSLContext()
+        if verify is not None or cert is not None:
+            ssl_context = create_ssl_context(verify, cert)
+        else:
+            ssl_context = ssl_context or SSLContext()
 
         if proxy is None:
             self._pool = httpcore.ConnectionPool(
@@ -273,9 +279,15 @@ class AsyncHTTPTransport(AsyncBaseTransport):
         local_address: str | None = None,
         retries: int = 0,
         socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
+        # Deprecated...
+        verify: typing.Any = None,
+        cert: typing.Any = None,
     ) -> None:
         proxy = Proxy(url=proxy) if isinstance(proxy, (str, URL)) else proxy
-        ssl_context = ssl_context or SSLContext()
+        if verify is not None or cert is not None:
+            ssl_context = create_ssl_context(verify, cert)
+        else:
+            ssl_context = ssl_context or SSLContext()
 
         if proxy is None:
             self._pool = httpcore.AsyncConnectionPool(

--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -139,7 +139,8 @@ class HTTPTransport(BaseTransport):
         cert: typing.Any = None,
     ) -> None:
         proxy = Proxy(url=proxy) if isinstance(proxy, (str, URL)) else proxy
-        if verify is not None or cert is not None:
+        if verify is not None or cert is not None:  # pragma: nocover
+            # Deprecated...
             ssl_context = create_ssl_context(verify, cert)
         else:
             ssl_context = ssl_context or SSLContext()
@@ -284,7 +285,8 @@ class AsyncHTTPTransport(AsyncBaseTransport):
         cert: typing.Any = None,
     ) -> None:
         proxy = Proxy(url=proxy) if isinstance(proxy, (str, URL)) else proxy
-        if verify is not None or cert is not None:
+        if verify is not None or cert is not None:  # pragma: nocover
+            # Deprecated...
             ssl_context = create_ssl_context(verify, cert)
         else:
             ssl_context = ssl_context or SSLContext()


### PR DESCRIPTION
This pull requests *retains but deprecates* the `verify=<...>` and `cert=<...>` parameters, and the `httpx.create_ssl_context()` helper function.

* `verify=<...>` becomes deprecated. Use `ssl_context = httpx.SSLContext()` instead.
* `cert=<...>` becomes deprecated. Use `ssl_context = httpx.SSLContext()` instead.
* `create_ssl_context()` becomes deprecated. Use `ssl_context = httpx.SSLContext()` instead.

The `SSL_CERT_FILE` and `SSL_CERT_DIR` environment variables are no longer supported by default.

I think this probably gets the branch to a point where we could release a 0.28 version introducing the deprecation gradually.

Thoughts?