### PR TITLE
Include header name in encoding error messages

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -64,14 +64,42 @@ def _is_known_encoding(encoding: str) -> bool:
     return True
 
 
-def _normalize_header_key(key: str | bytes, encoding: str | None = None) -> bytes:
+def _normalize_header_key(
+    key: str | bytes,
+    encoding: str | None = None,
+    header_name: str | bytes | None = None,
+) -> bytes:
     """
     Coerce str/bytes into a strictly byte-wise HTTP header key.
     """
-    return key if isinstance(key, bytes) else key.encode(encoding or "ascii")
+    if isinstance(key, bytes):
+        return key
+    try:
+        return key.encode(encoding or "ascii")
+    except UnicodeEncodeError as exc:
+        if header_name:
+            name_str = (
+                header_name
+                if isinstance(header_name, str)
+                else header_name.decode("ascii", errors="replace")
+            )
+            header_info = f" '{name_str}'"
+        else:
+            header_info = ""
+        raise UnicodeEncodeError(
+            exc.encoding,
+            exc.object,
+            exc.start,
+            exc.end,
+            f"Header name{header_info} contains non-ASCII characters",
+        ) from exc
 
 
-def _normalize_header_value(value: str | bytes, encoding: str | None = None) -> bytes:
+def _normalize_header_value(
+    value: str | bytes,
+    encoding: str | None = None,
+    header_name: str | bytes | None = None,
+) -> bytes:
     """
     Coerce str/bytes into a strictly byte-wise HTTP header value.
     """
@@ -79,7 +107,25 @@ def _normalize_header_value(value: str | bytes, encoding: str | None = None) -> 
         return value
     if not isinstance(value, str):
         raise TypeError(f"Header value must be str or bytes, not {type(value)}")
-    return value.encode(encoding or "ascii")
+    try:
+        return value.encode(encoding or "ascii")
+    except UnicodeEncodeError as exc:
+        if header_name:
+            name_str = (
+                header_name
+                if isinstance(header_name, str)
+                else header_name.decode("ascii", errors="replace")
+            )
+            header_info = f" '{name_str}'"
+        else:
+            header_info = ""
+        raise UnicodeEncodeError(
+            exc.encoding,
+            exc.object,
+            exc.start,
+            exc.end,
+            f"Header{header_info} value contains non-ASCII characters",
+        ) from exc
 
 
 def _parse_content_type_charset(content_type: str) -> str | None:
@@ -152,13 +198,13 @@ class Headers(typing.MutableMapping[str, str]):
             self._list = list(headers._list)
         elif isinstance(headers, Mapping):
             for k, v in headers.items():
-                bytes_key = _normalize_header_key(k, encoding)
-                bytes_value = _normalize_header_value(v, encoding)
+                bytes_key = _normalize_header_key(k, encoding, header_name=k)
+                bytes_value = _normalize_header_value(v, encoding, header_name=k)
                 self._list.append((bytes_key, bytes_key.lower(), bytes_value))
         elif headers is not None:
             for k, v in headers:
-                bytes_key = _normalize_header_key(k, encoding)
-                bytes_value = _normalize_header_value(v, encoding)
+                bytes_key = _normalize_header_key(k, encoding, header_name=k)
+                bytes_value = _normalize_header_value(v, encoding, header_name=k)
                 self._list.append((bytes_key, bytes_key.lower(), bytes_value))
 
         self._encoding = encoding

--- a/tests/models/test_headers.py
+++ b/tests/models/test_headers.py
@@ -217,3 +217,13 @@ def test_parse_header_links(value, expected):
 def test_parse_header_links_no_link():
     all_links = httpx.Response(200).links
     assert all_links == {}
+
+
+def test_header_encoding_error_mentions_header_name():
+    with pytest.raises(UnicodeEncodeError, match="Header 'auth' value"):
+        httpx.Headers({"auth": "안녕하세요"})
+
+
+def test_header_key_encoding_error_mentions_header_name():
+    with pytest.raises(UnicodeEncodeError, match="Header name '헤더'"):
+        httpx.Headers({"헤더": "value"})


### PR DESCRIPTION
 ### Summary

  When headers contain non-ASCII characters, the error message now includes the header name to make debugging easier.

<br/>

  **Before:**
  ```python
  httpx.Headers({"Authorization": "Bearer valid", "X-Custom": "안녕"})
  # UnicodeEncodeError: 'ascii' codec can't encode characters...
  # Which header failed? 
```

  **After:**

```python
  httpx.Headers({"Authorization": "Bearer valid", "X-Custom": "안녕"})
  # UnicodeEncodeError: Header 'X-Custom' value contains non-ASCII characters
  # Clear which header is the problem 
```

  **Changes**

  - Added optional header_name parameter to _normalize_header_key and _normalize_header_value
  - Updated error messages to include header name when encoding fails
  - Added tests for both header key and value encoding errors

  related #3400