### PR TITLE
Cleanup unneccessary test case

### DIFF
--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -271,29 +271,6 @@ def test_netrc_auth_credentials_do_not_exist() -> None:
 
 
 @pytest.mark.skipif(
-    sys.version_info < (3, 11),
-    reason="netrc files without a password are invalid with Python < 3.11",
-)
-def test_netrc_auth_nopassword() -> None:  # pragma: no cover
-    """
-    Python has different netrc parsing behaviours with different versions.
-    For Python 3.11+ a netrc file with no password is valid. In this case
-    we want to check that we allow the netrc auth, and simply don't provide
-    any credentials in the request.
-    """
-    netrc_file = str(FIXTURES_DIR / ".netrc-nopassword")
-    url = "http://example.org"
-    app = App()
-    auth = httpx.NetRCAuth(netrc_file)
-
-    with httpx.Client(transport=httpx.MockTransport(app), auth=auth) as client:
-        response = client.get(url)
-
-    assert response.status_code == 200
-    assert response.json() == {"auth": None}
-
-
-@pytest.mark.skipif(
     sys.version_info >= (3, 11),
     reason="netrc files without a password are valid from Python >= 3.11",
 )


### PR DESCRIPTION
This test case issues a warning on 3.11+

```
tests/client/test_auth.py:273: netrc files without a password are invalid with Python < 3.11
```

Let's just tidy this case up completely.