### PR TITLE
doc: Fix typo in SSL doc

### DIFF
--- a/docs/advanced/ssl.md
+++ b/docs/advanced/ssl.md
@@ -29,7 +29,7 @@ import certifi
 import httpx
 import ssl
 
-# This SSL context is equivelent to the default `verify=True`.
+# This SSL context is equivalent to the default `verify=True`.
 ctx = ssl.create_default_context(cafile=certifi.where())
 client = httpx.Client(verify=ctx)
 ```


### PR DESCRIPTION
# Summary

Fix a typo in the SSL documentation page: https://www.python-httpx.org/advanced/ssl/
