### PR TITLE
Upgrade Python formatter ruff

### DIFF
--- a/httpx/_exceptions.py
+++ b/httpx/_exceptions.py
@@ -331,9 +331,7 @@ class StreamClosed(StreamError):
     """
 
     def __init__(self) -> None:
-        message = (
-            "Attempted to read or stream content, but the stream has " "been closed."
-        )
+        message = "Attempted to read or stream content, but the stream has been closed."
         super().__init__(message)
 
 

--- a/httpx/_urls.py
+++ b/httpx/_urls.py
@@ -379,7 +379,7 @@ class URL:
 
         if ":" in userinfo:
             # Mask any password component.
-            userinfo = f'{userinfo.split(":")[0]}:[secure]'
+            userinfo = f"{userinfo.split(':')[0]}:[secure]"
 
         authority = "".join(
             [

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ coverage[toml]==7.6.1
 cryptography==44.0.1
 mypy==1.13.0
 pytest==8.3.4
-ruff==0.8.1
+ruff==0.12.11
 trio==0.27.0
 trio-typing==0.10.0
 trustme==1.2.0

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -489,18 +489,18 @@ def test_response_invalid_argument():
 def test_ensure_ascii_false_with_french_characters():
     data = {"greeting": "Bonjour, ça va ?"}
     response = httpx.Response(200, json=data)
-    assert (
-        "ça va" in response.text
-    ), "ensure_ascii=False should preserve French accented characters"
+    assert "ça va" in response.text, (
+        "ensure_ascii=False should preserve French accented characters"
+    )
     assert response.headers["Content-Type"] == "application/json"
 
 
 def test_separators_for_compact_json():
     data = {"clé": "valeur", "liste": [1, 2, 3]}
     response = httpx.Response(200, json=data)
-    assert (
-        response.text == '{"clé":"valeur","liste":[1,2,3]}'
-    ), "separators=(',', ':') should produce a compact representation"
+    assert response.text == '{"clé":"valeur","liste":[1,2,3]}', (
+        "separators=(',', ':') should produce a compact representation"
+    )
     assert response.headers["Content-Type"] == "application/json"
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

Unblocks #3648 which is currently failing on the command [`ruff format`](https://docs.astral.sh/ruff/formatter).
* #3648 
* https://github.com/astral-sh/ruff/releases

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
