### PR TITLE
Move normalize header functions from _utils.py to _models.py

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -54,6 +54,13 @@ from ._utils import (
 __all__ = ["Cookies", "Headers", "Request", "Response"]
 
 
+def _normalize_header_key(key: str | bytes, encoding: str | None = None) -> bytes:
+    """
+    Coerce str/bytes into a strictly byte-wise HTTP header key.
+    """
+    return key if isinstance(key, bytes) else key.encode(encoding or "ascii")
+
+
 def _normalize_header_value(value: str | bytes, encoding: str | None = None) -> bytes:
     """
     Coerce str/bytes into a strictly byte-wise HTTP header value.
@@ -81,12 +88,12 @@ class Headers(typing.MutableMapping[str, str]):
             self._list = list(headers._list)
         elif isinstance(headers, Mapping):
             for k, v in headers.items():
-                bytes_key = k if isinstance(k, bytes) else k.encode(encoding or "ascii")
+                bytes_key = _normalize_header_key(k, encoding)
                 bytes_value = _normalize_header_value(v, encoding)
                 self._list.append((bytes_key, bytes_key.lower(), bytes_value))
         elif headers is not None:
             for k, v in headers:
-                bytes_key = k if isinstance(k, bytes) else k.encode(encoding or "ascii")
+                bytes_key = _normalize_header_key(k, encoding)
                 bytes_value = _normalize_header_value(v, encoding)
                 self._list.append((bytes_key, bytes_key.lower(), bytes_value))
 

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -46,14 +46,23 @@ from ._types import (
 from ._urls import URL
 from ._utils import (
     is_known_encoding,
-    normalize_header_key,
-    normalize_header_value,
     obfuscate_sensitive_headers,
     parse_content_type_charset,
     parse_header_links,
 )
 
 __all__ = ["Cookies", "Headers", "Request", "Response"]
+
+
+def _normalize_header_value(value: str | bytes, encoding: str | None = None) -> bytes:
+    """
+    Coerce str/bytes into a strictly byte-wise HTTP header value.
+    """
+    if isinstance(value, bytes):
+        return value
+    if not isinstance(value, str):
+        raise TypeError(f"Header value must be str or bytes, not {type(value)}")
+    return value.encode(encoding or "ascii")
 
 
 class Headers(typing.MutableMapping[str, str]):
@@ -66,28 +75,20 @@ class Headers(typing.MutableMapping[str, str]):
         headers: HeaderTypes | None = None,
         encoding: str | None = None,
     ) -> None:
-        if headers is None:
-            self._list = []  # type: typing.List[typing.Tuple[bytes, bytes, bytes]]
-        elif isinstance(headers, Headers):
+        self._list = []  # type: typing.List[typing.Tuple[bytes, bytes, bytes]]
+
+        if isinstance(headers, Headers):
             self._list = list(headers._list)
         elif isinstance(headers, Mapping):
-            self._list = [
-                (
-                    normalize_header_key(k, lower=False, encoding=encoding),
-                    normalize_header_key(k, lower=True, encoding=encoding),
-                    normalize_header_value(v, encoding),
-                )
-                for k, v in headers.items()
-            ]
-        else:
-            self._list = [
-                (
-                    normalize_header_key(k, lower=False, encoding=encoding),
-                    normalize_header_key(k, lower=True, encoding=encoding),
-                    normalize_header_value(v, encoding),
-                )
-                for k, v in headers
-            ]
+            for k, v in headers.items():
+                bytes_key = k if isinstance(k, bytes) else k.encode(encoding or "ascii")
+                bytes_value = _normalize_header_value(v, encoding)
+                self._list.append((bytes_key, bytes_key.lower(), bytes_value))
+        elif headers is not None:
+            for k, v in headers:
+                bytes_key = k if isinstance(k, bytes) else k.encode(encoding or "ascii")
+                bytes_value = _normalize_header_value(v, encoding)
+                self._list.append((bytes_key, bytes_key.lower(), bytes_value))
 
         self._encoding = encoding
 

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -24,33 +24,6 @@ _HTML5_FORM_ENCODING_RE = re.compile(
 )
 
 
-def normalize_header_key(
-    value: str | bytes,
-    lower: bool,
-    encoding: str | None = None,
-) -> bytes:
-    """
-    Coerce str/bytes into a strictly byte-wise HTTP header key.
-    """
-    if isinstance(value, bytes):
-        bytes_value = value
-    else:
-        bytes_value = value.encode(encoding or "ascii")
-
-    return bytes_value.lower() if lower else bytes_value
-
-
-def normalize_header_value(value: str | bytes, encoding: str | None = None) -> bytes:
-    """
-    Coerce str/bytes into a strictly byte-wise HTTP header value.
-    """
-    if isinstance(value, bytes):
-        return value
-    if not isinstance(value, str):
-        raise TypeError(f"Header value must be str or bytes, not {type(value)}")
-    return value.encode(encoding or "ascii")
-
-
 def primitive_value_to_str(value: PrimitiveData) -> str:
     """
     Coerce a primitive data type into a string value.


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Issue: #3381

This PR refactors  the `normalize_header_key` as an inline method and moves `normalize_header_value` function to _models.py from _utils.py.   

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
