### PR TITLE
fix: set default elapsed on MockTransport responses

### DIFF
--- a/httpx/_transports/mock.py
+++ b/httpx/_transports/mock.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 import typing
 
 from .._models import Request, Response
@@ -24,6 +25,8 @@ class MockTransport(AsyncBaseTransport, BaseTransport):
         response = self.handler(request)
         if not isinstance(response, Response):  # pragma: no cover
             raise TypeError("Cannot use an async handler in a sync Client")
+        if not hasattr(response, "_elapsed"):
+            response.elapsed = datetime.timedelta(0)
         return response
 
     async def handle_async_request(
@@ -40,4 +43,6 @@ class MockTransport(AsyncBaseTransport, BaseTransport):
         if not isinstance(response, Response):
             response = await response
 
+        if not hasattr(response, "_elapsed"):
+            response.elapsed = datetime.timedelta(0)
         return response


### PR DESCRIPTION
## Summary

This PR fixes #3712 by setting a default `elapsed` value of `timedelta(0)` on responses returned from `MockTransport`.

## Problem

When creating a `Response` with pre-loaded content (e.g., `json=...`, `content=...`, `text=...`), the content is immediately read into `_content` in the Response's `__init__`. Later, when the client wraps the response stream with `BoundSyncStream`/`BoundAsyncStream` to track elapsed time, the stream is never actually consumed because `_content` is already set.

This causes a `RuntimeError` when accessing `response.elapsed`:

```python
def handler(request):
    return httpx.Response(200, json={"message": "Hello"})

transport = httpx.MockTransport(handler)
with httpx.Client(transport=transport) as client:
    response = client.get("https://example.com/")
    print(response.elapsed)  # RuntimeError: .elapsed accessed before response finished
```

## Solution

Set `elapsed = timedelta(0)` as a default in `MockTransport.handle_request()` and `handle_async_request()` if the response doesn't already have `_elapsed` set.

This:
1. Allows users to access `response.elapsed` without errors
2. Preserves user-set elapsed values if they manually set it in their handler
3. Doesn't require boilerplate code in every handler (as suggested in the issue)

## Changes

- Added `import datetime` to `httpx/_transports/mock.py`
- Added default elapsed setting in `handle_request()` (sync)
- Added default elapsed setting in `handle_async_request()` (async)

## Testing

Verified that:
- Existing MockTransport tests pass
- `response.elapsed` returns `timedelta(0)` for pre-loaded responses
- User-set elapsed values are preserved