### PR TITLE
Change return type annotation for Response.raise_for_status() to Self

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -70,7 +70,7 @@
   * The amount of time elapsed between sending the request and calling `close()` on the corresponding response received for that request.
   [total_seconds()](https://docs.python.org/3/library/datetime.html#datetime.timedelta.total_seconds) to correctly get
   the total elapsed seconds.
-* `def .raise_for_status()` - **Response**
+* `def .raise_for_status()` - **Self**
 * `def .json()` - **Any**
 * `def .read()` - **bytes**
 * `def .iter_raw([chunk_size])` - **bytes iterator**

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -791,7 +791,7 @@ class Response:
             and "Location" in self.headers
         )
 
-    def raise_for_status(self) -> Response:
+    def raise_for_status(self) -> typing.Self:
         """
         Raise the `HTTPStatusError` if one occurred.
         """


### PR DESCRIPTION


<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

It always returns its self argument. This change makes subclasses easier to use.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
