### PR TITLE
Feat/mock transport duration

### DIFF
--- a/httpx/_transports/mock.py
+++ b/httpx/_transports/mock.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import typing
+from datetime import timedelta
 
 from .._models import Request, Response
 from .base import AsyncBaseTransport, BaseTransport
-from datetime import timedelta
 
 SyncHandler = typing.Callable[[Request], Response]
 AsyncHandler = typing.Callable[[Request], typing.Coroutine[None, None, Response]]
@@ -15,7 +15,7 @@ __all__ = ["MockTransport"]
 
 class MockTransport(AsyncBaseTransport, BaseTransport):
     def __init__(
-        self, handler: SyncHandler | AsyncHandler, delay: timedelta | None = None
+        self, handler: SyncHandler | AsyncHandler, delay: timedelta = timedelta(0)
     ) -> None:
         self.handler = handler
         self.delay = delay

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -497,4 +497,4 @@ def test_mocktransport_sets_elapsed_none_when_no_delay():
 
     response = client.get("https://example.com")
 
-    assert response.elapsed is None
+    assert response.elapsed == timedelta(0)


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

This PR adds native support for simulating request latency in MockTransport by introducing an optional delay parameter.
When provided, the transport sets response.elapsed according to the delay value, unless the handler explicitly defines its own elapsed time.

This resolves the inconvenience described in issue #3712, where users needed to manually patch response.elapsed inside handlers to test timeout- or latency-sensitive logic.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
