### PR TITLE
Change timeout values to be ints

### DIFF
--- a/docs/advanced/timeouts.md
+++ b/docs/advanced/timeouts.md
@@ -9,11 +9,11 @@ You can set timeouts for an individual request:
 
 ```python
 # Using the top-level API:
-httpx.get('http://example.com/api/v1/example', timeout=10.0)
+httpx.get('http://example.com/api/v1/example', timeout=10)
 
 # Using a client instance:
 with httpx.Client() as client:
-    client.get("http://example.com/api/v1/example", timeout=10.0)
+    client.get("http://example.com/api/v1/example", timeout=10)
 ```
 
 Or disable timeouts for an individual request:


### PR DESCRIPTION

<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Timeout values are specified as `Timeout | int | None` in `get` and etc. `httpx.Timeout` however accepts value of `float` type.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
