### PR TITLE
Error on verify as str.

### DIFF
--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -31,6 +31,14 @@ def create_ssl_context(verify: ssl.SSLContext | bool = True) -> ssl.SSLContext:
         ssl_context.check_hostname = False
         ssl_context.verify_mode = ssl.CERT_NONE
         return ssl_context
+    elif isinstance(verify, str):
+        # Explicitly handle this deprecated usage pattern.
+        msg = (
+            "verify should be a boolean or SSLContext, since version 0.28. "
+            "Use `verify=ssl.create_default_context(cafile=...)` "
+            "or `verify=ssl.create_default_context(capath=...)`."
+        )
+        raise RuntimeError(msg)
 
     return verify
 


### PR DESCRIPTION
For users working with `verify="/path/to/certs"` point them explicitly towards the more explicit usage style.