### PR TITLE
chore(docs): add httpx-retry to 3P packages

### DIFF
--- a/docs/third_party_packages.md
+++ b/docs/third_party_packages.md
@@ -82,6 +82,12 @@ Allows consuming Server-Sent Events (SSE) with HTTPX.
 
 A library for scraping the web built on top of HTTPX.
 
+### httpx-retry
+
+[Github](https://github.com/mharrisb1/httpx-retry)
+
+Middleware for implementing retry policies with HTTPX
+
 ## Gists
 
 <!-- NOTE: this list is in alphabetical order. -->


### PR DESCRIPTION
# Summary

Adds [httpx-retry](https://github.com/mharrisb1/httpx-retry) to third-party packages page in docs as suggested by [issue comment](https://github.com/encode/httpx/issues/108#issuecomment-1653298485) in #108 

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] ~I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.~
- [x] I've updated the documentation accordingly.
