### PR TITLE
Python 3.14: handle `typing.Union` immutability

### DIFF
--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -102,4 +102,9 @@ __all__ = [
 __locals = locals()
 for __name in __all__:
     if not __name.startswith("__"):
-        setattr(__locals[__name], "__module__", "httpx")  # noqa
+        try:
+            setattr(__locals[__name], "__module__", "httpx")  # noqa
+        except AttributeError:
+            # typing.Union instances are immutable in Python 3.14+,
+            # so don't fail if writing to "__module__" fails
+            continue

--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -104,7 +104,7 @@ for __name in __all__:
     if not __name.startswith("__"):
         try:
             setattr(__locals[__name], "__module__", "httpx")  # noqa
-        except AttributeError:
+        except AttributeError:  # noqa
             # typing.Union instances are immutable in Python 3.14+,
             # so don't fail if writing to "__module__" fails
-            continue
+            continue  # noqa

--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -104,7 +104,7 @@ for __name in __all__:
     if not __name.startswith("__"):
         try:
             setattr(__locals[__name], "__module__", "httpx")  # noqa
-        except AttributeError:  # noqa
+        except AttributeError:  # pragma: no cover
             # typing.Union instances are immutable in Python 3.14+,
             # so don't fail if writing to "__module__" fails
-            continue  # noqa
+            continue  # pragma: no cover


### PR DESCRIPTION
# Summary

`typing.Union` instances are becoming immutable in Python 3.14+: https://docs.python.org/3.14/whatsnew/3.14.html#typing

This trips up the code in `httpx.__init__` that hides the internal module details in top-level object metadata by setting their `__module__` attributes.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.

I don't believe test or documentation changes are needed (when the CI config is expanded to include Python 3.14, this will be covered automatically), but I've left those unchecked until that has been confirmed.

# Details

Attempting to [publish an experimental project](https://github.com/ncoghlan/tstrprocess/actions/runs/14682311907/job/41206490424#step:3:76) that will require Python 3.14's t-strings to run, I encountered the following exception from this code:

```
AttributeError: 'typing.Union' object has no attribute '__module__' and no __dict__ for setting new attributes. Did you mean: '__reduce__'?
```

I then traced that new failure back to the `typing.Union` change described in the summary.

The PR currently works by ignoring the exception raised (since that's the most comprehensive option), but an alternative approach would be to add a `hasattr` check so only values that already have a `__module__` attribute get modified.
