### PR TITLE
Allow auth to be removed (be None)

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -281,7 +281,7 @@ class BaseClient:
         return self._auth
 
     @auth.setter
-    def auth(self, auth: AuthTypes) -> None:
+    def auth(self, auth: AuthTypes | None) -> None:
         self._auth = self._build_auth(auth)
 
     @property

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -336,6 +336,24 @@ async def test_auth_property() -> None:
 
 
 @pytest.mark.anyio
+async def test_auth_property_none() -> None:
+    app = App()
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(app), auth=("user", "password123")
+    ) as client:
+        assert isinstance(client.auth, httpx.BasicAuth)
+
+        client.auth = None
+        assert client.auth is None
+
+        url = "https://example.org/"
+        response = await client.get(url)
+        assert response.status_code == 200
+        assert response.json() == {"auth": None}
+
+
+@pytest.mark.anyio
 async def test_auth_invalid_type() -> None:
     app = App()
 


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Allow auth property on the BaseClient to be None (as a way to remove auth from the Client)

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
