### PR TITLE
HOTFIX: Keyword param "proxies" is missing.

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -651,6 +651,7 @@ class Client(BaseClient):
         http1: bool = True,
         http2: bool = False,
         proxy: ProxyTypes | None = None,
+        proxies: dict[str, ProxyTypes] | None = None,
         mounts: None | (typing.Mapping[str, BaseTransport | None]) = None,
         timeout: TimeoutTypes = DEFAULT_TIMEOUT_CONFIG,
         follow_redirects: bool = False,


### PR DESCRIPTION
Update _client.py

"proxies" param is missing if passed as keyword argument. Even tough it should be there, since it is mentioned in the docstring as an optional param.

<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

I am adding "proxies" keyword params to optional Client() params. It should already be there to deal with a scenario in which it is going as a keyword argument, even if it is None. I am facing this scenario at the moment and I thought of adding this missing part of the code so others won't need to face it as well.
Also, docstring of the class mentions it, but it is not there in the __init__ params.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
