### PR TITLE
docs: Use `with` to open files in multipart examples

### DIFF
--- a/docs/advanced/clients.md
+++ b/docs/advanced/clients.md
@@ -270,8 +270,9 @@ multipart file encoding is available by passing a dictionary with the
 name of the payloads as keys and either tuple of elements or a file-like object or a string as values.
 
 ```pycon
->>> files = {'upload-file': ('report.xls', open('report.xls', 'rb'), 'application/vnd.ms-excel')}
->>> r = httpx.post("https://httpbin.org/post", files=files)
+>>> with open('report.xls', 'rb') as report_file:
+...     files = {'upload-file': ('report.xls', report_file, 'application/vnd.ms-excel')}
+...     r = httpx.post("https://httpbin.org/post", files=files)
 >>> print(r.text)
 {
   ...
@@ -318,7 +319,10 @@ To do that, pass a list of `(field, <file>)` items instead of a dictionary, allo
 For instance this request sends 2 files, `foo.png` and `bar.png` in one request on the `images` form field:
 
 ```pycon
->>> files = [('images', ('foo.png', open('foo.png', 'rb'), 'image/png')),
-                      ('images', ('bar.png', open('bar.png', 'rb'), 'image/png'))]
->>> r = httpx.post("https://httpbin.org/post", files=files)
+>>> with open('foo.png', 'rb') as foo_file, open('bar.png', 'rb') as bar_file:
+...     files = [
+...         ('images', ('foo.png', foo_file, 'image/png')),
+...         ('images', ('bar.png', bar_file, 'image/png')),
+...     ]
+...     r = httpx.post("https://httpbin.org/post", files=files)
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -174,8 +174,9 @@ Form encoded data can also include multiple values from a given key.
 You can also upload files, using HTTP multipart encoding:
 
 ```pycon
->>> files = {'upload-file': open('report.xls', 'rb')}
->>> r = httpx.post("https://httpbin.org/post", files=files)
+>>> with open('report.xls', 'rb') as report_file:
+...     files = {'upload-file': report_file}
+...     r = httpx.post("https://httpbin.org/post", files=files)
 >>> print(r.text)
 {
   ...
@@ -190,8 +191,9 @@ You can also explicitly set the filename and content type, by using a tuple
 of items for the file value:
 
 ```pycon
->>> files = {'upload-file': ('report.xls', open('report.xls', 'rb'), 'application/vnd.ms-excel')}
->>> r = httpx.post("https://httpbin.org/post", files=files)
+>>> with open('report.xls', 'rb') report_file:
+...     files = {'upload-file': ('report.xls', report_file, 'application/vnd.ms-excel')}
+...     r = httpx.post("https://httpbin.org/post", files=files)
 >>> print(r.text)
 {
   ...
@@ -206,8 +208,9 @@ If you need to include non-file data fields in the multipart form, use the `data
 
 ```pycon
 >>> data = {'message': 'Hello, world!'}
->>> files = {'file': open('report.xls', 'rb')}
->>> r = httpx.post("https://httpbin.org/post", data=data, files=files)
+>>> with open('report.xls', 'rb') as report_file:
+...     files = {'file': report_file}
+...     r = httpx.post("https://httpbin.org/post", data=data, files=files)
 >>> print(r.text)
 {
   ...


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

While reading the docs for multipart file uploads, I wrongly assumed `httpx` will take care of closing the uploaded files because it was not done manually in the examples. Of course, I understand that the docs never stated this and closing files is usually a caller's responsibility, but I think it's still a good idea to make the examples more practical and less prone to confusion.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
