### PR TITLE
create_ssl_context: Don't skip ctx.load_cert_chain calls

### DIFF
--- a/httpx/_config.py
+++ b/httpx/_config.py
@@ -50,8 +50,9 @@ def create_ssl_context(
         )
         warnings.warn(message, DeprecationWarning)
         if os.path.isdir(verify):
-            return ssl.create_default_context(capath=verify)
-        return ssl.create_default_context(cafile=verify)
+            ctx = ssl.create_default_context(capath=verify)
+        else:
+            ctx = ssl.create_default_context(cafile=verify)
     else:
         ctx = verify
 


### PR DESCRIPTION
…s a str

<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

`create_ssl_context` returns early when `verify` is a `str`, bypassing calls to `ctx.load_cert_chain` to load the client certificates.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
