### PR TITLE
feat(content): allow multipart requests without files.

### DIFF
--- a/httpx/_content.py
+++ b/httpx/_content.py
@@ -208,7 +208,7 @@ def encode_request(
 
     if content is not None:
         return encode_content(content)
-    elif files:
+    elif files is not None:
         return encode_multipart_data(data or {}, files, boundary)
     elif data:
         return encode_urlencoded_data(data)

--- a/httpx/_main.py
+++ b/httpx/_main.py
@@ -487,7 +487,7 @@ def main(
                 params=list(params),
                 content=content,
                 data=dict(data),
-                files=files,  # type: ignore
+                files=files or None,  # type: ignore
                 json=json,
                 headers=headers,
                 cookies=dict(cookies),


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

related #3396.

Currently, a multipart request can only be sent when the files parameter is non-empty. This restriction limits cases where users might want to send data using multipart mode without attaching any files, which is possible in tools like Postman.

**Proposed Change**: Instead of requiring files to be non-empty, we could determine the need for a multipart request based on whether files is None rather than its emptiness. This would allow users to send multipart requests without attaching files if needed.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
