### PR TITLE
Add `content_type` for Response

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Now, let's get started:
 <Response [200 OK]>
 >>> r.status_code
 200
->>> r.headers['content-type']
+>>> r.content_type
 'text/html; charset=UTF-8'
 >>> r.text
 '<!doctype html>\n<html>\n<head>\n<title>Example Domain</title>...'

--- a/docs/api.md
+++ b/docs/api.md
@@ -61,6 +61,7 @@
 * `.content` - **bytes**
 * `.text` - **str**
 * `.encoding` - **str**
+* `.content_type` - **Optional[str]**
 * `.is_redirect` - **bool**
 * `.request` - **Request**
 * `.next_request` - **Optional[Request]**

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ Now, let's get started:
 <Response [200 OK]>
 >>> r.status_code
 200
->>> r.headers['content-type']
+>>> r.content_type
 'text/html; charset=UTF-8'
 >>> r.text
 '<!doctype html>\n<html>\n<head>\n<title>Example Domain</title>...'

--- a/httpx/_main.py
+++ b/httpx/_main.py
@@ -101,7 +101,7 @@ def print_help() -> None:
 
 
 def get_lexer_for_response(response: Response) -> str:
-    content_type = response.headers.get("Content-Type")
+    content_type = response.content_type
     if content_type is not None:
         mime_type, _, _ = content_type.partition(";")
         try:

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -690,11 +690,10 @@ class Response:
         """
         Return the encoding, as specified by the Content-Type header.
         """
-        content_type = self.headers.get("Content-Type")
-        if content_type is None:
+        if self.content_type is None:
             return None
 
-        return _parse_content_type_charset(content_type)
+        return _parse_content_type_charset(self.content_type)
 
     def _get_content_decoder(self) -> ContentDecoder:
         """
@@ -1074,6 +1073,14 @@ class Response:
             self.is_closed = True
             with request_context(request=self._request):
                 await self.stream.aclose()
+
+    @property
+    def content_type(self) -> str | None:
+        """
+        Return the Content-Type header.
+        """
+        result = self.headers.get("Content-Type")
+        return str(result) if result else None
 
 
 class Cookies(typing.MutableMapping[str, str]):

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -492,7 +492,7 @@ def test_ensure_ascii_false_with_french_characters():
     assert (
         "ça va" in response.text
     ), "ensure_ascii=False should preserve French accented characters"
-    assert response.headers["Content-Type"] == "application/json"
+    assert response.content_type == "application/json"
 
 
 def test_separators_for_compact_json():
@@ -501,7 +501,7 @@ def test_separators_for_compact_json():
     assert (
         response.text == '{"clé":"valeur","liste":[1,2,3]}'
     ), "separators=(',', ':') should produce a compact representation"
-    assert response.headers["Content-Type"] == "application/json"
+    assert response.content_type == "application/json"
 
 
 def test_allow_nan_false():


### PR DESCRIPTION
# Summary

I would like to suggest adding a little syntax sugar. It might be more convenient to use `response.content_type` instead of `response.headers.get("Content-Type")`.
I hope I haven't forgotten any places where changes need to be made

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
