### PR TITLE
docs: add a tip to use event hooks for `raise_for_status`

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -305,6 +305,9 @@ The method returns the response instance, allowing you to use it inline. For exa
 >>> data = httpx.get('...').raise_for_status().json()
 ```
 
+!!! tip
+    If you want `raise_for_status()` to be always called after **every** request, use a [`Client` instance](advanced/clients.md) with an [event hook](advanced/event-hooks.md) like `httpx.Client(event_hooks={"response": [Response.raise_for_status]})` instead of the top-level interface.
+
 ## Response Headers
 
 The response headers are available as a dictionary-like interface.


### PR DESCRIPTION
# Summary

This adds a tip about using event hooks for `raise_for_status` as found in #752 to the Quickstart. I think it's too valuable to leave in a GitHub issue only discoverable by Google. Also subtly hints at the benefits of using a `Client` ;)

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
