### PR TITLE
Enhance Tests: Replace Raw Status Codes with httpx.codes

### DIFF
--- a/tests/client/test_async_client.py
+++ b/tests/client/test_async_client.py
@@ -13,7 +13,7 @@ async def test_get(server):
     url = server.url
     async with httpx.AsyncClient(http2=True) as client:
         response = await client.get(url)
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.text == "Hello, world!"
     assert response.http_version == "HTTP/1.1"
     assert response.headers
@@ -45,7 +45,7 @@ async def test_build_request(server):
         request.headers.update(headers)
         response = await client.send(request)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.url == url
 
     assert response.json()["Custom-header"] == "value"
@@ -56,7 +56,7 @@ async def test_post(server):
     url = server.url
     async with httpx.AsyncClient() as client:
         response = await client.post(url, content=b"Hello, world!")
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
 
 
 @pytest.mark.anyio
@@ -64,7 +64,7 @@ async def test_post_json(server):
     url = server.url
     async with httpx.AsyncClient() as client:
         response = await client.post(url, json={"text": "Hello, world!"})
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
 
 
 @pytest.mark.anyio
@@ -73,7 +73,7 @@ async def test_stream_response(server):
         async with client.stream("GET", server.url) as response:
             body = await response.aread()
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert body == b"Hello, world!"
     assert response.content == b"Hello, world!"
 
@@ -84,7 +84,7 @@ async def test_access_content_stream_response(server):
         async with client.stream("GET", server.url) as response:
             pass
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     with pytest.raises(httpx.ResponseNotRead):
         response.content  # noqa: B018
 
@@ -97,7 +97,7 @@ async def test_stream_request(server):
 
     async with httpx.AsyncClient() as client:
         response = await client.post(server.url, content=hello_world())
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
 
 
 @pytest.mark.anyio
@@ -131,7 +131,7 @@ async def test_raise_for_status(server):
 async def test_options(server):
     async with httpx.AsyncClient() as client:
         response = await client.options(server.url)
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.text == "Hello, world!"
 
 
@@ -139,7 +139,7 @@ async def test_options(server):
 async def test_head(server):
     async with httpx.AsyncClient() as client:
         response = await client.head(server.url)
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.text == ""
 
 
@@ -147,21 +147,21 @@ async def test_head(server):
 async def test_put(server):
     async with httpx.AsyncClient() as client:
         response = await client.put(server.url, content=b"Hello, world!")
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
 
 
 @pytest.mark.anyio
 async def test_patch(server):
     async with httpx.AsyncClient() as client:
         response = await client.patch(server.url, content=b"Hello, world!")
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
 
 
 @pytest.mark.anyio
 async def test_delete(server):
     async with httpx.AsyncClient() as client:
         response = await client.delete(server.url)
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.text == "Hello, world!"
 
 
@@ -175,7 +175,7 @@ async def test_100_continue(server):
             server.url.copy_with(path="/echo_body"), headers=headers, content=content
         )
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.content == content
 
 
@@ -305,11 +305,11 @@ async def test_mounted_transport():
 
     async with httpx.AsyncClient(transport=transport, mounts=mounts) as client:
         response = await client.get("https://www.example.com")
-        assert response.status_code == 200
+        assert response.status_code == httpx.codes.OK.value
         assert response.json() == {"app": "unmounted"}
 
         response = await client.get("custom://www.example.com")
-        assert response.status_code == 200
+        assert response.status_code == httpx.codes.OK.value
         assert response.json() == {"app": "mounted"}
 
 
@@ -322,7 +322,7 @@ async def test_async_mock_transport():
 
     async with httpx.AsyncClient(transport=transport) as client:
         response = await client.get("https://www.example.com")
-        assert response.status_code == 200
+        assert response.status_code == httpx.codes.OK.value
         assert response.text == "Hello, world!"
 
 
@@ -371,5 +371,5 @@ async def test_server_extensions(server):
     url = server.url
     async with httpx.AsyncClient(http2=True) as client:
         response = await client.get(url)
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.extensions["http_version"] == b"HTTP/1.1"

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -168,7 +168,7 @@ async def test_basic_auth() -> None:
     async with httpx.AsyncClient(transport=httpx.MockTransport(app)) as client:
         response = await client.get(url, auth=auth)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {"auth": "Basic dXNlcjpwYXNzd29yZDEyMw=="}
 
 
