### PR TITLE
Ensured explicit closing of async generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [UNRELEASED]
 
+### Fixed
+
+* Explicitly close all async generators to ensure predictable behavior
+
 ### Removed
 
 * Drop support for Python 3.8

--- a/httpx/_multipart.py
+++ b/httpx/_multipart.py
@@ -5,6 +5,7 @@ import mimetypes
 import os
 import re
 import typing
+from collections.abc import AsyncGenerator
 from pathlib import Path
 
 from ._types import (
@@ -295,6 +296,6 @@ class MultipartStream(SyncByteStream, AsyncByteStream):
         for chunk in self.iter_chunks():
             yield chunk
 
-    async def __aiter__(self) -> typing.AsyncIterator[bytes]:
+    async def __aiter__(self) -> AsyncGenerator[bytes]:
         for chunk in self.iter_chunks():
             yield chunk

--- a/httpx/_transports/asgi.py
+++ b/httpx/_transports/asgi.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import typing
+from collections.abc import AsyncGenerator
 
 from .._models import Request, Response
 from .._types import AsyncByteStream
@@ -56,7 +57,7 @@ class ASGIResponseStream(AsyncByteStream):
     def __init__(self, body: list[bytes]) -> None:
         self._body = body
 
-    async def __aiter__(self) -> typing.AsyncIterator[bytes]:
+    async def __aiter__(self) -> AsyncGenerator[bytes]:
         yield b"".join(self._body)
 
 

--- a/httpx/_types.py
+++ b/httpx/_types.py
@@ -94,7 +94,6 @@ class SyncByteStream:
         raise NotImplementedError(
             "The '__iter__' method must be implemented."
         )  # pragma: no cover
-        yield b""  # pragma: no cover
 
     def close(self) -> None:
         """
@@ -104,11 +103,10 @@ class SyncByteStream:
 
 
 class AsyncByteStream:
-    async def __aiter__(self) -> AsyncIterator[bytes]:
+    def __aiter__(self) -> AsyncIterator[bytes]:
         raise NotImplementedError(
             "The '__aiter__' method must be implemented."
         )  # pragma: no cover
-        yield b""  # pragma: no cover
 
     async def aclose(self) -> None:
         pass

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -1,6 +1,5 @@
 import io
 import typing
-from collections.abc import AsyncGenerator
 
 import pytest
 


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->
This change ensures that async generators are always explicitly closed, even if the task running the generator is cancelled or another exception is raised. This prevents unpredictable behavior and also avoids the asyncgen finalizer warnings on Trio.

# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [X] I've updated the documentation accordingly.
