### PR TITLE
Bugfix: do not discard cookie default policy from jar

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -1092,9 +1092,7 @@ class Cookies(typing.MutableMapping[str, str]):
             for key, value in cookies:
                 self.set(key, value)
         elif isinstance(cookies, Cookies):
-            self.jar = CookieJar()
-            for cookie in cookies.jar:
-                self.jar.set_cookie(cookie)
+            self.jar = cookies.jar
         else:
             self.jar = cookies
 

--- a/tests/models/test_cookies.py
+++ b/tests/models/test_cookies.py
@@ -98,6 +98,7 @@ def test_cookies_repr():
         " <Cookie fizz=buzz for http://hello.com />]>"
     )
 
+
 def test_cookies_policy():
     jar = CookieJar()
     jar.set_policy(

--- a/tests/models/test_cookies.py
+++ b/tests/models/test_cookies.py
@@ -1,4 +1,5 @@
 import http
+from http.cookiejar import CookieJar, DefaultCookiePolicy
 
 import pytest
 
@@ -96,3 +97,14 @@ def test_cookies_repr():
         "<Cookies[<Cookie foo=bar for http://blah.com />,"
         " <Cookie fizz=buzz for http://hello.com />]>"
     )
+
+def test_cookies_policy():
+    jar = CookieJar()
+    jar.set_policy(
+        DefaultCookiePolicy(
+            strict_domain=True,
+        )
+    )
+    cookies = httpx.Cookies(jar)
+    new_cookies = httpx.Cookies(cookies)
+    assert new_cookies.jar._policy.strict_domain is True


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

http.cookiejar allows setting a custom default policy for cookies. httpx immediately discards that before any requests get sent

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
