### PR TITLE
fix: resolve async stream resource leak on timeout

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -1726,8 +1726,13 @@ class AsyncClient(BaseClient):
                 "Attempted to send a sync request with an AsyncClient instance."
             )
 
-        with request_context(request=request):
-            response = await transport.handle_async_request(request)
+        try:
+            with request_context(request=request):
+                response = await transport.handle_async_request(request)
+        except BaseException:
+            if hasattr(request.stream, "aclose"):
+                await request.stream.aclose()
+            raise
 
         assert isinstance(response.stream, AsyncByteStream)
         response.request = request


### PR DESCRIPTION
Hello everyone! I got an error when running the tests and saw that there was already a issue related to this (#3686)

# Summary
Fix async stream resource leak that caused ResourceWarning in Trio, basically replacing ByteStream.__aiter__() async generator with a iterator that can be properly closed via aclose()

# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [X] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