@@ -187,7 +187,7 @@ async def test_basic_auth_with_stream() -> None:
         async with client.stream("GET", url) as response:
             await response.aread()
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {"auth": "Basic dXNlcjpwYXNzd29yZDEyMw=="}
 
 
@@ -199,7 +199,7 @@ async def test_basic_auth_in_url() -> None:
     async with httpx.AsyncClient(transport=httpx.MockTransport(app)) as client:
         response = await client.get(url)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {"auth": "Basic dXNlcjpwYXNzd29yZDEyMw=="}
 
 
@@ -214,7 +214,7 @@ async def test_basic_auth_on_session() -> None:
     ) as client:
         response = await client.get(url)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {"auth": "Basic dXNlcjpwYXNzd29yZDEyMw=="}
 
 
@@ -230,7 +230,7 @@ async def test_custom_auth() -> None:
     async with httpx.AsyncClient(transport=httpx.MockTransport(app)) as client:
         response = await client.get(url, auth=auth)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {"auth": "Token 123"}
 
 
@@ -247,7 +247,7 @@ def test_netrc_auth_credentials_exist() -> None:
     with httpx.Client(transport=httpx.MockTransport(app), auth=auth) as client:
         response = client.get(url)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {
         "auth": "Basic ZXhhbXBsZS11c2VybmFtZTpleGFtcGxlLXBhc3N3b3Jk"
     }
@@ -266,7 +266,7 @@ def test_netrc_auth_credentials_do_not_exist() -> None:
     with httpx.Client(transport=httpx.MockTransport(app), auth=auth) as client:
         response = client.get(url)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {"auth": None}
 
 
@@ -296,7 +296,7 @@ async def test_auth_disable_per_request() -> None:
     ) as client:
         response = await client.get(url, auth=None)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {"auth": None}
 
 
@@ -331,7 +331,7 @@ async def test_auth_property() -> None:
 
         url = "https://example.org/"
         response = await client.get(url)
-        assert response.status_code == 200
+        assert response.status_code == httpx.codes.OK.value
         assert response.json() == {"auth": "Basic dXNlcjpwYXNzd29yZDEyMw=="}
 
 
@@ -362,7 +362,7 @@ async def test_digest_auth_returns_no_auth_if_no_digest_header_in_response() -> 
     async with httpx.AsyncClient(transport=httpx.MockTransport(app)) as client:
         response = await client.get(url, auth=auth)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {"auth": None}
     assert len(response.history) == 0
 
@@ -376,7 +376,7 @@ def test_digest_auth_returns_no_auth_if_alternate_auth_scheme() -> None:
     client = httpx.Client(transport=httpx.MockTransport(app))
     response = client.get(url, auth=auth)
 
-    assert response.status_code == 401
+    assert response.status_code == httpx.codes.UNAUTHORIZED.value
     assert response.json() == {"auth": None}
     assert len(response.history) == 0
 
@@ -391,7 +391,7 @@ async def test_digest_auth_200_response_including_digest_auth_header() -> None:
     async with httpx.AsyncClient(transport=httpx.MockTransport(app)) as client:
         response = await client.get(url, auth=auth)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {"auth": None}
     assert len(response.history) == 0
 
@@ -405,7 +405,7 @@ async def test_digest_auth_401_response_without_digest_auth_header() -> None:
     async with httpx.AsyncClient(transport=httpx.MockTransport(app)) as client:
         response = await client.get(url, auth=auth)
 
-    assert response.status_code == 401
+    assert response.status_code == httpx.codes.UNAUTHORIZED.value
     assert response.json() == {"auth": None}
     assert len(response.history) == 0
 
@@ -434,7 +434,7 @@ async def test_digest_auth(
     async with httpx.AsyncClient(transport=httpx.MockTransport(app)) as client:
         response = await client.get(url, auth=auth)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert len(response.history) == 1
 
     authorization = typing.cast(typing.Dict[str, typing.Any], response.json())["auth"]
@@ -465,7 +465,7 @@ async def test_digest_auth_no_specified_qop() -> None:
     async with httpx.AsyncClient(transport=httpx.MockTransport(app)) as client:
         response = await client.get(url, auth=auth)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert len(response.history) == 1
 
     authorization = typing.cast(typing.Dict[str, typing.Any], response.json())["auth"]
@@ -497,7 +497,7 @@ async def test_digest_auth_qop_including_spaces_and_auth_returns_auth(qop: str) 
     async with httpx.AsyncClient(transport=httpx.MockTransport(app)) as client:
         response = await client.get(url, auth=auth)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert len(response.history) == 1
 
 
@@ -532,7 +532,7 @@ async def test_digest_auth_incorrect_credentials() -> None:
     async with httpx.AsyncClient(transport=httpx.MockTransport(app)) as client:
         response = await client.get(url, auth=auth)
 
-    assert response.status_code == 401
+    assert response.status_code == httpx.codes.UNAUTHORIZED.value
     assert len(response.history) == 1
 
 
@@ -546,8 +546,8 @@ async def test_digest_auth_reuses_challenge() -> None:
         response_1 = await client.get(url, auth=auth)
         response_2 = await client.get(url, auth=auth)
 
-        assert response_1.status_code == 200
-        assert response_2.status_code == 200
+        assert response_1.status_code == httpx.codes.OK.value
+        assert response_2.status_code == httpx.codes.OK.value
 
         assert len(response_1.history) == 1
         assert len(response_2.history) == 0
@@ -561,7 +561,7 @@ async def test_digest_auth_resets_nonce_count_after_401() -> None:
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(app)) as client:
         response_1 = await client.get(url, auth=auth)
