### PR TITLE
Lazy load httpcore, ssl, certifi

### DIFF
--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import logging
 import os
-import ssl
 import typing
 from pathlib import Path
+
+if typing.TYPE_CHECKING:
+    import ssl
 
 from ._compat import set_minimum_tls_version_1_2
 from ._models import Headers
@@ -59,7 +61,8 @@ class SSLConfig:
     """
     SSL Configuration.
     """
-    DEFAULT_CA_BUNDLE_PATH: Path | None = None
+
+    DEFAULT_CA_BUNDLE_PATH = Path()
 
     def __init__(
         self,
@@ -70,6 +73,7 @@ class SSLConfig:
         http2: bool = False,
     ) -> None:
         import certifi
+
         SSLConfig.DEFAULT_CA_BUNDLE_PATH = Path(certifi.where())
         self.cert = cert
         self.verify = verify
@@ -94,6 +98,8 @@ class SSLConfig:
         """
         Return an SSL context for unverified connections.
         """
+        import ssl
+
         context = self._create_default_ssl_context()
         context.check_hostname = False
         context.verify_mode = ssl.CERT_NONE
@@ -104,6 +110,8 @@ class SSLConfig:
         """
         Return an SSL context for verified connections.
         """
+        import ssl
+
         if self.trust_env and self.verify is True:
             ca_bundle = get_ca_bundle_from_env()
             if ca_bundle is not None:
@@ -160,6 +168,8 @@ class SSLConfig:
         Creates the default SSLContext object that's used for both verified
         and unverified connections.
         """
+        import ssl
+
         context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         set_minimum_tls_version_1_2(context)
         context.options |= ssl.OP_NO_COMPRESSION

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -70,7 +70,7 @@ class SSLConfig:
         http2: bool = False,
     ) -> None:
         import certifi
-        SSLConfig.DEFAULT_CA_PATH = Path(certifi.where())
+        SSLConfig.DEFAULT_CA_BUNDLE_PATH = Path(certifi.where())
         self.cert = cert
         self.verify = verify
         self.trust_env = trust_env

--- a/httpx/_main.py
+++ b/httpx/_main.py
@@ -6,7 +6,6 @@ import sys
 import typing
 
 import click
-import httpcore
 import pygments.lexers
 import pygments.util
 import rich.console
@@ -20,6 +19,10 @@ from ._exceptions import RequestError
 from ._models import Response
 from ._status_codes import codes
 
+# don't import httpcore until we
+# use a transport which needs it
+if typing.TYPE_CHECKING:
+    import httpcore
 
 def print_help() -> None:
     console = rich.console.Console()
@@ -111,7 +114,7 @@ def get_lexer_for_response(response: Response) -> str:
     return ""  # pragma: no cover
 
 
-def format_request_headers(request: httpcore.Request, http2: bool = False) -> str:
+def format_request_headers(request:  httpcore.Request, http2: bool = False) -> str:
     version = "HTTP/2" if http2 else "HTTP/1.1"
     headers = [
         (name.lower() if http2 else name, value) for name, value in request.headers

--- a/httpx/_main.py
+++ b/httpx/_main.py
@@ -24,6 +24,7 @@ from ._status_codes import codes
 if typing.TYPE_CHECKING:
     import httpcore
 
+
 def print_help() -> None:
     console = rich.console.Console()
 
@@ -114,7 +115,7 @@ def get_lexer_for_response(response: Response) -> str:
     return ""  # pragma: no cover
 
 
-def format_request_headers(request:  httpcore.Request, http2: bool = False) -> str:
+def format_request_headers(request: httpcore.Request, http2: bool = False) -> str:
     version = "HTTP/2" if http2 else "HTTP/1.1"
     headers = [
         (name.lower() if http2 else name, value) for name, value in request.headers

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,6 +4,18 @@ import pytest
 
 import httpx
 
+# check that httpcore isn't imported until we do a request
+def test_httpcore_lazy_loading(server):
+    import sys
+    # unload our module if it is already loaded
+    if httpx in sys.modules:
+        del sys.modules['httpx']
+        del sys.modules['httpcore']
+    import httpx
+    assert("httpcore" not in sys.modules)
+    response = httpx.get(server.url)
+    assert("httpcore" in sys.modules)
+
 
 def test_get(server):
     response = httpx.get(server.url)
@@ -85,3 +97,4 @@ def test_stream(server):
 def test_get_invalid_url():
     with pytest.raises(httpx.UnsupportedProtocol):
         httpx.get("invalid://example.org")
+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,7 +8,7 @@ import httpx
 def test_httpcore_lazy_loading(server):
     import sys
     # unload our module if it is already loaded
-    if httpx in sys.modules:
+    if "httpx" in sys.modules:
         del sys.modules['httpx']
         del sys.modules['httpcore']
     import httpx

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,17 +4,20 @@ import pytest
 
 import httpx
 
+
 # check that httpcore isn't imported until we do a request
 def test_httpcore_lazy_loading(server):
     import sys
+
     # unload our module if it is already loaded
     if "httpx" in sys.modules:
-        del sys.modules['httpx']
-        del sys.modules['httpcore']
+        del sys.modules["httpx"]
+        del sys.modules["httpcore"]
     import httpx
-    assert("httpcore" not in sys.modules)
-    response = httpx.get(server.url)
-    assert("httpcore" in sys.modules)
+
+    assert "httpcore" not in sys.modules
+    _response = httpx.get(server.url)
+    assert "httpcore" in sys.modules
 
 
 def test_get(server):
@@ -97,4 +100,3 @@ def test_stream(server):
 def test_get_invalid_url():
     with pytest.raises(httpx.UnsupportedProtocol):
         httpx.get("invalid://example.org")
-

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -222,15 +222,32 @@ def test_invalid_proxy_scheme():
     with pytest.raises(ValueError):
         httpx.Proxy("invalid://example.com")
 
+
 def test_certifi_lazy_loading():
-    global httpx,certifi
+    global httpx, certifi
     import sys
+
     del sys.modules["httpx"]
     del sys.modules["certifi"]
     del httpx
     del certifi
     import httpx
-    assert("certifi" not in sys.modules)
-    context = httpx.create_ssl_context()
-    assert("certifi" in sys.modules)
 
+    assert "certifi" not in sys.modules
+    _context = httpx.create_ssl_context()
+    assert "certifi" in sys.modules
+
+
+def test_ssl_lazy_loading():
+    global httpx, ssl
+    import sys
+
+    del sys.modules["httpx"]
+    del sys.modules["ssl"]
+    del httpx
+    del ssl
+    import httpx
+
+    assert "ssl" not in sys.modules
+    _context = httpx.create_ssl_context()
+    assert "ssl" in sys.modules


### PR DESCRIPTION
This change makes httpcore, certifi and ssl only be loaded when the transport that uses it is actually instantiated.

As suggested in:
https://github.com/encode/httpx/pull/3330