### PR TITLE
Allow Timeout to receive timedelta

### DIFF
--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -2,6 +2,7 @@
 Type definitions for type checking purposes.
 """
 
+from datetime import timedelta
 from http.cookiejar import CookieJar
 from typing import (
     IO,
@@ -52,8 +53,13 @@ HeaderTypes = Union[
 CookieTypes = Union["Cookies", CookieJar, Dict[str, str], List[Tuple[str, str]]]
 
 TimeoutTypes = Union[
-    Optional[float],
-    Tuple[Optional[float], Optional[float], Optional[float], Optional[float]],
+    Optional[Union[float, timedelta]],
+    Tuple[
+        Optional[Union[float, timedelta]],
+        Optional[Union[float, timedelta]],
+        Optional[Union[float, timedelta]],
+        Optional[Union[float, timedelta]],
+    ],
     "Timeout",
 ]
 ProxyTypes = Union["URL", str, "Proxy"]

--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -4,12 +4,21 @@ import ipaddress
 import os
 import re
 import typing
+from datetime import timedelta
 from urllib.request import getproxies
 
 from ._types import PrimitiveData
 
 if typing.TYPE_CHECKING:  # pragma: no cover
     from ._urls import URL
+
+
+def opt_timedelta_to_seconds(
+    value: typing.Union[float, timedelta, None],
+) -> float | None:
+    if isinstance(value, timedelta):
+        return value.total_seconds()
+    return value
 
 
 def primitive_value_to_str(value: PrimitiveData) -> str:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 import ssl
 import typing
+from datetime import timedelta
 from pathlib import Path
 
 import certifi
@@ -105,8 +106,23 @@ def test_timeout_eq():
     assert timeout == httpx.Timeout(timeout=5.0)
 
 
+def test_timeout_timedelta_eq():
+    timeout = httpx.Timeout(timeout=timedelta(seconds=5.0))
+    assert timeout == httpx.Timeout(timeout=5.0)
+
+
 def test_timeout_all_parameters_set():
     timeout = httpx.Timeout(connect=5.0, read=5.0, write=5.0, pool=5.0)
+    assert timeout == httpx.Timeout(timeout=5.0)
+
+
+def test_timeout_all_parameters_timedelta_set():
+    timeout = httpx.Timeout(
+        connect=timedelta(seconds=5.0),
+        read=timedelta(seconds=5.0),
+        write=timedelta(seconds=5.0),
+        pool=timedelta(seconds=5.0),
+    )
     assert timeout == httpx.Timeout(timeout=5.0)
 
 
@@ -133,8 +149,18 @@ def test_timeout_from_one_value():
     assert timeout == httpx.Timeout(timeout=(None, 5.0, None, None))
 
 
+def test_timeout_from_one_timedelta_value():
+    timeout = httpx.Timeout(None, read=timedelta(seconds=5.0))
+    assert timeout == httpx.Timeout(timeout=(None, 5.0, None, None))
+
+
 def test_timeout_from_one_value_and_default():
     timeout = httpx.Timeout(5.0, pool=60.0)
+    assert timeout == httpx.Timeout(timeout=(5.0, 5.0, 5.0, 60.0))
+
+
+def test_timeout_from_one_value_and_default_timedelta():
+    timeout = httpx.Timeout(timedelta(seconds=5.0), pool=timedelta(seconds=60.0))
     assert timeout == httpx.Timeout(timeout=(5.0, 5.0, 5.0, 60.0))
 
 
@@ -145,6 +171,18 @@ def test_timeout_missing_default():
 
 def test_timeout_from_tuple():
     timeout = httpx.Timeout(timeout=(5.0, 5.0, 5.0, 5.0))
+    assert timeout == httpx.Timeout(timeout=5.0)
+
+
+def test_timeout_from_timedelta_tuple():
+    timeout = httpx.Timeout(
+        timeout=(
+            timedelta(seconds=5.0),
+            timedelta(seconds=5.0),
+            timedelta(seconds=5.0),
+            timedelta(seconds=5.0),
+        )
+    )
     assert timeout == httpx.Timeout(timeout=5.0)
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Added so the Timeout can receive timedelta. I would love to expand that to all the calls, but I thought I wanted your take on this first. I also want your feedback on the documentation, as I think this should only be mentioned a few places as not to overload the general user.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
