### PR TITLE
Move utility functions from _utils.py to _multipart.py

### DIFF
--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import codecs
 import email.message
 import ipaddress
-import mimetypes
 import os
 import re
 import typing
@@ -13,15 +12,6 @@ from ._types import PrimitiveData
 
 if typing.TYPE_CHECKING:  # pragma: no cover
     from ._urls import URL
-
-
-_HTML5_FORM_ENCODING_REPLACEMENTS = {'"': "%22", "\\": "\\\\"}
-_HTML5_FORM_ENCODING_REPLACEMENTS.update(
-    {chr(c): "%{:02X}".format(c) for c in range(0x1F + 1) if c != 0x1B}
-)
-_HTML5_FORM_ENCODING_RE = re.compile(
-    r"|".join([re.escape(c) for c in _HTML5_FORM_ENCODING_REPLACEMENTS.keys()])
-)
 
 
 def primitive_value_to_str(value: PrimitiveData) -> str:
@@ -48,18 +38,6 @@ def is_known_encoding(encoding: str) -> bool:
     except LookupError:
         return False
     return True
-
-
-def format_form_param(name: str, value: str) -> bytes:
-    """
-    Encode a name/value pair within a multipart form.
-    """
-
-    def replacer(match: typing.Match[str]) -> str:
-        return _HTML5_FORM_ENCODING_REPLACEMENTS[match.group(0)]
-
-    value = _HTML5_FORM_ENCODING_RE.sub(replacer, value)
-    return f'{name}="{value}"'.encode()
 
 
 def parse_header_links(value: str) -> list[dict[str, str]]:
@@ -214,12 +192,6 @@ def to_bytes_or_str(value: str, match_type_of: typing.AnyStr) -> typing.AnyStr:
 
 def unquote(value: str) -> str:
     return value[1:-1] if value[0] == value[-1] == '"' else value
-
-
-def guess_content_type(filename: str | None) -> str | None:
-    if filename:
-        return mimetypes.guess_type(filename)[0] or "application/octet-stream"
-    return None
 
 
 def peek_filelike_length(stream: typing.Any) -> int | None:


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary
Related issue: #3381

This PR moves the following utility functions from `_utils.py` to `_multipart.py` that are only used in `_multipart.py`
* `format_form_param`
* `guess_content_type`

# Checklist

- [ ] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
