### PR TITLE
add support for any type of URL as long as it can be stringified

### DIFF
--- a/httpx/_urls.py
+++ b/httpx/_urls.py
@@ -118,10 +118,7 @@ class URL:
         elif isinstance(url, URL):
             self._uri_reference = url._uri_reference.copy_with(**kwargs)
         else:
-            raise TypeError(
-                "Invalid type for url.  Expected str or httpx.URL,"
-                f" got {type(url)}: {url!r}"
-            )
+            self._uri_reference = urlparse(str(url), **kwargs)
 
     @property
     def scheme(self) -> str:

--- a/httpx/_urls.py
+++ b/httpx/_urls.py
@@ -113,9 +113,7 @@ class URL:
                 params = kwargs.pop("params")
                 kwargs["query"] = None if not params else str(QueryParams(params))
 
-        if isinstance(url, str):
-            self._uri_reference = urlparse(url, **kwargs)
-        elif isinstance(url, URL):
+        if isinstance(url, URL):
             self._uri_reference = url._uri_reference.copy_with(**kwargs)
         else:
             self._uri_reference = urlparse(str(url), **kwargs)

--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -452,19 +452,17 @@ def test_url_set():
     assert all(url in urls for url in url_set)
 
 
+def test_custom_object_url():
+    class ExternalURLClass:
+        def __str__(self):
+            return "https://www.example.com/"
+
+    url = ExternalURLClass()
+    httpx_url = httpx.URL(url)
+    assert httpx_url == "https://www.example.com/"
+
+
 # Tests for TypeErrors when instantiating `httpx.URL`.
-
-
-def test_url_invalid_type():
-    """
-    Ensure that invalid types on `httpx.URL()` raise a `TypeError`.
-    """
-
-    class ExternalURLClass:  # representing external URL class
-        pass
-
-    with pytest.raises(TypeError):
-        httpx.URL(ExternalURLClass())  # type: ignore
 
 
 def test_url_with_invalid_component():


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

for reference : https://github.com/encode/httpx/discussions/3142

This PR brings compatibility with pydantic HttpURL object (or any object). 

I'm using pydantic HttpURL type in my project (for validation purposes) but had errors when I passed the pydantic http object directly to https.request function. If the type of the given request is not httpx.URL, then the object will be stringified and the string will be passed on `urlparse`.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
