### PR TITLE
Update `Response.raise_for_status()` to respect `follow_redirects` parameter

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -305,6 +305,23 @@ The method returns the response instance, allowing you to use it inline. For exa
 >>> data = httpx.get('...').raise_for_status().json()
 ```
 
+### Controlling Redirect Behavior
+
+By default, `raise_for_status()` will raise an exception for redirect responses (3xx status codes). However, when you make a request with `follow_redirects=False`, the method automatically detects this and won't raise exceptions for redirect responses:
+
+```pycon
+# This will raise an exception for redirects (default behavior)
+response = httpx.get('https://httpbin.org/status/301')
+response.raise_for_status()  # Raises HTTPStatusError for 301 redirect
+
+# This will NOT raise an exception for redirects
+response = httpx.get('https://httpbin.org/status/301', follow_redirects=False)
+response.raise_for_status()  # No exception raised - treats redirect as successful
+```
+
+When `follow_redirects=False` is set on the request, HTTPX sets `response.next_request` for redirect responses, and `raise_for_status()` automatically detects this and treats redirects as successful responses.
+
+
 ## Response Headers
 
 The response headers are available as a dictionary-like interface.

--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -805,6 +805,10 @@ class Response:
         if self.is_success:
             return self
 
+        # If follow_redirects is False, we should not raise a redirect error
+        if self.next_request is not None:
+            return self
+
         if self.has_redirect_location:
             message = (
                 "{error_type} '{0.status_code} {0.reason_phrase}' for url '{0.url}'\n"

--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -145,6 +145,14 @@ def test_raise_for_status():
     with pytest.raises(RuntimeError):
         response.raise_for_status()
 
+    # If follow_redirects is False, we should not raise a redirect error
+    request_with_follow_redirects_false = httpx.Request(
+        "GET", "https://example.org", extensions={"follow_redirects": False}
+    )
+    response = httpx.Response(303, request=request_with_follow_redirects_false)
+    response.next_request = httpx.Request("GET", "https://other.org")
+    assert response.raise_for_status() is response
+
 
 def test_response_repr():
     response = httpx.Response(


### PR DESCRIPTION
## Summary
This PR enhances the `Response.raise_for_status()` method to detect when redirect responses (3xx status codes) automatically should not raise exceptions. When a request is made with `follow_redirects=False`, HTTPX sets `response.next_request` for redirect responses, and `raise_for_status()` now intelligently detects this and treats redirects as successful responses instead of raising `HTTPStatusError`.
This change addresses the inconsistency where developers had to manually check `response.next_request` or implement custom logic to handle redirects when `follow_redirects=False` was set on the request.

### Current Behaviour
- `raise_for_status()` always raises `HTTPStatusError` for 3xx redirect responses
- No way to control redirect handling behaviour in the method
- Developers must implement workarounds or check `response.next_request` manually
- Inconsistent with the principle of least surprise

### Expected Behaviour
- `raise_for_status()` automatically detects when redirects shouldn't raise exceptions
- When `follow_redirects=False` is set on the request, redirect responses are treated as successful
- No need for developers to implement custom redirect handling logic
- Consistent behaviour that aligns with request configuration

### Changes Made
-` httpx/_models.py`: Modified `raise_for_status()` method to check for `next_request` presence and return early for redirects when `follow_redirects=False`
- `tests/models/test_responses.py`: Added test case to verify that redirect responses don't raise exceptions when `follow_redirects=False`
- `docs/quickstart.md`: Updated documentation to explain the new redirect handling behaviour with clear examples

## Checklist
[x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
[x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
[x] I've updated the documentation accordingly.
