### PR TITLE
Fixed a syntax error in the file upload example

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -191,7 +191,7 @@ You can also explicitly set the filename and content type, by using a tuple
 of items for the file value:
 
 ```pycon
->>> with open('report.xls', 'rb') report_file:
+>>> with open('report.xls', 'rb') as report_file:
 ...     files = {'upload-file': ('report.xls', report_file, 'application/vnd.ms-excel')}
 ...     r = httpx.post("https://httpbin.org/post", files=files)
 >>> print(r.text)


### PR DESCRIPTION
The code from the documentation contains a syntax error that raises an exception in Python.