### PR TITLE
Version 0.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 0.28.1 (4th December, 2024)
+## 0.28.1 (6th December, 2024)
 
 * Fix SSL case where `verify=False` together with client side certificates.
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Dev
+## 0.28.1 (4th December, 2024)
 
 * Fix SSL case where `verify=False` together with client side certificates.
  

--- a/httpx/__version__.py
+++ b/httpx/__version__.py
@@ -1,3 +1,3 @@
 __title__ = "httpx"
 __description__ = "A next generation HTTP client, for Python 3."
-__version__ = "0.28.0"
+__version__ = "0.28.1"


### PR DESCRIPTION
## 0.28.1 (6th December, 2024)

* Fix SSL case where `verify=False` together with client side certificates.

---

Release draft... (maintainers) https://github.com/encode/httpx/releases/tag/untagged-cd33408902cf0089b895