### PR TITLE
sync-version: fix warning on gnu grep

### DIFF
--- a/scripts/sync-version
+++ b/scripts/sync-version
@@ -1,8 +1,8 @@
 #!/bin/sh -e
 
-SEMVER_REGEX="([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?"
-CHANGELOG_VERSION=$(grep -o -E $SEMVER_REGEX CHANGELOG.md | sed -n 2p)
-VERSION=$(grep -o -E $SEMVER_REGEX httpx/__version__.py | head -1)
+SEMVER_REGEX="([0-9]+)\.([0-9]+)\.([0-9]+)(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\\+[0-9A-Za-z-]+)?"
+CHANGELOG_VERSION=$(grep -o -E "$SEMVER_REGEX" CHANGELOG.md | sed -n 2p)
+VERSION=$(grep -o -E "$SEMVER_REGEX" httpx/__version__.py | head -1)
 echo "CHANGELOG_VERSION: $CHANGELOG_VERSION"
 echo "VERSION: $VERSION"
 if [ "$CHANGELOG_VERSION" != "$VERSION" ]; then


### PR DESCRIPTION
# Summary
Without this commit, when using gnu grep (as found on Linuxes), sync-version emits warnings:

$ scripts/sync-version
grep: warning: ? at start of expression
grep: warning: ? at start of expression
grep: warning: ? at start of expression
grep: warning: ? at start of expression
grep: warning: ? at start of expression
grep: warning: ? at start of expression
CHANGELOG_VERSION: 0.28.1
VERSION: 0.28.1

I've tested these changes both on Linux and on macOS to make sure they work