### PR TITLE
Docs: Add `httpx.Proxy` to api.md

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -162,7 +162,7 @@ what gets sent over the wire.*
 
 ## `Proxy`
 
-*A configuration of the proxy server*
+*A configuration of the proxy server.*
 
 ```pycon
 >>> proxy = Proxy("http://proxy.example.com")

--- a/docs/api.md
+++ b/docs/api.md
@@ -165,7 +165,7 @@ what gets sent over the wire.*
 *A configuration of the proxy server.*
 
 ```pycon
->>> proxy = Proxy("http://proxy.example.com")
+>>> proxy = Proxy("http://proxy.example.com:8030")
 >>> client = Client(proxy=proxy)
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -159,3 +159,18 @@ what gets sent over the wire.*
 * `def delete(name, [domain], [path])`
 * `def clear([domain], [path])`
 * *Standard mutable mapping interface*
+
+## `Proxy`
+
+*A configuration of the proxy server*
+
+```pycon
+>>> proxy = Proxy("http://proxy.example.com")
+>>> client = Client(proxy=proxy)
+```
+
+* `def __init__(url, [ssl_context], [auth], [headers])`
+* `.url` - **URL**
+* `.auth` - **tuple[str, str]**
+* `.headers` - **Headers**
+* `.ssl_context` - **SSLContext**


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Documentation of httpx does not mention the parameters of `httpx.Proxy()`. They can be important e.g. in the case of custom `ssl_context`. This PR documents them in the API Reference.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
