### PR TITLE
fix CVE-2025-43859

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 dependencies = [
     "certifi",
-    "httpcore==1.*",
+    "httpcore>=1.0.9",
     "anyio",
     "idna",
 ]


### PR DESCRIPTION
h11 accepts some malformed Chunked-Encoding bodies before 0.16.0, httpcore 1.0.9 ensure using at least 0.16.0

<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

# Checklist

- [ ] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
