### PR TITLE
chore: require minimum httpcore with security fix for h11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "certifi",
-    "httpcore==1.*",
+    "httpcore>=1.0.9",
     "anyio",
     "idna",
 ]


### PR DESCRIPTION
# Summary

The `httpcore` subdependency `h11` has a security fix for the [critical security issue](https://osv.dev/vulnerability/GHSA-vqfr-h8mv-ghfj)  that requires the minimum version [`1.0.9`](https://github.com/encode/httpcore/releases/tag/1.0.9).

References:
- https://osv.dev/vulnerability/GHSA-vqfr-h8mv-ghfj
- https://github.com/encode/httpcore/releases/tag/1.0.9

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
