### PR TITLE
Update _client.py to fix bug when proxy_map contains None

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -706,7 +706,7 @@ class Client(BaseClient):
                 http2=http2,
                 limits=limits,
             )
-            for key, proxy in proxy_map.items()
+            for key, proxy in proxy_map.items() if proxy is not None
         }
         if mounts is not None:
             self._mounts.update(
@@ -1421,7 +1421,7 @@ class AsyncClient(BaseClient):
                 http2=http2,
                 limits=limits,
             )
-            for key, proxy in proxy_map.items()
+            for key, proxy in proxy_map.items() if proxy is not None
         }
         if mounts is not None:
             self._mounts.update(


### PR DESCRIPTION
When proxy_map contains None as value, the library will throw an exception, the proposed changes will fix the error: 

proxy_map:
{'http://': Proxy('http://sys-proxy-rd-relay.xxxx.org:8119'), 'https://': Proxy('http://sys-proxy-rd-relay.xxxx.org:8119'), 'all://localhost': None}

Exception:
File /usr/local/lib/python3.11/dist-packages/httpx/_urlparse.py:411, in normalize_port(port, scheme)
    409     port_as_int = int(port)
    410 except ValueError:
--> 411     raise InvalidURL(f"Invalid port: {port!r}")
    413 # See https://url.spec.whatwg.org/#url-miscellaneous
    414 default_port = {"ftp": 21, "http": 80, "https": 443, "ws": 80, "wss": 443}.get(
    415     scheme
    416 )

InvalidURL: Invalid port: ':'

<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