-        assert response_1.status_code == 200
+        assert response_1.status_code == httpx.codes.OK.value
         assert len(response_1.history) == 1
 
         first_nonce = parse_keqv_list(
@@ -577,7 +577,7 @@ async def test_digest_auth_resets_nonce_count_after_401() -> None:
         # we expect the client again to try to authenticate,
         # i.e. the history length must be 1
         response_2 = await client.get(url, auth=auth)
-        assert response_2.status_code == 200
+        assert response_2.status_code == httpx.codes.OK.value
         assert len(response_2.history) == 1
 
         second_nonce = parse_keqv_list(
@@ -645,7 +645,7 @@ async def test_async_auth_history() -> None:
     async with httpx.AsyncClient(transport=httpx.MockTransport(app)) as client:
         response = await client.get(url, auth=auth)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {"auth": "Repeat abc.abc"}
 
     assert len(response.history) == 2
@@ -671,7 +671,7 @@ def test_sync_auth_history() -> None:
     with httpx.Client(transport=httpx.MockTransport(app)) as client:
         response = client.get(url, auth=auth)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {"auth": "Repeat abc.abc"}
 
     assert len(response.history) == 2
@@ -719,7 +719,7 @@ async def test_async_auth_reads_response_body() -> None:
     async with httpx.AsyncClient(transport=httpx.MockTransport(app)) as client:
         response = await client.get(url, auth=auth)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {"auth": '{"auth":"xyz"}'}
 
 
@@ -735,7 +735,7 @@ def test_sync_auth_reads_response_body() -> None:
     with httpx.Client(transport=httpx.MockTransport(app)) as client:
         response = client.get(url, auth=auth)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {"auth": '{"auth":"xyz"}'}
 
 
@@ -753,7 +753,7 @@ async def test_async_auth() -> None:
     async with httpx.AsyncClient(transport=httpx.MockTransport(app)) as client:
         response = await client.get(url, auth=auth)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {"auth": "async-auth"}
 
 
@@ -768,5 +768,5 @@ def test_sync_auth() -> None:
     with httpx.Client(transport=httpx.MockTransport(app)) as client:
         response = client.get(url, auth=auth)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {"auth": "sync-auth"}

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -17,7 +17,7 @@ def test_get(server):
     url = server.url
     with httpx.Client(http2=True) as http:
         response = http.get(url)
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.url == url
     assert response.content == b"Hello, world!"
     assert response.text == "Hello, world!"
@@ -53,7 +53,7 @@ def test_build_request(server):
         request.headers.update(headers)
         response = client.send(request)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.url == url
 
     assert response.json()["Custom-header"] == "value"
@@ -68,7 +68,7 @@ def test_build_post_request(server):
         request.headers.update(headers)
         response = client.send(request)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.url == url
 
     assert response.json()["Content-length"] == "0"
@@ -78,14 +78,14 @@ def test_build_post_request(server):
 def test_post(server):
     with httpx.Client() as client:
         response = client.post(server.url, content=b"Hello, world!")
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.reason_phrase == "OK"
 
 
 def test_post_json(server):
     with httpx.Client() as client:
         response = client.post(server.url, json={"text": "Hello, world!"})
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.reason_phrase == "OK"
 
 
@@ -93,7 +93,7 @@ def test_stream_response(server):
     with httpx.Client() as client:
         with client.stream("GET", server.url) as response:
             content = response.read()
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert content == b"Hello, world!"
 
 
@@ -105,7 +105,7 @@ def test_stream_iterator(server):
             for chunk in response.iter_bytes():
                 body += chunk
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert body == b"Hello, world!"
 
 
@@ -117,7 +117,7 @@ def test_raw_iterator(server):
             for chunk in response.iter_raw():
                 body += chunk
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert body == b"Hello, world!"
 
 
@@ -149,35 +149,35 @@ def test_raise_for_status(server):
 def test_options(server):
     with httpx.Client() as client:
         response = client.options(server.url)
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.reason_phrase == "OK"
 
 
 def test_head(server):
     with httpx.Client() as client:
         response = client.head(server.url)
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.reason_phrase == "OK"
 
 
 def test_put(server):
     with httpx.Client() as client:
         response = client.put(server.url, content=b"Hello, world!")
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.reason_phrase == "OK"
 
 
 def test_patch(server):
     with httpx.Client() as client:
         response = client.patch(server.url, content=b"Hello, world!")
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.reason_phrase == "OK"
 
 
 def test_delete(server):
     with httpx.Client() as client:
         response = client.delete(server.url)
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.reason_phrase == "OK"
 
 
@@ -185,7 +185,7 @@ def test_base_url(server):
     base_url = server.url
     with httpx.Client(base_url=base_url) as client:
         response = client.get("/")
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.url == base_url
 
 
@@ -353,7 +353,7 @@ def test_raw_client_header():
     )
     response = client.get(url)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == [
         ["Host", "example.org"],
         ["Accept", "*/*"],
@@ -381,11 +381,11 @@ def test_mounted_transport():
     client = httpx.Client(transport=transport, mounts=mounts)
 
     response = client.get("https://www.example.com")
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {"app": "unmounted"}
 
     response = client.get("custom://www.example.com")
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {"app": "mounted"}
 
 
@@ -395,7 +395,7 @@ def test_all_mounted_transport():
     client = httpx.Client(mounts=mounts)
 
     response = client.get("https://www.example.com")
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {"app": "mounted"}
 
 
@@ -403,7 +403,7 @@ def test_server_extensions(server):
     url = server.url.copy_with(path="/http_version_2")
     with httpx.Client(http2=True) as client:
         response = client.get(url)
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.extensions["http_version"] == b"HTTP/1.1"
 
 
@@ -429,7 +429,7 @@ def test_client_decode_text_using_autodetect():
     with httpx.Client(transport=transport, default_encoding=autodetect) as client:
         response = client.get("http://www.example.com")
 
-        assert response.status_code == 200
+        assert response.status_code == httpx.codes.OK.value
         assert response.reason_phrase == "OK"
         assert response.encoding == "ISO-8859-1"
         assert response.text == text
@@ -456,7 +456,7 @@ def test_client_decode_text_using_explicit_encoding():
     with httpx.Client(transport=transport, default_encoding=autodetect) as client:
         response = client.get("http://www.example.com")
 
-        assert response.status_code == 200
+        assert response.status_code == httpx.codes.OK.value
         assert response.reason_phrase == "OK"
         assert response.encoding == "ISO-8859-1"
         assert response.text == text

--- a/tests/client/test_cookies.py
+++ b/tests/client/test_cookies.py
@@ -27,7 +27,7 @@ def test_set_cookie() -> None:
     )
     response = client.get(url)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {"cookies": "example-name=example-value"}
 
 
@@ -42,7 +42,7 @@ def test_set_per_request_cookie_is_deprecated() -> None:
     with pytest.warns(DeprecationWarning):
         response = client.get(url, cookies=cookies)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {"cookies": "example-name=example-value"}
 
 
@@ -79,7 +79,7 @@ def test_set_cookie_with_cookiejar() -> None:
     )
     response = client.get(url)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {"cookies": "example-name=example-value"}
 
 
