### PR TITLE
Keep original host on IDNA decode errors

### DIFF
--- a/httpx/_urls.py
+++ b/httpx/_urls.py
@@ -170,6 +170,7 @@ class URL:
         """
         The URL host as a string.
         Always normalized to lowercase, with IDNA hosts decoded into unicode.
+        Invalid IDNA encodings are kept in their original xn-- form.
 
         Examples:
 
@@ -182,13 +183,19 @@ class URL:
         url = httpx.URL("http://xn--fiqs8s.icom.museum")
         assert url.host == "中国.icom.museum"
 
+        url = httpx.URL("https://xn--ls8h.la/")
+        assert url.host == "xn--ls8h.la"
+
         url = httpx.URL("https://[::ffff:192.168.0.1]")
         assert url.host == "::ffff:192.168.0.1"
         """
         host: str = self._uri_reference.host
 
         if host.startswith("xn--"):
-            host = idna.decode(host)
+            try:
+                host = idna.decode(host)
+            except idna.IDNAError:
+                pass
 
         return host
 

--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -802,6 +802,12 @@ def test_url_invalid_idna_host():
     assert str(exc.value) == "Invalid IDNA hostname: '☃.com'"
 
 
+def test_url_invalid_idna_encoding_kept():
+    url = httpx.URL("https://xn--ls8h.la/")
+    assert url.host == "xn--ls8h.la"
+    assert url.raw_host == b"xn--ls8h.la"
+
+
 # Tests for IPv4 hostname support.
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Emoji domains (e.g., `https://xn--i-7iq.ws/`, `https://xn--ls8h.la/`) are not allowed by IDNA2008 but are supported by some TLDs, have valid TLS certificates, and work in browsers, curl, and Python's `requests` library. 

Previously, httpx would raise an `IDNAError` when attempting to decode these Punycode domains, preventing legitimate requests.

This PR modifies the `host` property to gracefully handle IDNA decode errors by catching `idna.IDNAError` and keeping the original `xn--` encoded form. This allows httpx to work with these real-world emoji domains.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
