### PR TITLE
Update default proxy construction in HTTPTransport to include SSL context

### DIFF
--- a/tests/client/test_proxies.py
+++ b/tests/client/test_proxies.py
@@ -1,3 +1,5 @@
+import ssl
+
 import httpcore
 import pytest
 
@@ -263,3 +265,9 @@ def test_proxy_with_mounts():
 
     transport = client._transport_for_url(httpx.URL("http://example.com"))
     assert transport == proxy_transport
+
+
+def test_proxy_with_ssl_context():
+    ssl_context = ssl.create_default_context()
+    proxy_transport = httpx.HTTPTransport(proxy="https://127.0.0.1", verify=ssl_context)
+    assert proxy_transport._pool._proxy_ssl_context == ssl_context  # type: ignore[attr-defined]


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary
When a user created an HTTPTransport and supplied a URL for their proxy, the SSLContext was not passed to the created proxy. This caused some confusion when I ran into it the first time.

Now, the SSLContext is passed to the proxy when constructing by default.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
