### PR TITLE
Do CLI import in __main__, not __init__

### DIFF
--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -11,20 +11,6 @@ from ._transports import *
 from ._types import *
 from ._urls import *
 
-try:
-    from ._main import main
-except ImportError:  # pragma: no cover
-
-    def main() -> None:  # type: ignore
-        import sys
-
-        print(
-            "The httpx command line client could not run because the required "
-            "dependencies were not installed.\nMake sure you've installed "
-            "everything with: pip install 'httpx[cli]'"
-        )
-        sys.exit(1)
-
 
 __all__ = [
     "__description__",
@@ -59,7 +45,6 @@ __all__ = [
     "InvalidURL",
     "Limits",
     "LocalProtocolError",
-    "main",
     "MockTransport",
     "NetRCAuth",
     "NetworkError",

--- a/httpx/__main__.py
+++ b/httpx/__main__.py
@@ -1,0 +1,17 @@
+try:
+    from ._main import main
+except ImportError:  # pragma: no cover
+
+    def main() -> None:  # type: ignore
+        import sys
+
+        print(
+            "The httpx command line client could not run because the required "
+            "dependencies were not installed.\nMake sure you've installed "
+            "everything with: pip install 'httpx[cli]'"
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ zstd = [
 ]
 
 [project.scripts]
-httpx = "httpx:main"
+httpx = "httpx.__main__:main"
 
 [project.urls]
 Changelog = "https://github.com/encode/httpx/blob/master/CHANGELOG.md"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,7 +3,7 @@ import typing
 
 from click.testing import CliRunner
 
-import httpx
+import httpx.__main__
 
 
 def splitlines(output: str) -> typing.Iterable[str]:
@@ -16,7 +16,7 @@ def remove_date_header(lines: typing.Iterable[str]) -> typing.Iterable[str]:
 
 def test_help():
     runner = CliRunner()
-    result = runner.invoke(httpx.main, ["--help"])
+    result = runner.invoke(httpx.__main__.main, ["--help"])
     assert result.exit_code == 0
     assert "A next generation HTTP client." in result.output
 
@@ -24,7 +24,7 @@ def test_help():
 def test_get(server):
     url = str(server.url)
     runner = CliRunner()
-    result = runner.invoke(httpx.main, [url])
+    result = runner.invoke(httpx.__main__.main, [url])
     assert result.exit_code == 0
     assert remove_date_header(splitlines(result.output)) == [
         "HTTP/1.1 200 OK",
@@ -39,7 +39,7 @@ def test_get(server):
 def test_json(server):
     url = str(server.url.copy_with(path="/json"))
     runner = CliRunner()
-    result = runner.invoke(httpx.main, [url])
+    result = runner.invoke(httpx.__main__.main, [url])
     assert result.exit_code == 0
     assert remove_date_header(splitlines(result.output)) == [
         "HTTP/1.1 200 OK",
@@ -57,7 +57,7 @@ def test_binary(server):
     url = str(server.url.copy_with(path="/echo_binary"))
     runner = CliRunner()
     content = "Hello, world!"
-    result = runner.invoke(httpx.main, [url, "-c", content])
+    result = runner.invoke(httpx.__main__.main, [url, "-c", content])
     assert result.exit_code == 0
     assert remove_date_header(splitlines(result.output)) == [
         "HTTP/1.1 200 OK",
@@ -72,7 +72,7 @@ def test_binary(server):
 def test_redirects(server):
     url = str(server.url.copy_with(path="/redirect_301"))
     runner = CliRunner()
-    result = runner.invoke(httpx.main, [url])
+    result = runner.invoke(httpx.__main__.main, [url])
     assert result.exit_code == 1
     assert remove_date_header(splitlines(result.output)) == [
         "HTTP/1.1 301 Moved Permanently",
@@ -86,7 +86,7 @@ def test_redirects(server):
 def test_follow_redirects(server):
     url = str(server.url.copy_with(path="/redirect_301"))
     runner = CliRunner()
-    result = runner.invoke(httpx.main, [url, "--follow-redirects"])
+    result = runner.invoke(httpx.__main__.main, [url, "--follow-redirects"])
     assert result.exit_code == 0
     assert remove_date_header(splitlines(result.output)) == [
         "HTTP/1.1 301 Moved Permanently",
@@ -106,7 +106,7 @@ def test_follow_redirects(server):
 def test_post(server):
     url = str(server.url.copy_with(path="/echo_body"))
     runner = CliRunner()
-    result = runner.invoke(httpx.main, [url, "-m", "POST", "-j", '{"hello": "world"}'])
+    result = runner.invoke(httpx.__main__.main, [url, "-m", "POST", "-j", '{"hello": "world"}'])
     assert result.exit_code == 0
     assert remove_date_header(splitlines(result.output)) == [
         "HTTP/1.1 200 OK",
@@ -121,7 +121,7 @@ def test_post(server):
 def test_verbose(server):
     url = str(server.url)
     runner = CliRunner()
-    result = runner.invoke(httpx.main, [url, "-v"])
+    result = runner.invoke(httpx.__main__.main, [url, "-v"])
     assert result.exit_code == 0
     assert remove_date_header(splitlines(result.output)) == [
         "* Connecting to '127.0.0.1'",
@@ -145,7 +145,7 @@ def test_verbose(server):
 def test_auth(server):
     url = str(server.url)
     runner = CliRunner()
-    result = runner.invoke(httpx.main, [url, "-v", "--auth", "username", "password"])
+    result = runner.invoke(httpx.__main__.main, [url, "-v", "--auth", "username", "password"])
     print(result.output)
     assert result.exit_code == 0
     assert remove_date_header(splitlines(result.output)) == [
@@ -172,7 +172,7 @@ def test_download(server):
     url = str(server.url)
     runner = CliRunner()
     with runner.isolated_filesystem():
-        runner.invoke(httpx.main, [url, "--download", "index.txt"])
+        runner.invoke(httpx.__main__.main, [url, "--download", "index.txt"])
         assert os.path.exists("index.txt")
         with open("index.txt", "r") as input_file:
             assert input_file.read() == "Hello, world!"
@@ -180,7 +180,7 @@ def test_download(server):
 
 def test_errors():
     runner = CliRunner()
-    result = runner.invoke(httpx.main, ["invalid://example.org"])
+    result = runner.invoke(httpx.__main__.main, ["invalid://example.org"])
     assert result.exit_code == 1
     assert splitlines(result.output) == [
         "UnsupportedProtocol: Request URL has an unsupported protocol 'invalid://'.",


### PR DESCRIPTION
# Summary
From https://github.com/encode/httpx/discussions/3523

Importing the `_main.py` module in `httpx/__init__.py` adds 0.087s worth of import time on my machine (MacBook M1 Pro, 32 GB RAM, macOS 15.3.1) running Python 3.13.2.

It's certainly not a *huge* amount of time in the absolute, but it roughly doubles the amount of time it takes to `import httpx`, even when you're not intending to run the CLI. Here's an import time graph generated using [tuna](https://github.com/nschloe/tuna) on the output of `python -X importtime -c "import httpx" > import.log`

<img width="1560" alt="Screenshot 2025-03-03 at 4 15 23 PM" src="https://github.com/user-attachments/assets/b2936b4d-d944-456a-a436-088864013e7c" />

This PR adds `httpx/__main__.py` that does the import instead. This also allows `python -m httpx` as in https://github.com/encode/httpx/discussions/3216.

It does change the public API: `httpx.main` becomes the (more ungainly) `httpx.__main__.main`.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
