### PR TITLE
Fix `verify=False`, `cert=...` case.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Dev
+
+* Fix SSL case where `verify=False` together with client side certificates.
+ 
 ## 0.28.0 (28th November, 2024)
 
 The 0.28 release includes a limited set of deprecations.

--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -39,10 +39,9 @@ def create_ssl_context(
             # Default case...
             ctx = ssl.create_default_context(cafile=certifi.where())
     elif verify is False:
-        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-        ssl_context.check_hostname = False
-        ssl_context.verify_mode = ssl.CERT_NONE
-        return ssl_context
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
     elif isinstance(verify, str):  # pragma: nocover
         message = (
             "`verify=<str>` is deprecated. "


### PR DESCRIPTION
Fix for the case where `verify=False` and client-side certs are being used.

Refs #3441.
