### PR TITLE
Improve error message formatting in Response class to not give a link for unofficial codes.

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -805,17 +805,11 @@ class Response:
         if self.is_success:
             return self
 
+        message = "{error_type} '{0.status_code} {0.reason_phrase}' for url '{0.url}'"
         if self.has_redirect_location:
-            message = (
-                "{error_type} '{0.status_code} {0.reason_phrase}' for url '{0.url}'\n"
-                "Redirect location: '{0.headers[location]}'\n"
-                "For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/{0.status_code}"
-            )
-        else:
-            message = (
-                "{error_type} '{0.status_code} {0.reason_phrase}' for url '{0.url}'\n"
-                "For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/{0.status_code}"
-            )
+            message += "\nRedirect location: '{0.headers[location]}'"
+        if self.reason_phrase:
+            message += "\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/{0.status_code}"
 
         status_class = self.status_code // 100
         error_types = {


### PR DESCRIPTION
# Summary

When seeing an [unofficial status code](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#Unofficial_codes) the suggested further reading link to MDN Web Docs will be broken since it contains only official codes.

As an example, the unofficial code for 529 will direct the developer to [https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/529](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/529), a web page that does not exist.

The change adds the line with the link only if the status code has a reason phrase, meaning it is a part of the 'codes' Enum.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
  - There are no message tests for raise_for_status. 
- [ ] I've updated the documentation accordingly.
  - No behavioral change, so no documentation to update.
