### PR TITLE
show how to send multipart form data without files

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -169,7 +169,7 @@ Form encoded data can also include multiple values from a given key.
 }
 ```
 
-## Sending Multipart File Uploads
+## Sending Multipart File Uploads and/or Data
 
 You can also upload files, using HTTP multipart encoding:
 
@@ -216,6 +216,23 @@ If you need to include non-file data fields in the multipart form, use the `data
   },
   "form": {
     "message": "Hello, world!",
+  },
+  ...
+}
+```
+
+If you need to send non-file data only, you can do so by using a tuple
+of items for the field value without a filename:
+
+```pycon
+>>> files = {'some-field': (None, "field-value")}
+>>> r = httpx.post("https://httpbin.org/post", files=files)
+>>> print(r.text)
+{
+  ...
+  "files": {},
+  "form": {
+    "some-field": "field-value"
   },
   ...
 }


### PR DESCRIPTION
# Summary

As it is, the documentation hints at the possibility of sending a request with a multipart form encoded  body, but it is not explicit about it.

Hence it takes more time to figure it out on your own, especially for a less experienced developer.

This PR only adds 1 example in the multipart section of the quickstart page to demonstrate the process.

# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] ~~I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.~~ Not applicable (only changed documentation)
- [X] I've updated the documentation accordingly.
