### PR TITLE
Add httpx-retries to third party packages docs

### DIFF
--- a/docs/third_party_packages.md
+++ b/docs/third_party_packages.md
@@ -2,31 +2,15 @@
 
 As HTTPX usage grows, there is an expanding community of developers building tools and libraries that integrate with HTTPX, or depend on HTTPX. Here are some of them.
 
+<!-- NOTE: Entries are alphabetised. -->
+
 ## Plugins
-
-### Authlib
-
-[GitHub](https://github.com/lepture/authlib) - [Documentation](https://docs.authlib.org/en/latest/)
-
-The ultimate Python library in building OAuth and OpenID Connect clients and servers. Includes an [OAuth HTTPX client](https://docs.authlib.org/en/latest/client/httpx.html).
-
-### Gidgethub
-
-[GitHub](https://github.com/brettcannon/gidgethub) - [Documentation](https://gidgethub.readthedocs.io/en/latest/index.html)
-
-An asynchronous GitHub API library. Includes [HTTPX support](https://gidgethub.readthedocs.io/en/latest/httpx.html).
 
 ### Hishel
 
 [GitHub](https://github.com/karpetrosyan/hishel) - [Documentation](https://hishel.com/)
 
 An elegant HTTP Cache implementation for HTTPX and HTTP Core.
-
-### httpdbg
-
-[GitHub](https://github.com/cle-b/httpdbg) - [Documentation](https://httpdbg.readthedocs.io/)
-
-A tool for Python developers to easily debug the HTTP(S) client requests in a Python program.
 
 ### HTTPX-Auth
 
@@ -82,6 +66,26 @@ A utility for mocking out the Python HTTPX library.
 
 An fast and powerful RPC framework based on ASGI/WSGI. Use HTTPX as the client of the RPC service.
 
+## Libraries with HTTPX support
+
+### Authlib
+
+[GitHub](https://github.com/lepture/authlib) - [Documentation](https://docs.authlib.org/en/latest/)
+
+A python library for building OAuth and OpenID Connect clients and servers. Includes an [OAuth HTTPX client](https://docs.authlib.org/en/latest/client/httpx.html).
+
+### Gidgethub
+
+[GitHub](https://github.com/brettcannon/gidgethub) - [Documentation](https://gidgethub.readthedocs.io/en/latest/index.html)
+
+An asynchronous GitHub API library. Includes [HTTPX support](https://gidgethub.readthedocs.io/en/latest/httpx.html).
+
+### httpdbg
+
+[GitHub](https://github.com/cle-b/httpdbg) - [Documentation](https://httpdbg.readthedocs.io/)
+
+A tool for Python developers to easily debug the HTTP(S) client requests in a Python program.
+
 ### VCR.py
 
 [GitHub](https://github.com/kevin1024/vcrpy) - [Documentation](https://vcrpy.readthedocs.io/)
@@ -89,8 +93,6 @@ An fast and powerful RPC framework based on ASGI/WSGI. Use HTTPX as the client o
 A utility for record and repeat an http request.
 
 ## Gists
-
-<!-- NOTE: this list is in alphabetical order. -->
 
 ### urllib3-transport
 

--- a/docs/third_party_packages.md
+++ b/docs/third_party_packages.md
@@ -16,7 +16,7 @@ An elegant HTTP Cache implementation for HTTPX and HTTP Core.
 
 [GitHub](https://github.com/Colin-b/httpx_auth) - [Documentation](https://colin-b.github.io/httpx_auth/)
 
-Provides authentication classes to be used with HTTPX [authentication parameter](advanced/authentication.md#customizing-authentication).
+Provides authentication classes to be used with HTTPX's [authentication parameter](advanced/authentication.md#customizing-authentication).
 
 ### httpx-caching
 
@@ -52,7 +52,7 @@ WebSocket support for HTTPX.
 
 [GitHub](https://github.com/Colin-b/pytest_httpx) - [Documentation](https://colin-b.github.io/pytest_httpx/)
 
-Provides `httpx_mock` [pytest](https://docs.pytest.org/en/latest/) fixture to mock HTTPX within test cases.
+Provides a [pytest](https://docs.pytest.org/en/latest/) fixture to mock HTTPX within test cases.
 
 ### RESPX
 

--- a/docs/third_party_packages.md
+++ b/docs/third_party_packages.md
@@ -90,7 +90,7 @@ A tool for Python developers to easily debug the HTTP(S) client requests in a Py
 
 [GitHub](https://github.com/kevin1024/vcrpy) - [Documentation](https://vcrpy.readthedocs.io/)
 
-A utility for record and repeat an http request.
+Record and repeat requests.
 
 ## Gists
 

--- a/docs/third_party_packages.md
+++ b/docs/third_party_packages.md
@@ -76,12 +76,6 @@ Provides `httpx_mock` [pytest](https://docs.pytest.org/en/latest/) fixture to mo
 
 A utility for mocking out the Python HTTPX library.
 
-### robox
-
-[Github](https://github.com/danclaudiupop/robox)
-
-A library for scraping the web built on top of HTTPX.
-
 ### rpc.py
 
 [Github](https://github.com/abersheeran/rpc.py) - [Documentation](https://github.com/abersheeran/rpc.py#rpcpy)

--- a/docs/third_party_packages.md
+++ b/docs/third_party_packages.md
@@ -4,30 +4,6 @@ As HTTPX usage grows, there is an expanding community of developers building too
 
 ## Plugins
 
-### httpx-ws
-
-[GitHub](https://github.com/frankie567/httpx-ws) - [Documentation](https://frankie567.github.io/httpx-ws/)
-
-WebSocket support for HTTPX.
-
-### httpx-socks
-
-[GitHub](https://github.com/romis2012/httpx-socks)
-
-Proxy (HTTP, SOCKS) transports for httpx.
-
-### httpdbg
-
-[GitHub](https://github.com/cle-b/httpdbg) - [Documentation](https://httpdbg.readthedocs.io/)
-
-A tool for Python developers to easily debug the HTTP(S) client requests in a Python program.
-
-### Hishel
-
-[GitHub](https://github.com/karpetrosyan/hishel) - [Documentation](https://hishel.com/)
-
-An elegant HTTP Cache implementation for HTTPX and HTTP Core.
-
 ### Authlib
 
 [GitHub](https://github.com/lepture/authlib) - [Documentation](https://docs.authlib.org/en/latest/)
@@ -40,11 +16,53 @@ The ultimate Python library in building OAuth and OpenID Connect clients and ser
 
 An asynchronous GitHub API library. Includes [HTTPX support](https://gidgethub.readthedocs.io/en/latest/httpx.html).
 
+### Hishel
+
+[GitHub](https://github.com/karpetrosyan/hishel) - [Documentation](https://hishel.com/)
+
+An elegant HTTP Cache implementation for HTTPX and HTTP Core.
+
+### httpdbg
+
+[GitHub](https://github.com/cle-b/httpdbg) - [Documentation](https://httpdbg.readthedocs.io/)
+
+A tool for Python developers to easily debug the HTTP(S) client requests in a Python program.
+
 ### HTTPX-Auth
 
 [GitHub](https://github.com/Colin-b/httpx_auth) - [Documentation](https://colin-b.github.io/httpx_auth/)
 
 Provides authentication classes to be used with HTTPX [authentication parameter](advanced/authentication.md#customizing-authentication).
+
+### httpx-caching
+
+[Github](https://github.com/johtso/httpx-caching)
+
+This package adds caching functionality to HTTPX
+
+### httpx-socks
+
+[GitHub](https://github.com/romis2012/httpx-socks)
+
+Proxy (HTTP, SOCKS) transports for httpx.
+
+### httpx-sse
+
+[GitHub](https://github.com/florimondmanca/httpx-sse)
+
+Allows consuming Server-Sent Events (SSE) with HTTPX.
+
+### httpx-retries
+
+[GitHub](https://github.com/will-ockmore/httpx-retries) - [Documentation](https://will-ockmore.github.io/httpx-retries/)
+
+A retry layer for HTTPX.
+
+### httpx-ws
+
+[GitHub](https://github.com/frankie567/httpx-ws) - [Documentation](https://frankie567.github.io/httpx-ws/)
+
+WebSocket support for HTTPX.
 
 ### pytest-HTTPX
 
@@ -58,6 +76,12 @@ Provides `httpx_mock` [pytest](https://docs.pytest.org/en/latest/) fixture to mo
 
 A utility for mocking out the Python HTTPX library.
 
+### robox
+
+[Github](https://github.com/danclaudiupop/robox)
+
+A library for scraping the web built on top of HTTPX.
+
 ### rpc.py
 
 [Github](https://github.com/abersheeran/rpc.py) - [Documentation](https://github.com/abersheeran/rpc.py#rpcpy)
@@ -69,24 +93,6 @@ An fast and powerful RPC framework based on ASGI/WSGI. Use HTTPX as the client o
 [GitHub](https://github.com/kevin1024/vcrpy) - [Documentation](https://vcrpy.readthedocs.io/)
 
 A utility for record and repeat an http request.
-
-### httpx-caching
-
-[Github](https://github.com/johtso/httpx-caching)
-
-This package adds caching functionality to HTTPX
-
-### httpx-sse
-
-[GitHub](https://github.com/florimondmanca/httpx-sse)
-
-Allows consuming Server-Sent Events (SSE) with HTTPX.
-
-### robox
-
-[Github](https://github.com/danclaudiupop/robox)
-
-A library for scraping the web built on top of HTTPX.
 
 ## Gists
 

--- a/docs/third_party_packages.md
+++ b/docs/third_party_packages.md
@@ -58,13 +58,13 @@ Provides `httpx_mock` [pytest](https://docs.pytest.org/en/latest/) fixture to mo
 
 [GitHub](https://github.com/lundberg/respx) - [Documentation](https://lundberg.github.io/respx/)
 
-A utility for mocking out the python HTTPX library.
+A utility for mocking out HTTPX.
 
 ### rpc.py
 
 [Github](https://github.com/abersheeran/rpc.py) - [Documentation](https://github.com/abersheeran/rpc.py#rpcpy)
 
-An fast and powerful RPC framework based on ASGI/WSGI. Use HTTPX as the client of the RPC service.
+A fast and powerful RPC framework based on ASGI/WSGI. Use HTTPX as the client of the RPC service.
 
 ## Libraries with HTTPX support
 

--- a/docs/third_party_packages.md
+++ b/docs/third_party_packages.md
@@ -58,7 +58,7 @@ Provides `httpx_mock` [pytest](https://docs.pytest.org/en/latest/) fixture to mo
 
 [GitHub](https://github.com/lundberg/respx) - [Documentation](https://lundberg.github.io/respx/)
 
-A utility for mocking out the Python HTTPX library.
+A utility for mocking out the python HTTPX library.
 
 ### rpc.py
 
@@ -84,7 +84,7 @@ An asynchronous GitHub API library. Includes [HTTPX support](https://gidgethub.r
 
 [GitHub](https://github.com/cle-b/httpdbg) - [Documentation](https://httpdbg.readthedocs.io/)
 
-A tool for Python developers to easily debug the HTTP(S) client requests in a Python program.
+A tool for python developers to easily debug the HTTP(S) client requests in a python program.
 
 ### VCR.py
 


### PR DESCRIPTION
# Summary

[httpx-retries](https://github.com/will-ockmore/httpx-retries) is a third-party package which implements request retry. 

There's been extensive discussion on this feature in https://github.com/encode/httpx/issues/108 - take a look at the end of the thread (specifically, the [recent comment I left](https://github.com/encode/httpx/issues/108)) for the current state of play.

I've added the package to the third-party packages docs; I've also sorted the entries alphabetically, as there's quite a few, to make it easier to browse (if this is an undesired change, let me know, I'll revert it!). I've run the docs locally, to verify everything looks good.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
