### PR TITLE
Migrate API docs to mkdocstrings

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -9,43 +9,68 @@
     long-lived connections.
 
 ::: httpx.request
-    :docstring:
 
 ::: httpx.get
-    :docstring:
 
 ::: httpx.options
-    :docstring:
 
 ::: httpx.head
-    :docstring:
 
 ::: httpx.post
-    :docstring:
 
 ::: httpx.put
-    :docstring:
 
 ::: httpx.patch
-    :docstring:
 
 ::: httpx.delete
-    :docstring:
 
 ::: httpx.stream
-    :docstring:
 
 ## `Client`
 
 ::: httpx.Client
-    :docstring:
-    :members: headers cookies params auth request get head options post put patch delete stream build_request send close
+    options:
+      inherited_members: true
+      members:
+      - headers
+      - cookies
+      - params
+      - auth 
+      - request
+      - get
+      - head
+      - options
+      - post
+      - put
+      - patch
+      - delete
+      - stream
+      - build_request
+      - send
+      - close
 
 ## `AsyncClient`
 
 ::: httpx.AsyncClient
-    :docstring:
-    :members: headers cookies params auth request get head options post put patch delete stream build_request send aclose
+    inherited_members: true
+    options:
+      members:
+      - headers
+      - cookies
+      - params
+      - auth
+      - request
+      - get
+      - head
+      - options
+      - post
+      - put
+      - patch
+      - delete
+      - stream
+      - build_request
+      - send
+      - aclose
 
 
 ## `Response`

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -8,3 +8,11 @@ div.autodoc-members {
   padding-left: 20px;
   margin-bottom: 15px;
 }
