### PR TITLE
Use standard libary Zstandard for Python 3.14+

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ As well as these optional installs:
 * `rich` - Rich terminal support. *(Optional, with `httpx[cli]`)*
 * `click` - Command line client support. *(Optional, with `httpx[cli]`)*
 * `brotli` or `brotlicffi` - Decoding for "brotli" compressed responses. *(Optional, with `httpx[brotli]`)*
-* `zstandard` - Decoding for "zstd" compressed responses. *(Optional, with `httpx[zstd]`)*
+* `zstandard` - Decoding for "zstd" compressed responses before Python 3.14. *(Optional, with `httpx[zstd]`)*
 
 A huge amount of credit is due to `requests` for the API layout that
 much of this work follows, as well as to `urllib3` for plenty of design

--- a/docs/index.md
+++ b/docs/index.md
@@ -119,7 +119,7 @@ As well as these optional installs:
 * `rich` - Rich terminal support. *(Optional, with `httpx[cli]`)*
 * `click` - Command line client support. *(Optional, with `httpx[cli]`)*
 * `brotli` or `brotlicffi` - Decoding for "brotli" compressed responses. *(Optional, with `httpx[brotli]`)*
-* `zstandard` - Decoding for "zstd" compressed responses. *(Optional, with `httpx[zstd]`)*
+* `zstandard` - Decoding for "zstd" compressed responses before Python 3.14. *(Optional, with `httpx[zstd]`)*
 
 A huge amount of credit is due to `requests` for the API layout that
 much of this work follows, as well as to `urllib3` for plenty of design

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -100,8 +100,9 @@ b'<!doctype html>\n<html>\n<head>\n<title>Example Domain</title>...'
 
 Any `gzip` and `deflate` HTTP response encodings will automatically
 be decoded for you. If `brotlipy` is installed, then the `brotli` response
-encoding will be supported. If `zstandard` is installed, then `zstd`
-response encodings will also be supported.
+encoding will be supported. The `zstd` response encoding is supported by
+default on Python 3.14 and later, and optionally available on earlier Python
+versions with `zstandard` installed.
 
 For example, to create an image from binary data returned by a request, you can use the following code:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ socks = [
     "socksio==1.*",
 ]
 zstd = [
-  "zstandard>=0.18.0",
+  "zstandard>=0.18.0; python_version < \"3.14\"",
 ]
 
 [project.scripts]

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -6,7 +6,11 @@ import zlib
 
 import chardet
 import pytest
-import zstandard as zstd
+
+try:
+    from compression import zstd
+except ImportError:
+    import zstandard as zstd
 
 import httpx
 


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary
[PEP 784](https://peps.python.org/pep-0784/) add a Zstandard implementation to the Python standard library under `compression.zstd`, and is scheduled for release in Python 3.14. This PR adapts `ZStandardDecoder` to work with either the standard library implementation or the implementation from the [`zstandard`](https://github.com/indygreg/python-zstandard) package.

This has the implication that Zstandard content decoding is available by default on Python 3.14 and later, without the need to install the `zstd` extra. 

# Checklist
- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
  - Testing this requires Python 3.14, but the existing zstd unit tests pass with the standard library implementation. I'm always happy to add more tests if needed!
- [x] I've updated the documentation accordingly.
