### PR TITLE
Detect blocking calls in coroutines during tests using BlockBuster

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ trio-typing==0.10.0
 trustme==1.1.0; python_version < '3.9'
 trustme==1.2.0; python_version >= '3.9'
 uvicorn==0.32.1
+blockbuster==1.5.23

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import typing
 
 import pytest
 import trustme
+from blockbuster import blockbuster_ctx
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.serialization import (
     BestAvailableEncryption,
@@ -29,6 +30,13 @@ ENVIRONMENT_VARIABLES = {
     "NO_PROXY",
     "SSLKEYLOGFILE",
 }
+
+
+@pytest.fixture(autouse=True)
+def blockbuster():
+    with blockbuster_ctx() as bb:
+        bb.functions["os.stat"].can_block_in("/mimetypes.py", "init")
+        yield bb
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/models/test_whatwg.py
+++ b/tests/models/test_whatwg.py
@@ -3,6 +3,7 @@
 # https://url.spec.whatwg.org/
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -10,7 +11,8 @@ from httpx._urlparse import urlparse
 
 # URL test cases from...
 # https://github.com/web-platform-tests/wpt/blob/master/url/resources/urltestdata.json
-with open("tests/models/whatwg.json", "r", encoding="utf-8") as input:
+whatwg_path = Path(__file__).parent.parent / "models" / "whatwg.json"
+with whatwg_path.open("r", encoding="utf-8") as input:
     test_cases = json.load(input)
     test_cases = [
         item


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

[BlockBuster](https://github.com/cbornet/blockbuster) is a library to detect harmful blocking calls done in the async event loop (when activated, it raises an error if a blocking call is done).
It is just a few lines to integrate with pytest.
Globally, `httpx` is a good citizen and the only blocking call it detected is `mimetypes.guess_type` in `Request` constructor. `mimetypes` has a global cache so this blocking call is only done once.
Solutions for this would be:
* defer the mimetype resolution to when the request is actually called and call `mimetypes.guess_type` in a thread
* or just accept that it blocks for a short time only once and add an exemption in blockbuster setup.
I've also seen blocking calls made when using HTTPS but there seems to be no unit tests for async+TLS.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
