### PR TITLE
Graceful upgrade path for 0.28.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-This release introduces an `httpx.SSLContext()` class and `ssl_context` parameter.
+The 0.28 release includes a limited set of backwards incompatible changes.
 
-* Added `httpx.SSLContext` class and `ssl_context` parameter. (#3022, #3335)
-* The `verify` and `cert` arguments have been deprecated and will now raise warnings. (#3022, #3335)
+**Backwards incompatible changes**:
+
+SSL configuration has been significantly simplified.
+
+* The `verify` argument no longer accepts string arguments.
+* The `cert` argument has now been removed.
+* The `SSL_CERT_FILE` and `SSL_CERT_DIR` environment variables are no longer automatically used.
+
+For users of the standard `verify=True` or `verify=False` cases this should require no changes.
+
+For information on configuring more complex SSL cases, please see the [SSL documentation](docs/advanced/ssl.md).
+
+**The following changes are also included**:
+
+* The undocumented `URL.raw` property has now been deprecated, and will raise warnings.
 * The deprecated `proxies` argument has now been removed.
 * The deprecated `app` argument has now been removed.
-* The `URL.raw` property has now been removed.
 * Ensure JSON request bodies are compact. (#3363)
 * Review URL percent escape sets, based on WHATWG spec. (#3371, #3373)
 * Ensure `certifi` and `httpcore` are only imported if required. (#3377)

--- a/docs/advanced/ssl.md
+++ b/docs/advanced/ssl.md
@@ -93,7 +93,7 @@ If you do need to make HTTPS connections to a local server, for example to test 
 
 1. Use [trustme](https://github.com/python-trio/trustme) to generate a pair of server key/cert files, and a client cert file.
 2. Pass the server key/cert files when starting your local server. (This depends on the particular web server you're using. For example, [Uvicorn](https://www.uvicorn.org) provides the `--ssl-keyfile` and `--ssl-certfile` options.)
-3. Tell HTTPX to use the certificates stored in `client.pem`.
+3. Configure `httpx` to use the certificates stored in `client.pem`.
 
 ```python
 ctx = ssl.create_default_context(cafile="client.pem")

--- a/docs/advanced/ssl.md
+++ b/docs/advanced/ssl.md
@@ -16,99 +16,56 @@ You can disable SSL verification completely and allow insecure requests...
 <Response [200 OK]>
 ```
 
-For more complex configurations you can pass an SSL Context instance...
-
-```pycon
->>> import certifi, ssl
->>> ctx = ssl.create_default_context(cafile=certifi.where())
->>> response = httpx.get("https://www.example.com", verify=ctx)
-```
-
-The default configuration of `verify=True` uses certificates from `certifi` for the SSL context.
-
 ### Configuring client instances
 
-If you're using a `Client()` instance you should pass any verification settings when instantiating the client.
+If you're using a `Client()` instance you should pass any `verify=<...>` configuration when instantiating the client.
 
-```pycon
->>> ctx = ssl.create_default_context(cafile=certifi.where())
->>> client = httpx.Client(verify=ctx)
+By default the [certifi CA bundle](https://certifiio.readthedocs.io/en/latest/) is used for SSL verification.
+
+For more complex configurations you can pass an [SSL Context](https://docs.python.org/3/library/ssl.html) instance...
+
+```python
+import certifi
+import httpx
+import ssl
+
+# This SSL context is equivelent to the default `verify=True`.
+ctx = ssl.create_default_context(cafile=certifi.where())
+client = httpx.Client(verify=ctx)
 ```
 
-The `client.get(...)` method and other request methods on a `Client` instance *do not* support changing the SSL settings on a per-request basis.
-
-If you need different SSL settings in different cases you should use more than one client instance, with different settings on each. Each client will then be using an isolated connection pool with a specific fixed SSL configuration on all connections within that pool.
-
-### Configuring certificate stores
-
-By default, HTTPX uses the CA bundle provided by [Certifi](https://pypi.org/project/certifi/).
-
-You can load additional certificate verification using the [`.load_verify_locations()`](https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_verify_locations) API:
-
-```pycon
->>> ctx = ssl.create_default_context(cafile="path/to/certs.pem")
->>> client = httpx.Client(verify=ctx)
->>> client.get("https://www.example.com")
-<Response [200 OK]>
-```
-
-Or by providing an certificate directory:
-
-```pycon
->>> ctx = ssl.create_default_context(capath="path/to/certdir")
->>> client = httpx.Client(verify=ctx)
->>> client.get("https://www.example.com")
-<Response [200 OK]>
-```
-
-### Client side certificates
-
-You can also specify a local cert to use as a client-side certificate, using the [`.load_cert_chain()`](https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_cert_chain) API:
-
-```pycon
->>> ctx = ssl.create_default_context()
->>> ctx.load_cert_chain(certfile="path/to/client.pem")
->>> httpx.get("https://example.org", verify=ctx)
-<Response [200 OK]>
-```
-
-Or including a keyfile...
-
-```pycon
->>> ctx = ssl.create_default_context()
->>> ctx.load_cert_chain(
-        certfile="path/to/client.pem",
-        keyfile="path/to/client.key"
-    )
->>> httpx.get("https://example.org", verify=ctx)
-<Response [200 OK]>
-```
-
-Or including a keyfile and password...
-
-```pycon
->>> ctx = ssl.create_default_context()
->>> ctx.load_cert_chain(
-        certfile="path/to/client.pem",
-        keyfile="path/to/client.key"
-        password="password"
-    )
->>> httpx.get("https://example.org", verify=ctx)
-<Response [200 OK]>
-```
-
-### Using alternate SSL contexts
-
-You can also use an alternate `ssl.SSLContext` instances.
-
-For example, [using the `truststore` package](https://truststore.readthedocs.io/)...
+Using [the `truststore` package](https://truststore.readthedocs.io/) to support system certificate stores...
 
 ```python
 import ssl
 import truststore
 import httpx
 
+# Use system certificate stores.
 ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+client = httpx.Client(verify=ctx)
+```
+
+Loding an alternative certificate verification store using [the standard SSL context API](https://docs.python.org/3/library/ssl.html)...
+
+```python
+import httpx
+import ssl
+
+# Use an explicitly configured certificate store.
+ctx = ssl.create_default_context(cafile="path/to/certs.pem")  # Either cafile or capath.
+client = httpx.Client(verify=ctx)
+```
+
+### Client side certificates
+
+Client side certificates allow a remote server to verify the client. They tend to be used within private organizations to authenticate requests to remote servers.
+
+You can specify client-side certificates, using the [`.load_cert_chain()`](https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_cert_chain) API...
+
+```python
+ctx = ssl.create_default_context()
+ctx.load_cert_chain(certfile="path/to/client.pem")  # Optionally also keyfile or password.
 client = httpx.Client(verify=ctx)
 ```
 
@@ -120,61 +77,25 @@ For example...
 
 ```python
 # Use `SSL_CERT_FILE` or `SSL_CERT_DIR` if configured.
-# Default to certifi.
+# Otherwise default to certifi.
 ctx = ssl.create_default_context(
     cafile=os.environ.get("SSL_CERT_FILE", certifi.where()),
     capath=os.environ.get("SSL_CERT_DIR"),
 )
-```
-
-## `SSLKEYLOGFILE`
-
-Valid values: a filename
-
-If this environment variable is set, TLS keys will be appended to the specified file, creating it if it doesn't exist, whenever key material is generated or received. The keylog file is designed for debugging purposes only.
-
-Support for `SSLKEYLOGFILE` requires Python 3.8 and OpenSSL 1.1.1 or newer.
-
-Example:
-
-```python
-# test_script.py
-import httpx
-
-with httpx.Client() as client:
-    r = client.get("https://google.com")
-```
-
-```console
-SSLKEYLOGFILE=test.log python test_script.py
-cat test.log
-# TLS secrets log file, generated by OpenSSL / Python
-SERVER_HANDSHAKE_TRAFFIC_SECRET XXXX
-EXPORTER_SECRET XXXX
-SERVER_TRAFFIC_SECRET_0 XXXX
-CLIENT_HANDSHAKE_TRAFFIC_SECRET XXXX
-CLIENT_TRAFFIC_SECRET_0 XXXX
-SERVER_HANDSHAKE_TRAFFIC_SECRET XXXX
-EXPORTER_SECRET XXXX
-SERVER_TRAFFIC_SECRET_0 XXXX
-CLIENT_HANDSHAKE_TRAFFIC_SECRET XXXX
-CLIENT_TRAFFIC_SECRET_0 XXXX
+client = httpx.Client(verify=ctx)
 ```
 
 ### Making HTTPS requests to a local server
 
 When making requests to local servers, such as a development server running on `localhost`, you will typically be using unencrypted HTTP connections.
 
-If you do need to make HTTPS connections to a local server, for example to test an HTTPS-only service, you will need to create and use your own certificates. Here's one way to do it:
+If you do need to make HTTPS connections to a local server, for example to test an HTTPS-only service, you will need to create and use your own certificates. Here's one way to do it...
 
 1. Use [trustme](https://github.com/python-trio/trustme) to generate a pair of server key/cert files, and a client cert file.
 2. Pass the server key/cert files when starting your local server. (This depends on the particular web server you're using. For example, [Uvicorn](https://www.uvicorn.org) provides the `--ssl-keyfile` and `--ssl-certfile` options.)
-3. Tell HTTPX to use the certificates stored in `client.pem`:
+3. Tell HTTPX to use the certificates stored in `client.pem`.
 
-```pycon
->>> ctx = ssl.create_default_context()
->>> ctx.load_verify_locations(cafile="/tmp/client.pem")
->>> r = httpx.get("https://localhost:8000", verify=ctx)
->>> r
-Response <200 OK>
+```python
+ctx = ssl.create_default_context(cafile="client.pem")
+client = httpx.Client(verify=ctx)
 ```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -210,12 +210,9 @@ configure HTTPX as described in the
 the [SSL certificates section](https://www.python-httpx.org/advanced/ssl/),
 this is where our previously generated `client.pem` comes in:
 
-```
-import httpx
-
-with httpx.Client(proxy="http://127.0.0.1:8080/", verify="/path/to/client.pem") as client:
-    response = client.get("https://example.org")
-    print(response.status_code)  # should print 200
+```python
+ctx = ssl.create_default_context(cafile="/path/to/client.pem")
+client = httpx.Client(proxy="http://127.0.0.1:8080/", verify=ctx)
 ```
 
 Note, however, that HTTPS requests will only succeed to the host specified

--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -81,7 +81,6 @@ __all__ = [
     "RequestNotRead",
     "Response",
     "ResponseNotRead",
-    "SSLContext",
     "stream",
     "StreamClosed",
     "StreamConsumed",

--- a/httpx/_api.py
+++ b/httpx/_api.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import ssl
 import typing
 from contextlib import contextmanager
 
@@ -19,6 +18,10 @@ from ._types import (
     TimeoutTypes,
 )
 from ._urls import URL
+
+if typing.TYPE_CHECKING:
+    import ssl  # pragma: no cover
+
 
 __all__ = [
     "delete",
@@ -48,11 +51,8 @@ def request(
     proxy: ProxyTypes | None = None,
     timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
     follow_redirects: bool = False,
-    ssl_context: ssl.SSLContext | None = None,
+    verify: ssl.SSLContext | bool = True,
     trust_env: bool = True,
-    # Deprecated in favor of `ssl_context`...
-    verify: typing.Any = None,
-    cert: typing.Any = None,
 ) -> Response:
     """
     Sends an HTTP request.
@@ -82,8 +82,9 @@ def request(
     * **timeout** - *(optional)* The timeout configuration to use when sending
     the request.
     * **follow_redirects** - *(optional)* Enables or disables HTTP redirects.
-    * **ssl_context** - *(optional)* An SSL certificate used by the requested host
-    to authenticate the client.
+    * **verify** - *(optional)* Either `True` to use an SSL context with the
+    default CA bundle, `False` to disable verification, or an instance of
+    `ssl.SSLContext` to use a custom context.
     * **trust_env** - *(optional)* Enables or disables usage of environment
     variables for configuration.
 
@@ -101,11 +102,9 @@ def request(
     with Client(
         cookies=cookies,
         proxy=proxy,
-        ssl_context=ssl_context,
+        verify=verify,
         timeout=timeout,
         trust_env=trust_env,
-        verify=verify,
-        cert=cert,
     ) as client:
         return client.request(
             method=method,
@@ -137,11 +136,8 @@ def stream(
     proxy: ProxyTypes | None = None,
     timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
     follow_redirects: bool = False,
-    ssl_context: ssl.SSLContext | None = None,
+    verify: ssl.SSLContext | bool = True,
     trust_env: bool = True,
-    # Deprecated in favor of `ssl_context`...
-    verify: typing.Any = None,
-    cert: typing.Any = None,
 ) -> typing.Iterator[Response]:
     """
     Alternative to `httpx.request()` that streams the response body
@@ -156,11 +152,9 @@ def stream(
     with Client(
         cookies=cookies,
         proxy=proxy,
-        ssl_context=ssl_context,
+        verify=verify,
         timeout=timeout,
         trust_env=trust_env,
-        verify=verify,
-        cert=cert,
     ) as client:
         with client.stream(
             method=method,
@@ -186,12 +180,9 @@ def get(
     auth: AuthTypes | None = None,
     proxy: ProxyTypes | None = None,
     follow_redirects: bool = False,
-    ssl_context: ssl.SSLContext | None = None,
+    verify: ssl.SSLContext | bool = True,
     timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
     trust_env: bool = True,
-    # Deprecated in favor of `ssl_context`...
-    verify: typing.Any = None,
-    cert: typing.Any = None,
 ) -> Response:
     """
     Sends a `GET` request.
@@ -210,11 +201,9 @@ def get(
         auth=auth,
         proxy=proxy,
         follow_redirects=follow_redirects,
-        ssl_context=ssl_context,
+        verify=verify,
         timeout=timeout,
         trust_env=trust_env,
-        verify=verify,
-        cert=cert,
     )
 
 
@@ -227,12 +216,9 @@ def options(
     auth: AuthTypes | None = None,
     proxy: ProxyTypes | None = None,
     follow_redirects: bool = False,
-    ssl_context: ssl.SSLContext | None = None,
+    verify: ssl.SSLContext | bool = True,
     timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
     trust_env: bool = True,
-    # Deprecated in favor of `ssl_context`...
-    verify: typing.Any = None,
-    cert: typing.Any = None,
 ) -> Response:
     """
     Sends an `OPTIONS` request.
@@ -251,11 +237,9 @@ def options(
         auth=auth,
         proxy=proxy,
         follow_redirects=follow_redirects,
-        ssl_context=ssl_context,
+        verify=verify,
         timeout=timeout,
         trust_env=trust_env,
-        verify=verify,
-        cert=cert,
     )
 
 
@@ -268,12 +252,9 @@ def head(
     auth: AuthTypes | None = None,
     proxy: ProxyTypes | None = None,
     follow_redirects: bool = False,
-    ssl_context: ssl.SSLContext | None = None,
+    verify: ssl.SSLContext | bool = True,
     timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
     trust_env: bool = True,
-    # Deprecated in favor of `ssl_context`...
-    verify: typing.Any = None,
-    cert: typing.Any = None,
 ) -> Response:
     """
     Sends a `HEAD` request.
@@ -292,11 +273,9 @@ def head(
         auth=auth,
         proxy=proxy,
         follow_redirects=follow_redirects,
-        ssl_context=ssl_context,
+        verify=verify,
         timeout=timeout,
         trust_env=trust_env,
-        verify=verify,
-        cert=cert,
     )
 
 
@@ -313,12 +292,9 @@ def post(
     auth: AuthTypes | None = None,
     proxy: ProxyTypes | None = None,
     follow_redirects: bool = False,
-    ssl_context: ssl.SSLContext | None = None,
+    verify: ssl.SSLContext | bool = True,
     timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
     trust_env: bool = True,
-    # Deprecated in favor of `ssl_context`...
-    verify: typing.Any = None,
-    cert: typing.Any = None,
 ) -> Response:
     """
     Sends a `POST` request.
@@ -338,11 +314,9 @@ def post(
         auth=auth,
         proxy=proxy,
         follow_redirects=follow_redirects,
-        ssl_context=ssl_context,
+        verify=verify,
         timeout=timeout,
         trust_env=trust_env,
-        verify=verify,
-        cert=cert,
     )
 
 
@@ -359,12 +333,9 @@ def put(
     auth: AuthTypes | None = None,
     proxy: ProxyTypes | None = None,
     follow_redirects: bool = False,
-    ssl_context: ssl.SSLContext | None = None,
+    verify: ssl.SSLContext | bool = True,
     timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
     trust_env: bool = True,
-    # Deprecated in favor of `ssl_context`...
-    verify: typing.Any = None,
-    cert: typing.Any = None,
 ) -> Response:
     """
     Sends a `PUT` request.
@@ -384,11 +355,9 @@ def put(
         auth=auth,
         proxy=proxy,
         follow_redirects=follow_redirects,
-        ssl_context=ssl_context,
+        verify=verify,
         timeout=timeout,
         trust_env=trust_env,
-        verify=verify,
-        cert=cert,
     )
 
 
@@ -405,12 +374,9 @@ def patch(
     auth: AuthTypes | None = None,
     proxy: ProxyTypes | None = None,
     follow_redirects: bool = False,
-    ssl_context: ssl.SSLContext | None = None,
+    verify: ssl.SSLContext | bool = True,
     timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
     trust_env: bool = True,
-    # Deprecated in favor of `ssl_context`...
-    verify: typing.Any = None,
-    cert: typing.Any = None,
 ) -> Response:
     """
     Sends a `PATCH` request.
@@ -430,11 +396,9 @@ def patch(
         auth=auth,
         proxy=proxy,
         follow_redirects=follow_redirects,
-        ssl_context=ssl_context,
+        verify=verify,
         timeout=timeout,
         trust_env=trust_env,
-        verify=verify,
-        cert=cert,
     )
 
 
@@ -448,11 +412,8 @@ def delete(
     proxy: ProxyTypes | None = None,
     follow_redirects: bool = False,
     timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
-    ssl_context: ssl.SSLContext | None = None,
+    verify: ssl.SSLContext | bool = True,
     trust_env: bool = True,
-    # Deprecated in favor of `ssl_context`...
-    verify: typing.Any = None,
-    cert: typing.Any = None,
 ) -> Response:
     """
     Sends a `DELETE` request.
@@ -471,9 +432,7 @@ def delete(
         auth=auth,
         proxy=proxy,
         follow_redirects=follow_redirects,
-        ssl_context=ssl_context,
+        verify=verify,
         timeout=timeout,
         trust_env=trust_env,
-        verify=verify,
-        cert=cert,
     )

--- a/httpx/_main.py
+++ b/httpx/_main.py
@@ -15,7 +15,6 @@ import rich.syntax
 import rich.table
 
 from ._client import Client
-from ._config import SSLContext
 from ._exceptions import RequestError
 from ._models import Response
 from ._status_codes import codes
@@ -476,11 +475,8 @@ def main(
     if not method:
         method = "POST" if content or data or files or json else "GET"
 
-    ssl_context = SSLContext(verify=verify)
     try:
-        with Client(
-            proxy=proxy, timeout=timeout, http2=http2, ssl_context=ssl_context
-        ) as client:
+        with Client(proxy=proxy, timeout=timeout, http2=http2, verify=verify) as client:
             with client.stream(
                 method,
                 url,

--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -35,7 +35,7 @@ if typing.TYPE_CHECKING:
 
     import httpx  # pragma: no cover
 
-from .._config import DEFAULT_LIMITS, Limits, Proxy, SSLContext, create_ssl_context
+from .._config import DEFAULT_LIMITS, Limits, Proxy, create_ssl_context
 from .._exceptions import (
     ConnectError,
     ConnectTimeout,
@@ -135,7 +135,7 @@ class ResponseStream(SyncByteStream):
 class HTTPTransport(BaseTransport):
     def __init__(
         self,
-        ssl_context: ssl.SSLContext | None = None,
+        verify: ssl.SSLContext | bool = True,
         http1: bool = True,
         http2: bool = False,
         limits: Limits = DEFAULT_LIMITS,
@@ -144,18 +144,11 @@ class HTTPTransport(BaseTransport):
         local_address: str | None = None,
         retries: int = 0,
         socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
-        # Deprecated...
-        verify: typing.Any = None,
-        cert: typing.Any = None,
     ) -> None:
         import httpcore
 
         proxy = Proxy(url=proxy) if isinstance(proxy, (str, URL)) else proxy
-        if verify is not None or cert is not None:  # pragma: nocover
-            # Deprecated...
-            ssl_context = create_ssl_context(verify, cert)
-        else:
-            ssl_context = ssl_context or SSLContext()
+        ssl_context = create_ssl_context(verify=verify)
 
         if proxy is None:
             self._pool = httpcore.ConnectionPool(
@@ -284,7 +277,7 @@ class AsyncResponseStream(AsyncByteStream):
 class AsyncHTTPTransport(AsyncBaseTransport):
     def __init__(
         self,
-        ssl_context: ssl.SSLContext | None = None,
+        verify: ssl.SSLContext | bool = True,
         http1: bool = True,
         http2: bool = False,
         limits: Limits = DEFAULT_LIMITS,
@@ -293,18 +286,11 @@ class AsyncHTTPTransport(AsyncBaseTransport):
         local_address: str | None = None,
         retries: int = 0,
         socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
-        # Deprecated...
-        verify: typing.Any = None,
-        cert: typing.Any = None,
     ) -> None:
         import httpcore
 
         proxy = Proxy(url=proxy) if isinstance(proxy, (str, URL)) else proxy
-        if verify is not None or cert is not None:  # pragma: nocover
-            # Deprecated...
-            ssl_context = create_ssl_context(verify, cert)
-        else:
-            ssl_context = ssl_context or SSLContext()
+        ssl_context = create_ssl_context(verify=verify)
 
         if proxy is None:
             self._pool = httpcore.AsyncConnectionPool(

--- a/httpx/_urls.py
+++ b/httpx/_urls.py
@@ -407,7 +407,7 @@ class URL:
 
         warnings.warn("URL.raw is deprecated.")
         attributes = ["raw_scheme", "raw_host", "port", "raw_path"]
-        RawURL = collections.namedtuple('RawURL', attributes)
+        RawURL = collections.namedtuple("RawURL", attributes)
         return RawURL(
             self.raw_scheme,
             self.raw_host,

--- a/httpx/_urls.py
+++ b/httpx/_urls.py
@@ -406,7 +406,7 @@ class URL:
         import warnings
 
         warnings.warn("URL.raw is deprecated.")
-        attributes = ["raw_scheme", "raw_host", "port", "raw_path"],
+        attributes = ["raw_scheme", "raw_host", "port", "raw_path"]
         RawURL = collections.namedtuple('RawURL', attributes)
         return RawURL(
             self.raw_scheme,

--- a/httpx/_urls.py
+++ b/httpx/_urls.py
@@ -401,18 +401,19 @@ class URL:
         return f"{self.__class__.__name__}({url!r})"
 
     @property
-    def raw(self):  # pragma: nocover
+    def raw(self) -> tuple[bytes, bytes, int, bytes]:  # pragma: nocover
         import collections
         import warnings
 
         warnings.warn("URL.raw is deprecated.")
-        attributes = ["raw_scheme", "raw_host", "port", "raw_path"]
-        RawURL = collections.namedtuple("RawURL", attributes)
+        RawURL = collections.namedtuple(
+            "RawURL", ["raw_scheme", "raw_host", "port", "raw_path"]
+        )
         return RawURL(
-            self.raw_scheme,
-            self.raw_host,
-            self.port,
-            self.raw_path,
+            raw_scheme=self.raw_scheme,
+            raw_host=self.raw_host,
+            port=self.port,
+            raw_path=self.raw_path,
         )
 
 

--- a/httpx/_urls.py
+++ b/httpx/_urls.py
@@ -400,6 +400,21 @@ class URL:
 
         return f"{self.__class__.__name__}({url!r})"
 
+    @property
+    def raw(self):  # pragma: nocover
+        import collections
+        import warnings
+
+        warnings.warn("URL.raw is deprecated.")
+        attributes = ["raw_scheme", "raw_host", "port", "raw_path"],
+        RawURL = collections.namedtuple('RawURL', attributes)
+        return RawURL(
+            self.raw_scheme,
+            self.raw_host,
+            self.port,
+            self.raw_path,
+        )
+
 
 class QueryParams(typing.Mapping[str, str]):
     """


### PR DESCRIPTION
Suggested upgrade path for an upcoming 0.28 release...

We *do* have some backwards incompatible changes that we want to issue, but clearly need to minimise disruption to our userbase. Here's what we're currently looking at...

---

# Release Notes

The 0.28 release includes a limited set of backwards incompatible changes.

## Backwards incompatible changes

SSL configuration has been significantly simplified.

* The `verify` argument no longer accepts string arguments for custom verify paths.
* The `cert` argument has now been removed.
* The `SSL_CERT_FILE` and `SSL_CERT_DIR` environment variables are no longer automatically used.

For users of the standard `verify=True` or `verify=False` cases this should require no changes.

For information on configuring more complex SSL cases, please see the [SSL documentation](https://github.com/encode/httpx/blob/graceful-upgrade-path/docs/advanced/ssl.md).

## Other updates

* The undocumented `URL.raw` property has now been deprecated, and will raise warnings. (#3394)
* The deprecated `proxies` argument has now been removed. (#3319)
* The deprecated `app` argument has now been removed. (#3319)
* Ensure JSON request bodies are compact. (#3363)
* Review URL percent escape sets, based on WHATWG spec. (#3371, #3373)
* Ensure `certifi` and `httpcore` are only imported if required. (#3377)
* Treat `socks5h` as a valid proxy scheme. (#3178)
* Cleanup `Request()` method signature in line with `client.request()` and `httpx.request()`. (#3378)