+
+.doc-class-bases {
+  display: none;
+}
+
+div[data-md-type="toc"] .md-nav__item > .md-nav {
+  display: none;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,53 +3,53 @@ site_description: A next-generation HTTP client for Python.
 site_url: https://www.python-httpx.org/
 
 theme:
-  name: "material"
-  custom_dir: "docs/overrides"
+  name: 'material'
+  custom_dir: 'docs/overrides'
   palette:
-    - scheme: "default"
-      media: "(prefers-color-scheme: light)"
+    - scheme: 'default'
+      media: '(prefers-color-scheme: light)'
       toggle:
-        icon: "material/lightbulb"
-        name: "Switch to dark mode"
-    - scheme: "slate"
-      media: "(prefers-color-scheme: dark)"
-      primary: "blue"
+        icon: 'material/lightbulb'
+        name: 'Switch to dark mode'
+    - scheme: 'slate'
+      media: '(prefers-color-scheme: dark)'
+      primary: 'blue'
       toggle:
-        icon: "material/lightbulb-outline"
-        name: "Switch to light mode"
+        icon: 'material/lightbulb-outline'
+        name: 'Switch to light mode'
 
 repo_name: encode/httpx
 repo_url: https://github.com/encode/httpx/
-edit_uri: ""
+edit_uri: ''
 
 nav:
-  - Introduction: "index.md"
-  - QuickStart: "quickstart.md"
+  - Introduction: 'index.md'
+  - QuickStart: 'quickstart.md'
   - Advanced:
-      - Clients: "advanced/clients.md"
-      - Authentication: "advanced/authentication.md"
-      - SSL: "advanced/ssl.md"
-      - Proxies: "advanced/proxies.md"
-      - Timeouts: "advanced/timeouts.md"
-      - Resource Limits: "advanced/resource-limits.md"
-      - Event Hooks: "advanced/event-hooks.md"
-      - Transports: "advanced/transports.md"
-      - Text Encodings: "advanced/text-encodings.md"
-      - Extensions: "advanced/extensions.md"
+      - Clients: 'advanced/clients.md'
+      - Authentication: 'advanced/authentication.md'
+      - SSL: 'advanced/ssl.md'
+      - Proxies: 'advanced/proxies.md'
+      - Timeouts: 'advanced/timeouts.md'
+      - Resource Limits: 'advanced/resource-limits.md'
+      - Event Hooks: 'advanced/event-hooks.md'
+      - Transports: 'advanced/transports.md'
+      - Text Encodings: 'advanced/text-encodings.md'
+      - Extensions: 'advanced/extensions.md'
   - Guides:
-      - Async Support: "async.md"
-      - HTTP/2 Support: "http2.md"
-      - Logging: "logging.md"
-      - Requests Compatibility: "compatibility.md"
-      - Troubleshooting: "troubleshooting.md"
+      - Async Support: 'async.md'
+      - HTTP/2 Support: 'http2.md'
+      - Logging: 'logging.md'
+      - Requests Compatibility: 'compatibility.md'
+      - Troubleshooting: 'troubleshooting.md'
   - API Reference:
-      - Developer Interface: "api.md"
-      - Exceptions: "exceptions.md"
-      - Environment Variables: "environment_variables.md"
+      - Developer Interface: 'api.md'
+      - Exceptions: 'exceptions.md'
+      - Environment Variables: 'environment_variables.md'
   - Community:
-      - Third Party Packages: "third_party_packages.md"
-      - Contributing: "contributing.md"
-      - Code of Conduct: "code_of_conduct.md"
+      - Third Party Packages: 'third_party_packages.md'
+      - Contributing: 'contributing.md'
+      - Code of Conduct: 'code_of_conduct.md'
 
 plugins:
   - mkdocstrings:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,59 +3,69 @@ site_description: A next-generation HTTP client for Python.
 site_url: https://www.python-httpx.org/
 
 theme:
-    name: 'material'
-    custom_dir: 'docs/overrides'
-    palette:
-      - scheme: 'default'
-        media: '(prefers-color-scheme: light)'
-        toggle:
-          icon: 'material/lightbulb'
-          name: "Switch to dark mode"
-      - scheme: 'slate'
-        media: '(prefers-color-scheme: dark)'
-        primary: 'blue'
-        toggle:
-          icon: 'material/lightbulb-outline'
-          name: 'Switch to light mode'
+  name: "material"
+  custom_dir: "docs/overrides"
+  palette:
+    - scheme: "default"
+      media: "(prefers-color-scheme: light)"
+      toggle:
+        icon: "material/lightbulb"
+        name: "Switch to dark mode"
+    - scheme: "slate"
+      media: "(prefers-color-scheme: dark)"
+      primary: "blue"
+      toggle:
+        icon: "material/lightbulb-outline"
+        name: "Switch to light mode"
 
 repo_name: encode/httpx
 repo_url: https://github.com/encode/httpx/
 edit_uri: ""
 
 nav:
-    - Introduction: 'index.md'
-    - QuickStart: 'quickstart.md'
-    - Advanced:
-        - Clients: 'advanced/clients.md'
-        - Authentication: 'advanced/authentication.md'
-        - SSL: 'advanced/ssl.md'
-        - Proxies: 'advanced/proxies.md'
-        - Timeouts: 'advanced/timeouts.md'
-        - Resource Limits: 'advanced/resource-limits.md'
-        - Event Hooks: 'advanced/event-hooks.md'
-        - Transports: 'advanced/transports.md'
-        - Text Encodings: 'advanced/text-encodings.md'
-        - Extensions: 'advanced/extensions.md'
-    - Guides:
-        - Async Support: 'async.md'
-        - HTTP/2 Support: 'http2.md'
-        - Logging: 'logging.md'
-        - Requests Compatibility: 'compatibility.md'
-        - Troubleshooting: 'troubleshooting.md'
-    - API Reference:
-        - Developer Interface: 'api.md'
-        - Exceptions: 'exceptions.md'
-        - Environment Variables: 'environment_variables.md'
-    - Community:
-        - Third Party Packages: 'third_party_packages.md'
-        - Contributing: 'contributing.md'
-        - Code of Conduct: 'code_of_conduct.md'
+  - Introduction: "index.md"
+  - QuickStart: "quickstart.md"
+  - Advanced:
+      - Clients: "advanced/clients.md"
+      - Authentication: "advanced/authentication.md"
+      - SSL: "advanced/ssl.md"
+      - Proxies: "advanced/proxies.md"
+      - Timeouts: "advanced/timeouts.md"
+      - Resource Limits: "advanced/resource-limits.md"
+      - Event Hooks: "advanced/event-hooks.md"
+      - Transports: "advanced/transports.md"
+      - Text Encodings: "advanced/text-encodings.md"
+      - Extensions: "advanced/extensions.md"
+  - Guides:
+      - Async Support: "async.md"
+      - HTTP/2 Support: "http2.md"
+      - Logging: "logging.md"
+      - Requests Compatibility: "compatibility.md"
+      - Troubleshooting: "troubleshooting.md"
+  - API Reference:
+      - Developer Interface: "api.md"
+      - Exceptions: "exceptions.md"
+      - Environment Variables: "environment_variables.md"
+  - Community:
+      - Third Party Packages: "third_party_packages.md"
+      - Contributing: "contributing.md"
+      - Code of Conduct: "code_of_conduct.md"
+
+plugins:
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            merge_init_into_class: true
+            show_root_heading: true
+            heading_level: 3
+          inventories:
+            - https://docs.python.org/3/objects.inv
 
 markdown_extensions:
   - admonition
   - codehilite:
       css_class: highlight
-  - mkautodoc
 
 extra_css:
-    - css/custom.css
+  - css/custom.css

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ chardet==5.2.0
 
 # Documentation
 mkdocs==1.6.1
-mkautodoc==0.2.0
+mkdocstrings[python]==0.30.0
 mkdocs-material==9.5.47
 
 # Packaging


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Migrates API docs from `autodoc` to `mkdocstrings`. I was hoping to be able to use an httpx inventory file in some documentation and noticed there seems to be interest in it from the attached issue so tried sending a PR.

I have made tweaks such as to the CSS to make it as close to the current site as possible. Though it could also make sense to have the full TOC.

The biggest difference in rendering is the docs don't have a inlet and are rendered directly. There are some other differences like font size and not showing the word `class` (mkdocstrings may allow it in the future as they have an insiders-only feature for it right now).

To really render using mkdocstrings, i.e. rendering out parameters in a structured way, the docstrings themselves would need to be updated to one of the supported styles like Google, numpy, or sphinx. This PR doesn't change that though to be smaller and still be quite close to what's already there, while also providing the inventory file.

To test, I run 

```
uv run --with mkdocs --with mkdocs-material --with mkautodoc --with 'mkdocstrings[python]' mkdocs build
open site/index.html
```

Fixes #3145 

<img width="813" height="1088" alt="image" src="https://github.com/user-attachments/assets/387a9fd3-66f2-4d38-84fe-7807cf67a88f" />


# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [X] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [X] I've updated the documentation accordingly.