@@ -116,7 +116,7 @@ def test_setting_client_cookies_to_cookiejar() -> None:
     )
     response = client.get(url)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {"cookies": "example-name=example-value"}
 
 
@@ -133,7 +133,7 @@ def test_set_cookie_with_cookies_model() -> None:
     client.cookies = cookies
     response = client.get(url)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {"cookies": "example-name=example-value"}
 
 
@@ -143,7 +143,7 @@ def test_get_cookie() -> None:
     client = httpx.Client(transport=httpx.MockTransport(get_and_set_cookies))
     response = client.get(url)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.cookies["example-name"] == "example-value"
     assert client.cookies["example-name"] == "example-value"
 
@@ -155,14 +155,14 @@ def test_cookie_persistence() -> None:
     client = httpx.Client(transport=httpx.MockTransport(get_and_set_cookies))
 
     response = client.get("http://example.org/echo_cookies")
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {"cookies": None}
 
     response = client.get("http://example.org/set_cookie")
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.cookies["example-name"] == "example-value"
     assert client.cookies["example-name"] == "example-value"
 
     response = client.get("http://example.org/echo_cookies")
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {"cookies": "example-name=example-value"}

--- a/tests/client/test_headers.py
+++ b/tests/client/test_headers.py
@@ -30,7 +30,7 @@ def test_client_header():
     client = httpx.Client(transport=httpx.MockTransport(echo_headers), headers=headers)
     response = client.get(url)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {
         "headers": {
             "accept": "*/*",
@@ -52,7 +52,7 @@ def test_header_merge():
     )
     response = client.get(url, headers=request_headers)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {
         "headers": {
             "accept": "*/*",
@@ -74,7 +74,7 @@ def test_header_merge_conflicting_headers():
     )
     response = client.get(url, headers=request_headers)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {
         "headers": {
             "accept": "*/*",
@@ -96,7 +96,7 @@ def test_header_update():
     )
     second_response = client.get(url)
 
-    assert first_response.status_code == 200
+    assert first_response.status_code == httpx.codes.OK.value
     assert first_response.json() == {
         "headers": {
             "accept": "*/*",
@@ -107,7 +107,7 @@ def test_header_update():
         }
     }
 
-    assert second_response.status_code == 200
+    assert second_response.status_code == httpx.codes.OK.value
     assert second_response.json() == {
         "headers": {
             "accept": "*/*",
@@ -125,7 +125,7 @@ def test_header_repeated_items():
     client = httpx.Client(transport=httpx.MockTransport(echo_repeated_headers_items))
     response = client.get(url, headers=[("x-header", "1"), ("x-header", "2,3")])
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
 
     echoed_headers = response.json()["headers"]
     # as per RFC 7230, the whitespace after a comma is insignificant
@@ -142,7 +142,7 @@ def test_header_repeated_multi_items():
     )
     response = client.get(url, headers=[("x-header", "1"), ("x-header", "2,3")])
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
 
     echoed_headers = response.json()["headers"]
     assert ["x-header", "1"] in echoed_headers
@@ -160,7 +160,7 @@ def test_remove_default_header():
 
     response = client.get(url)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {
         "headers": {
             "accept": "*/*",
@@ -196,7 +196,7 @@ def test_host_with_auth_and_port_in_url():
     client = httpx.Client(transport=httpx.MockTransport(echo_headers))
     response = client.get(url)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {
         "headers": {
             "accept": "*/*",
@@ -219,7 +219,7 @@ def test_host_with_non_default_port_in_url():
     client = httpx.Client(transport=httpx.MockTransport(echo_headers))
     response = client.get(url)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {
         "headers": {
             "accept": "*/*",

--- a/tests/client/test_queryparams.py
+++ b/tests/client/test_queryparams.py
@@ -31,5 +31,5 @@ def test_client_queryparams_echo():
     )
     response = client.get(url, params=request_queryparams)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.url == "http://example.org/echo_queryparams?first=str&second=dict"

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -35,7 +35,7 @@ def test_response():
         request=httpx.Request("GET", "https://example.org"),
     )
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.reason_phrase == "OK"
     assert response.text == "Hello, world!"
     assert response.request.method == "GET"
@@ -46,7 +46,7 @@ def test_response():
 def test_response_content():
     response = httpx.Response(200, content="Hello, world!")
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.reason_phrase == "OK"
     assert response.text == "Hello, world!"
     assert response.headers == {"Content-Length": "13"}
@@ -55,7 +55,7 @@ def test_response_content():
 def test_response_text():
     response = httpx.Response(200, text="Hello, world!")
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.reason_phrase == "OK"
     assert response.text == "Hello, world!"
     assert response.headers == {
@@ -67,7 +67,7 @@ def test_response_text():
 def test_response_html():
     response = httpx.Response(200, html="<html><body>Hello, world!</html></body>")
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.reason_phrase == "OK"
     assert response.text == "<html><body>Hello, world!</html></body>"
     assert response.headers == {
@@ -79,7 +79,7 @@ def test_response_html():
 def test_response_json():
     response = httpx.Response(200, json={"hello": "world"})
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.reason_phrase == "OK"
     assert str(response.json()) == "{'hello': 'world'}"
     assert response.headers == {
@@ -209,7 +209,7 @@ def test_response_no_charset_with_ascii_content():
         content=content,
         headers=headers,
     )
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.encoding == "utf-8"
     assert response.text == "Hello, world!"
 
@@ -292,7 +292,7 @@ def test_response_force_encoding():
         content="Snowman: ☃".encode("utf-8"),
     )
     response.encoding = "iso-8859-1"
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.reason_phrase == "OK"
     assert response.text == "Snowman: â\x98\x83"
     assert response.encoding == "iso-8859-1"
@@ -303,7 +303,7 @@ def test_response_force_encoding_after_text_accessed():
         200,
         content=b"Hello, world!",
     )
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.reason_phrase == "OK"
     assert response.text == "Hello, world!"
     assert response.encoding == "utf-8"
@@ -321,7 +321,7 @@ def test_read():
         content=b"Hello, world!",
     )
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.text == "Hello, world!"
     assert response.encoding == "utf-8"
     assert response.is_closed
@@ -336,7 +336,7 @@ def test_read():
 def test_empty_read():
     response = httpx.Response(200)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.text == ""
     assert response.encoding == "utf-8"
     assert response.is_closed
@@ -355,7 +355,7 @@ async def test_aread():
         content=b"Hello, world!",
     )
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.text == "Hello, world!"
     assert response.encoding == "utf-8"
     assert response.is_closed
@@ -371,7 +371,7 @@ async def test_aread():
 async def test_empty_aread():
     response = httpx.Response(200)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.text == ""
     assert response.encoding == "utf-8"
     assert response.is_closed
@@ -687,7 +687,7 @@ def test_sync_streaming_response():
         content=streaming_body(),
     )
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert not response.is_closed
 
     content = response.read()
@@ -704,7 +704,7 @@ async def test_async_streaming_response():
         content=async_streaming_body(),
     )
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert not response.is_closed
 
     content = await response.aread()
@@ -916,7 +916,7 @@ def test_value_error_without_request(header_value):
 def test_response_with_unset_request():
     response = httpx.Response(200, content=b"Hello, world!")
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.reason_phrase == "OK"
     assert response.text == "Hello, world!"
     assert not response.is_error
@@ -967,7 +967,7 @@ def test_response_picklable():
     assert pickle_response.next_request is None
     assert pickle_response.stream is not None
     assert pickle_response.content == b"Hello, world!"
-    assert pickle_response.status_code == 200
+    assert pickle_response.status_code == httpx.codes.OK.value
     assert pickle_response.request.url == response.request.url
     assert pickle_response.extensions == {}
     assert pickle_response.history == []
@@ -1009,7 +1009,7 @@ def test_response_decode_text_using_autodetect():
     content = text.encode("ISO-8859-1")
     response = httpx.Response(200, content=content, default_encoding=autodetect)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.reason_phrase == "OK"
     assert response.encoding == "ISO-8859-1"
     assert response.text == text
@@ -1031,7 +1031,7 @@ def test_response_decode_text_using_explicit_encoding():
     content = text.encode("cp1252")
     response = httpx.Response(200, content=content, default_encoding="cp1252")
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.reason_phrase == "OK"
     assert response.encoding == "cp1252"
     assert response.text == text

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,7 +7,7 @@ import httpx
 
 def test_get(server):
     response = httpx.get(server.url)
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.reason_phrase == "OK"
     assert response.text == "Hello, world!"
     assert response.http_version == "HTTP/1.1"
@@ -15,7 +15,7 @@ def test_get(server):
 
 def test_post(server):
     response = httpx.post(server.url, content=b"Hello, world!")
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.reason_phrase == "OK"
 
 
@@ -26,7 +26,7 @@ def test_post_byte_iterator(server):
         yield b"world!"
 
     response = httpx.post(server.url, content=data())
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.reason_phrase == "OK"
 
 
@@ -38,37 +38,37 @@ def test_post_byte_stream(server):
             yield b"world!"
 
     response = httpx.post(server.url, content=Data())
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.reason_phrase == "OK"
 
 
 def test_options(server):
     response = httpx.options(server.url)
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.reason_phrase == "OK"
 
 
 def test_head(server):
     response = httpx.head(server.url)
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.reason_phrase == "OK"
 
 
 def test_put(server):
     response = httpx.put(server.url, content=b"Hello, world!")
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.reason_phrase == "OK"
 
 
 def test_patch(server):
     response = httpx.patch(server.url, content=b"Hello, world!")
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.reason_phrase == "OK"
 
 
 def test_delete(server):
     response = httpx.delete(server.url)
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.reason_phrase == "OK"
 
 
@@ -76,7 +76,7 @@ def test_stream(server):
     with httpx.stream("GET", server.url) as response:
         response.read()
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.reason_phrase == "OK"
     assert response.text == "Hello, world!"
     assert response.http_version == "HTTP/1.1"

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -76,7 +76,7 @@ async def test_asgi_transport():
         request = httpx.Request("GET", "http://www.example.com/")
         response = await transport.handle_async_request(request)
         await response.aread()
-        assert response.status_code == 200
+        assert response.status_code == httpx.codes.OK.value
         assert response.content == b"Hello, World!"
 
 
@@ -86,7 +86,7 @@ async def test_asgi_transport_no_body():
         request = httpx.Request("GET", "http://www.example.com/")
         response = await transport.handle_async_request(request)
         await response.aread()
-        assert response.status_code == 200
+        assert response.status_code == httpx.codes.OK.value
         assert response.content == b""
 
 
@@ -96,7 +96,7 @@ async def test_asgi():
     async with httpx.AsyncClient(transport=transport) as client:
         response = await client.get("http://www.example.org/")
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.text == "Hello, World!"
 
 
@@ -107,7 +107,7 @@ async def test_asgi_urlencoded_path():
         url = httpx.URL("http://www.example.org/").copy_with(path="/user@example.org")
         response = await client.get(url)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {"path": "/user@example.org"}
 
 
@@ -118,7 +118,7 @@ async def test_asgi_raw_path():
         url = httpx.URL("http://www.example.org/").copy_with(path="/user@example.org")
         response = await client.get(url)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {"raw_path": "/user@example.org"}
 
 
@@ -132,7 +132,7 @@ async def test_asgi_raw_path_should_not_include_querystring_portion():
         url = httpx.URL("http://www.example.org/path?query")
         response = await client.get(url)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {"raw_path": "/path"}
 
 
@@ -142,7 +142,7 @@ async def test_asgi_upload():
     async with httpx.AsyncClient(transport=transport) as client:
         response = await client.post("http://www.example.org/", content=b"example")
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.text == "example"
 
 
@@ -152,7 +152,7 @@ async def test_asgi_headers():
     async with httpx.AsyncClient(transport=transport) as client:
         response = await client.get("http://www.example.org/")
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.json() == {
         "headers": [
             ["host", "www.example.org"],
@@ -211,7 +211,7 @@ async def test_asgi_disconnect_after_response_complete():
     async with httpx.AsyncClient(transport=transport) as client:
         response = await client.post("http://www.example.org/", content=b"example")
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert disconnect
 
 
@@ -221,4 +221,4 @@ async def test_asgi_exc_no_raise():
     async with httpx.AsyncClient(transport=transport) as client:
         response = await client.get("http://www.example.org/")
 
-        assert response.status_code == 500
+        assert response.status_code == httpx.codes.INTERNAL_SERVER_ERROR.value

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -83,7 +83,7 @@ def test_SSLContext_with_get_request(server, cert_pem_file):
     context = httpx.create_ssl_context()
     context.load_verify_locations(cert_pem_file)
     response = httpx.get(server.url, verify=context)
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
 
 
 def test_limits_repr():

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -24,7 +24,7 @@ def test_multipart(value, output):
     boundary = response.request.headers["Content-Type"].split("boundary=")[-1]
     boundary_bytes = boundary.encode("ascii")
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.content == b"".join(
         [
             b"--" + boundary_bytes + b"\r\n",
@@ -62,7 +62,7 @@ def test_multipart_explicit_boundary(header: str) -> None:
     response = client.post("http://127.0.0.1:8000/", files=files, headers=headers)
     boundary_bytes = b"+++"
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.request.headers["Content-Type"] == header
     assert response.content == b"".join(
         [
@@ -90,7 +90,7 @@ def test_multipart_header_without_boundary(header: str) -> None:
     headers = {"content-type": header}
     response = client.post("http://127.0.0.1:8000/", files=files, headers=headers)
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.request.headers["Content-Type"] == header
 
 
@@ -132,7 +132,7 @@ def test_multipart_file_tuple():
     boundary = response.request.headers["Content-Type"].split("boundary=")[-1]
     boundary_bytes = boundary.encode("ascii")
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.content == b"".join(
         [
             b"--" + boundary_bytes + b"\r\n",
@@ -429,13 +429,13 @@ def test_multipart_rewinds_files():
 
         files = {"file": upload}
         response = client.post("http://127.0.0.1:8000/", files=files)
-        assert response.status_code == 200
+        assert response.status_code == httpx.codes.OK.value
         assert b"\r\nHello, world!\r\n" in response.content
 
         # POSTing the same file instance a second time should have the same content.
         files = {"file": upload}
         response = client.post("http://127.0.0.1:8000/", files=files)
-        assert response.status_code == 200
+        assert response.status_code == httpx.codes.OK.value
         assert b"\r\nHello, world!\r\n" in response.content
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -54,7 +54,7 @@ def test_logging_request(server, caplog):
     caplog.set_level(logging.INFO)
     with httpx.Client() as client:
         response = client.get(server.url)
-        assert response.status_code == 200
+        assert response.status_code == httpx.codes.OK.value
 
     assert caplog.record_tuples == [
         (
@@ -69,7 +69,7 @@ def test_logging_redirect_chain(server, caplog):
     caplog.set_level(logging.INFO)
     with httpx.Client(follow_redirects=True) as client:
         response = client.get(server.url.copy_with(path="/redirect_301"))
-        assert response.status_code == 200
+        assert response.status_code == httpx.codes.OK.value
 
     assert caplog.record_tuples == [
         (

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -95,7 +95,7 @@ def test_wsgi():
     transport = httpx.WSGITransport(app=application_factory([b"Hello, World!"]))
     client = httpx.Client(transport=transport)
     response = client.get("http://www.example.org/")
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.text == "Hello, World!"
 
 
@@ -103,7 +103,7 @@ def test_wsgi_upload():
     transport = httpx.WSGITransport(app=echo_body)
     client = httpx.Client(transport=transport)
     response = client.post("http://www.example.org/", content=b"example")
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.text == "example"
 
 
@@ -111,7 +111,7 @@ def test_wsgi_upload_with_response_stream():
     transport = httpx.WSGITransport(app=echo_body_with_response_stream)
     client = httpx.Client(transport=transport)
     response = client.post("http://www.example.org/", content=b"example")
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.text == "example"
 
 
@@ -134,7 +134,7 @@ def test_wsgi_generator():
     transport = httpx.WSGITransport(app=application_factory(output))
     client = httpx.Client(transport=transport)
     response = client.get("http://www.example.org/")
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.text == "Some content and more content"
 
 
@@ -143,7 +143,7 @@ def test_wsgi_generator_empty():
     transport = httpx.WSGITransport(app=application_factory(output))
     client = httpx.Client(transport=transport)
     response = client.get("http://www.example.org/")
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.text == ""
 
 
@@ -152,7 +152,7 @@ def test_logging():
     transport = httpx.WSGITransport(app=log_to_wsgi_log_buffer, wsgi_errors=buffer)
     client = httpx.Client(transport=transport)
     response = client.post("http://www.example.org/", content=b"example")
-    assert response.status_code == 200  # no errors
+    assert response.status_code == httpx.codes.OK.value  # no errors
     buffer.seek(0)
     assert buffer.read() == "test1\ntest2"
 
@@ -180,7 +180,7 @@ def test_wsgi_server_port(url: str, expected_server_port: str) -> None:
     transport = httpx.WSGITransport(app=app)
     client = httpx.Client(transport=transport)
     response = client.get(url)
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.text == "Hello, World!"
     assert server_port == expected_server_port
 
@@ -198,6 +198,6 @@ def test_wsgi_server_protocol():
     with httpx.Client(transport=transport, base_url="http://testserver") as client:
         response = client.get("/")
 
-    assert response.status_code == 200
+    assert response.status_code == httpx.codes.OK.value
     assert response.text == "success"
     assert server_protocol == "HTTP/1.1"


### PR DESCRIPTION
**Description:**

This pull request improves the test suite by replacing raw status codes with `httpx.codes` constants for better readability and consistency with the `httpx` package conventions.

### Changes:
- Replaced raw status code `200` with `httpx.codes.OK.value` in the tests.
- Replaced raw status code `500` with `httpx.codes.INTERNAL_SERVER_ERROR.value` in the tests.

### Rationale:
- The `httpx.codes` module provides human-readable status codes, making the tests easier to understand and maintain.
- Replacing raw status codes (e.g., `200`, `500`) with the corresponding `httpx.codes` constants improves consistency with the `httpx` library's intended usage and avoids the use of "magic numbers" in the test code.

### Why this PR is Important:
- **Improved Readability**: Makes the test code more intuitive, especially for contributors unfamiliar with HTTP status codes.
- **Better Consistency**: Aligns the test code with the `httpx` package's built-in status code handling.
- **Maintainability**: Helps prevent errors related to hardcoded status codes by using standardized constants.

### Request for Review:
Please review the changes and let me know if any further modifications or refinements are needed. This small enhancement will make the tests more consistent and easier to understand for all contributors.
