### PR TITLE
fix: resolve test hang with websockets 14+

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -235,10 +235,9 @@ class TestServer(Server):
     async def serve(self, sockets=None):
         self.restart_requested = asyncio.Event()
 
-        loop = asyncio.get_event_loop()
         tasks = {
-            loop.create_task(super().serve(sockets=sockets)),
-            loop.create_task(self.watch_restarts()),
+            asyncio.create_task(super().serve(sockets=sockets)),
+            asyncio.create_task(self.watch_restarts()),
         }
         await asyncio.wait(tasks)
 
@@ -269,7 +268,15 @@ class TestServer(Server):
 
 
 def serve_in_thread(server: TestServer) -> typing.Iterator[TestServer]:
-    thread = threading.Thread(target=server.run)
+    def run_server():
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_until_complete(server.serve())
+        finally:
+            loop.close()
+
+    thread = threading.Thread(target=run_server)
     thread.start()
     try:
         while not server.started:
@@ -282,6 +289,6 @@ def serve_in_thread(server: TestServer) -> typing.Iterator[TestServer]:
 
 @pytest.fixture(scope="session")
 def server() -> typing.Iterator[TestServer]:
-    config = Config(app=app, lifespan="off", loop="asyncio")
+    config = Config(app=app, lifespan="off")
     server = TestServer(config=config)
     yield from serve_in_thread(server)


### PR DESCRIPTION
## Summary

Fixes #3708

The test suite hangs indefinitely when upgrading `websockets` from 13.x to 14.x or 15.x. This is because [websockets 14.0 switched to a new asyncio implementation](https://websockets.readthedocs.io/en/stable/project/changelog.html#id12) by default, which has different behavior around event loop handling.

## Root Cause

The issue stems from how the `TestServer` manages event loops when running in a background thread:

1. **In `TestServer.serve()`**: The deprecated `asyncio.get_event_loop()` + `loop.create_task()` pattern doesn't work correctly with websockets 14+'s new asyncio handling
2. **In `serve_in_thread()`**: The `server.run()` method relies on `asyncio.run()` which doesn't play well with the threaded setup when websockets is involved

## Changes

1. **`TestServer.serve()`**: Replace deprecated `asyncio.get_event_loop()` pattern with `asyncio.create_task()` which is the modern way to create tasks when already inside an async context.

2. **`serve_in_thread()`**: Instead of relying on `server.run()` which uses `asyncio.run()`, explicitly create a new event loop in the background thread with `asyncio.new_event_loop()` and `asyncio.set_event_loop()`.

3. **`server` fixture**: Remove `loop="asyncio"` from `Config()` since we now manage the event loop manually, avoiding conflicts with websockets' asyncio implementation.

## Testing

Tested locally with websockets 15.0.1 - all 43 integration tests pass without hanging.