### PR TITLE
Move utility functions from _utils.py to _client.py

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -46,12 +46,7 @@ from ._types import (
     TimeoutTypes,
 )
 from ._urls import URL, QueryParams
-from ._utils import (
-    URLPattern,
-    get_environment_proxies,
-    is_https_redirect,
-    same_origin,
-)
+from ._utils import URLPattern, get_environment_proxies
 
 __all__ = ["USE_CLIENT_DEFAULT", "AsyncClient", "Client"]
 
@@ -59,6 +54,38 @@ __all__ = ["USE_CLIENT_DEFAULT", "AsyncClient", "Client"]
 # https://www.python.org/dev/peps/pep-0484/#annotating-instance-and-class-methods
 T = typing.TypeVar("T", bound="Client")
 U = typing.TypeVar("U", bound="AsyncClient")
+
+
+def _is_https_redirect(url: URL, location: URL) -> bool:
+    """
+    Return 'True' if 'location' is a HTTPS upgrade of 'url'
+    """
+    if url.host != location.host:
+        return False
+
+    return (
+        url.scheme == "http"
+        and _port_or_default(url) == 80
+        and location.scheme == "https"
+        and _port_or_default(location) == 443
+    )
+
+
+def _port_or_default(url: URL) -> int | None:
+    if url.port is not None:
+        return url.port
+    return {"http": 80, "https": 443}.get(url.scheme)
+
+
+def _same_origin(url: URL, other: URL) -> bool:
+    """
+    Return 'True' if the given URLs share the same origin.
+    """
+    return (
+        url.scheme == other.scheme
+        and url.host == other.host
+        and _port_or_default(url) == _port_or_default(other)
+    )
 
 
 class UseClientDefault:
@@ -519,8 +546,8 @@ class BaseClient:
         """
         headers = Headers(request.headers)
 
-        if not same_origin(url, request.url):
-            if not is_https_redirect(request.url, url):
+        if not _same_origin(url, request.url):
+            if not _is_https_redirect(request.url, url):
                 # Strip Authorization headers when responses are redirected
                 # away from the origin. (Except for direct HTTP to HTTPS redirects.)
                 headers.pop("Authorization", None)

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -27,38 +27,6 @@ def primitive_value_to_str(value: PrimitiveData) -> str:
     return str(value)
 
 
-def port_or_default(url: URL) -> int | None:
-    if url.port is not None:
-        return url.port
-    return {"http": 80, "https": 443}.get(url.scheme)
-
-
-def same_origin(url: URL, other: URL) -> bool:
-    """
-    Return 'True' if the given URLs share the same origin.
-    """
-    return (
-        url.scheme == other.scheme
-        and url.host == other.host
-        and port_or_default(url) == port_or_default(other)
-    )
-
-
-def is_https_redirect(url: URL, location: URL) -> bool:
-    """
-    Return 'True' if 'location' is a HTTPS upgrade of 'url'
-    """
-    if url.host != location.host:
-        return False
-
-    return (
-        url.scheme == "http"
-        and port_or_default(url) == 80
-        and location.scheme == "https"
-        and port_or_default(location) == 443
-    )
-
-
 def get_environment_proxies() -> dict[str, str | None]:
     """Gets proxy information from the environment"""
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,10 +6,7 @@ import random
 import pytest
 
 import httpx
-from httpx._utils import (
-    URLPattern,
-    get_environment_proxies,
-)
+from httpx._utils import URLPattern, get_environment_proxies
 
 
 @pytest.mark.parametrize(
@@ -113,62 +110,6 @@ def test_get_environment_proxies(environment, proxies):
     os.environ.update(environment)
 
     assert get_environment_proxies() == proxies
-
-
-def test_same_origin():
-    origin = httpx.URL("https://example.com")
-    request = httpx.Request("GET", "HTTPS://EXAMPLE.COM:443")
-
-    client = httpx.Client()
-    headers = client._redirect_headers(request, origin, "GET")
-
-    assert headers["Host"] == request.url.netloc.decode("ascii")
-
-
-def test_not_same_origin():
-    origin = httpx.URL("https://example.com")
-    request = httpx.Request("GET", "HTTP://EXAMPLE.COM:80")
-
-    client = httpx.Client()
-    headers = client._redirect_headers(request, origin, "GET")
-
-    assert headers["Host"] == origin.netloc.decode("ascii")
-
-
-def test_is_https_redirect():
-    url = httpx.URL("https://example.com")
-    request = httpx.Request(
-        "GET", "http://example.com", headers={"Authorization": "empty"}
-    )
-
-    client = httpx.Client()
-    headers = client._redirect_headers(request, url, "GET")
-
-    assert "Authorization" in headers
-
-
-def test_is_not_https_redirect():
-    url = httpx.URL("https://www.example.com")
-    request = httpx.Request(
-        "GET", "http://example.com", headers={"Authorization": "empty"}
-    )
-
-    client = httpx.Client()
-    headers = client._redirect_headers(request, url, "GET")
-
-    assert "Authorization" not in headers
-
-
-def test_is_not_https_redirect_if_not_default_ports():
-    url = httpx.URL("https://example.com:1337")
-    request = httpx.Request(
-        "GET", "http://example.com:9999", headers={"Authorization": "empty"}
-    )
-
-    client = httpx.Client()
-    headers = client._redirect_headers(request, url, "GET")
-
-    assert "Authorization" not in headers
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary
Related issue: #3381

This PR moves the following remaining utility functions from `_utils.py` to `_client.py` that are only used in `_client.py`:
* `port_or_default`
* `same_origin`
* `is_https_redirect`

Related tests are also moved accordingly (to `tests/client/test_headers.py`)

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
