### PR TITLE
Use zstandard implementation from stdlib (PEP-784)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ As well as these optional installs:
 * `rich` - Rich terminal support. *(Optional, with `httpx[cli]`)*
 * `click` - Command line client support. *(Optional, with `httpx[cli]`)*
 * `brotli` or `brotlicffi` - Decoding for "brotli" compressed responses. *(Optional, with `httpx[brotli]`)*
-* `zstandard` - Decoding for "zstd" compressed responses. *(Optional, with `httpx[zstd]`)*
+* `backports.zstd` - Decoding for "zstd" compressed responses on Python before 3.14. *(Optional, with `httpx[zstd]`)*
 
 A huge amount of credit is due to `requests` for the API layout that
 much of this work follows, as well as to `urllib3` for plenty of design

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -100,8 +100,8 @@ b'<!doctype html>\n<html>\n<head>\n<title>Example Domain</title>...'
 
 Any `gzip` and `deflate` HTTP response encodings will automatically
 be decoded for you. If `brotlipy` is installed, then the `brotli` response
-encoding will be supported. If `zstandard` is installed, then `zstd`
-response encodings will also be supported.
+encoding will be supported. If the Python version used is 3.14 or higher or
+if `backports.zstd` is installed, then `zstd` response encodings will also be supported.
 
 For example, to create an image from binary data returned by a request, you can use the following code:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ socks = [
     "socksio==1.*",
 ]
 zstd = [
-  "zstandard>=0.18.0",
+  "backports.zstd>=1.0.0 ; python_version < '3.14'",
 ]
 
 [project.scripts]

--- a/tests/test_decoders.py
+++ b/tests/test_decoders.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
 import io
+import sys
 import typing
 import zlib
 
 import chardet
 import pytest
-import zstandard as zstd
 
 import httpx
+
+if sys.version_info >= (3, 14):
+    from compression import zstd  # pragma: no cover
+else:
+    from backports import zstd  # pragma: no cover
 
 
 def test_deflate():


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

## Context

Thanks to [PEP-784](https://peps.python.org/pep-0784/), Zstandard is included in Python starting from version 3.14 with the [`compression.zstd`](https://docs.python.org/3.14/library/compression.zstd.html) module.

So for Python 3.14+, we don't need an external lib. For older version of Python, I'm using [`backports.zstd`](https://github.com/Rogdham/backports.zstd) which exposes the same API as stdlib.

This also means that users of Python 3.14+ will benefit from Zstandard support even if they install `httpx` instead of `httpx[zstd]`.

A similar change has been adopted in various other libraries already, such as `urllib3` from version 2.6.0.

_Full disclosure: I'm the author and maintainer of `backports.zstd`, and the maintainer of `pyzstd` (which code was used as a base for the integration into Python). I also helped with PEP-784 and its integration into CPython._

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
