### PR TITLE
Make it work without ssl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 This release introduces an `httpx.SSLContext()` class and `ssl_context` parameter.
 
+* Made it possible to run on environments where 'ssl' is not importable (#3385)
 * Added `httpx.SSLContext` class and `ssl_context` parameter. (#3022, #3335)
 * The `verify` and `cert` arguments have been deprecated and will now raise warnings. (#3022, #3335)
 * The deprecated `proxies` argument has now been removed.

--- a/httpx/_api.py
+++ b/httpx/_api.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-import ssl
 import typing
 from contextlib import contextmanager
+
+if typing.TYPE_CHECKING:
+    import ssl  # pragma: no cover
 
 from ._client import Client
 from ._config import DEFAULT_TIMEOUT_CONFIG

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import datetime
 import enum
 import logging
-import ssl
 import time
 import typing
 import warnings
@@ -52,6 +51,10 @@ from ._utils import (
     is_https_redirect,
     same_origin,
 )
+
+if typing.TYPE_CHECKING:
+    import ssl  # pragma: no cover
+
 
 __all__ = ["USE_CLIENT_DEFAULT", "AsyncClient", "Client"]
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,5 @@
+import subprocess
+import sys
 import typing
 
 import pytest
@@ -89,14 +91,12 @@ def test_get_invalid_url():
 
 # check that httpcore isn't imported until we do a request
 def test_httpcore_lazy_loading(server):
-    import sys
-
-    # unload our module if it is already loaded
-    if "httpx" in sys.modules:
-        del sys.modules["httpx"]
-        del sys.modules["httpcore"]
-    import httpx
-
-    assert "httpcore" not in sys.modules
-    _response = httpx.get(server.url)
-    assert "httpcore" in sys.modules
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-c",
+            "import httpx,sys;assert 'httpcore' not in sys.modules;"
+            + f"_response = httpx.get('{server.url}');"
+            + "assert 'httpcore' in sys.modules",
+        ]
+    )


### PR DESCRIPTION
As per #3330  here is a change to make the core library code work if the ssl library is not importable (assuming the transport being used doesn't require it obviously). This will make emscripten support more download / load efficient, because it won't have to depend on ssl.