### PR TITLE
Display proxy protocol scheme on error

### DIFF
--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -355,7 +355,7 @@ class AsyncHTTPTransport(AsyncBaseTransport):
         else:  # pragma: no cover
             raise ValueError(
                 "Proxy protocol must be either 'http', 'https', 'socks5', or 'socks5h',"
-                " but got {proxy.url.scheme!r}."
+                f" but got {proxy.url.scheme!r}."
             )
 
     async def __aenter__(self: A) -> A:  # Use generics for subclass support.


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary
This small PR evaluates `proxy.url.scheme` in the error message.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
