### PR TITLE
docs: Add link to Event Hooks docs on Compatibility page

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -223,6 +223,6 @@ For both query params (`params=`) and form data (`data=`), `requests` supports s
 
 `requests` allows event hooks to mutate `Request` and `Response` objects. See [examples](https://requests.readthedocs.io/en/master/user/advanced/#event-hooks) given in the documentation for `requests`.
 
-In HTTPX, event hooks may access properties of requests and responses, but event hook callbacks cannot mutate the original request/response.
+In HTTPX, [event hooks](advanced/event-hooks.md) may access properties of requests and responses, but event hook callbacks cannot mutate the original request/response.
 
 If you are looking for more control, consider checking out [Custom Transports](advanced/transports.md#custom-transports).


### PR DESCRIPTION
# Summary

Add a nice-to-have link to the Event Hooks docs on the Compatibility page.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.