### PR TITLE
feat: allow passing extra error message in raise_for_status

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -791,7 +791,7 @@ class Response:
             and "Location" in self.headers
         )
 
-    def raise_for_status(self) -> Response:
+    def raise_for_status(self, reason: str | None = None) -> Response:
         """
         Raise the `HTTPStatusError` if one occurred.
         """
@@ -807,13 +807,13 @@ class Response:
 
         if self.has_redirect_location:
             message = (
-                "{error_type} '{0.status_code} {0.reason_phrase}' for url '{0.url}'\n"
+                "{error_type} '{0.status_code} {0.reason_phrase}{extra_reason}' for url '{0.url}'\n"
                 "Redirect location: '{0.headers[location]}'\n"
                 "For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/{0.status_code}"
             )
         else:
             message = (
-                "{error_type} '{0.status_code} {0.reason_phrase}' for url '{0.url}'\n"
+                "{error_type} '{0.status_code} {0.reason_phrase}{extra_reason}' for url '{0.url}'\n"
                 "For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/{0.status_code}"
             )
 
@@ -825,7 +825,8 @@ class Response:
             5: "Server error",
         }
         error_type = error_types.get(status_class, "Invalid status code")
-        message = message.format(self, error_type=error_type)
+        extra_reason = f' {reason}' if reason  else ''
+        message = message.format(self, error_type=error_type, extra_reason=extra_reason)
         raise HTTPStatusError(message, request=request, response=self)
 
     def json(self, **kwargs: typing.Any) -> typing.Any:


### PR DESCRIPTION
this allows usgae of `rsp.raise_for_status(rsp.text)`, in many error response, the body contains more error messages.

<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

# Checklist

- [ ] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
