### PR TITLE
feat: support "auth-int" quality-of-protection when using DigestAuth

### DIFF
--- a/docs/advanced/authentication.md
+++ b/docs/advanced/authentication.md
@@ -40,6 +40,18 @@ HTTP digest authentication is a challenge-response authentication scheme. Unlike
 [<Response [401 UNAUTHORIZED]>]
 ```
 
+HTTPX also supports digest authentication using `auth-int` quality-of-protection, which provides message integrity protection. When `qop="auth-int"` is used, the authentication response includes a hash of the request body, protecting against tampering with the message content during transmission. This provides additional security over `qop="auth"` by ensuring that both the authentication credentials and the message body integrity are verified.
+
+```pycon
+>>> auth = httpx.DigestAuth(username="olivia", password="secret")
+>>> client = httpx.Client(auth=auth)
+>>> response = client.get("https://httpbin.org/digest-auth/auth-int/olivia/secret")
+>>> response
+<Response [200 OK]>
+>>> response.history
+[<Response [401 UNAUTHORIZED]>]
+```
+
 ## NetRC authentication
 
 HTTPX can be configured to use [a `.netrc` config file](https://everything.curl.dev/usingcurl/netrc) for authentication.

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -238,7 +238,8 @@ def test_digest_auth_rfc_7616_md5(monkeypatch):
         in request.headers["Authorization"]
     )
     assert (
-        'response="8ca523f5e9506fed4657c9700eebdbec"'
+        # 'response="8ca523f5e9506fed4657c9700eebdbec"'
+        'response="7d2b5599cc59f94b525f726e44474803"'
         in request.headers["Authorization"]
     )
 
@@ -292,13 +293,14 @@ def test_digest_auth_rfc_7616_sha_256(monkeypatch):
         'cnonce="f2/wE4q74E6zIJEtWaHKaf5wv/H5QzzpXusqGemxURZJ"'
         in request.headers["Authorization"]
     )
-    assert "qop=auth" in request.headers["Authorization"]
+    assert "qop=auth-int" in request.headers["Authorization"]
     assert (
         'opaque="FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS"'
         in request.headers["Authorization"]
     )
     assert (
-        'response="753927fa0e85d155564e2e272a28d1802ca10daf4496794697cf8db5856cb6c1"'
+        # 'response="753927fa0e85d155564e2e272a28d1802ca10daf4496794697cf8db5856cb6c1"'
+        'response="a2274700215378a04e1a528e3706c7aab17a3fe7a988900a6c439c9509209acf"'
         in request.headers["Authorization"]
     )
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -208,7 +208,7 @@ def test_digest_auth_rfc_7616_md5(monkeypatch):
     headers = {
         "WWW-Authenticate": (
             'Digest realm="http-auth@example.org", '
-            'qop="auth, auth-int", '
+            "qop=auth, "
             "algorithm=MD5, "
             'nonce="7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v", '
             'opaque="FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS"'
@@ -232,14 +232,13 @@ def test_digest_auth_rfc_7616_md5(monkeypatch):
         'cnonce="f2/wE4q74E6zIJEtWaHKaf5wv/H5QzzpXusqGemxURZJ"'
         in request.headers["Authorization"]
     )
-    assert "qop=auth" in request.headers["Authorization"]
+    assert "qop=auth," in request.headers["Authorization"]
     assert (
         'opaque="FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS"'
         in request.headers["Authorization"]
     )
     assert (
-        # 'response="8ca523f5e9506fed4657c9700eebdbec"'
-        'response="7d2b5599cc59f94b525f726e44474803"'
+        'response="8ca523f5e9506fed4657c9700eebdbec"'
         in request.headers["Authorization"]
     )
 
@@ -269,7 +268,7 @@ def test_digest_auth_rfc_7616_sha_256(monkeypatch):
     headers = {
         "WWW-Authenticate": (
             'Digest realm="http-auth@example.org", '
-            'qop="auth, auth-int", '
+            "qop=auth, "
             "algorithm=SHA-256, "
             'nonce="7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v", '
             'opaque="FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS"'
@@ -293,14 +292,129 @@ def test_digest_auth_rfc_7616_sha_256(monkeypatch):
         'cnonce="f2/wE4q74E6zIJEtWaHKaf5wv/H5QzzpXusqGemxURZJ"'
         in request.headers["Authorization"]
     )
-    assert "qop=auth-int" in request.headers["Authorization"]
+    assert "qop=auth," in request.headers["Authorization"]
     assert (
         'opaque="FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS"'
         in request.headers["Authorization"]
     )
     assert (
-        # 'response="753927fa0e85d155564e2e272a28d1802ca10daf4496794697cf8db5856cb6c1"'
-        'response="a2274700215378a04e1a528e3706c7aab17a3fe7a988900a6c439c9509209acf"'
+        'response="753927fa0e85d155564e2e272a28d1802ca10daf4496794697cf8db5856cb6c1"'
+        in request.headers["Authorization"]
+    )
+
+    # No other requests are made.
+    response = httpx.Response(content=b"Hello, world!", status_code=200)
+    with pytest.raises(StopIteration):
+        flow.send(response)
+
+
+def test_digest_auth_int_rfc_7616_md5(monkeypatch):
+    def mock_get_client_nonce(nonce_count: int, nonce: bytes) -> bytes:
+        return "f2/wE4q74E6zIJEtWaHKaf5wv/H5QzzpXusqGemxURZJ".encode()
+
+    auth = httpx.DigestAuth(username="Mufasa", password="Circle of Life")
+    monkeypatch.setattr(auth, "_get_client_nonce", mock_get_client_nonce)
+
+    request = httpx.Request("GET", "https://www.example.com/dir/index.html")
+
+    # The initial request should not include an auth header.
+    flow = auth.sync_auth_flow(request)
+    request = next(flow)
+    assert "Authorization" not in request.headers
+
+    # If a 401 response is returned, then a digest auth request is made.
+    headers = {
+        "WWW-Authenticate": (
+            'Digest realm="http-auth@example.org", '
+            "qop=auth-int, "
+            "algorithm=MD5, "
+            'nonce="7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v", '
+            'opaque="FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS"'
+        )
+    }
+    response = httpx.Response(
+        content=b"Auth required", status_code=401, headers=headers, request=request
+    )
+    request = flow.send(response)
+    assert request.headers["Authorization"].startswith("Digest")
+    assert 'username="Mufasa"' in request.headers["Authorization"]
+    assert 'realm="http-auth@example.org"' in request.headers["Authorization"]
+    assert 'uri="/dir/index.html"' in request.headers["Authorization"]
+    assert "algorithm=MD5" in request.headers["Authorization"]
+    assert (
+        'nonce="7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v"'
+        in request.headers["Authorization"]
+    )
+    assert "nc=00000001" in request.headers["Authorization"]
+    assert (
+        'cnonce="f2/wE4q74E6zIJEtWaHKaf5wv/H5QzzpXusqGemxURZJ"'
+        in request.headers["Authorization"]
+    )
+    assert "qop=auth-int," in request.headers["Authorization"]
+    assert (
+        'opaque="FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS"'
+        in request.headers["Authorization"]
+    )
+    assert (
+        'response="8804a53d3640a40a4f73cea12c5ba451"'
+        in request.headers["Authorization"]
+    )
+
+    # No other requests are made.
+    response = httpx.Response(content=b"Hello, world!", status_code=200)
+    with pytest.raises(StopIteration):
+        flow.send(response)
+
+
+def test_digest_auth_int_rfc7616_sha256(monkeypatch):
+    def mock_get_client_nonce(nonce_count: int, nonce: bytes) -> bytes:
+        return "f2/wE4q74E6zIJEtWaHKaf5wv/H5QzzpXusqGemxURZJ".encode()
+
+    auth = httpx.DigestAuth(username="Mufasa", password="Circle of Life")
+    monkeypatch.setattr(auth, "_get_client_nonce", mock_get_client_nonce)
+
+    request = httpx.Request("GET", "https://www.example.com/dir/index.html")
+
+    # The initial request should not include an auth header.
+    flow = auth.sync_auth_flow(request)
+    request = next(flow)
+    assert "Authorization" not in request.headers
+
+    # If a 401 response is returned, then a digest auth request is made.
+    headers = {
+        "WWW-Authenticate": (
+            'Digest realm="http-auth@example.org", '
+            "qop=auth-int, "
+            "algorithm=SHA-256, "
+            'nonce="7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v", '
+            'opaque="FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS"'
+        )
+    }
+    response = httpx.Response(
+        content=b"Auth required", status_code=401, headers=headers, request=request
+    )
+    request = flow.send(response)
+    assert request.headers["Authorization"].startswith("Digest")
+    assert 'username="Mufasa"' in request.headers["Authorization"]
+    assert 'realm="http-auth@example.org"' in request.headers["Authorization"]
+    assert 'uri="/dir/index.html"' in request.headers["Authorization"]
+    assert "algorithm=SHA-256" in request.headers["Authorization"]
+    assert (
+        'nonce="7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v"'
+        in request.headers["Authorization"]
+    )
+    assert "nc=00000001" in request.headers["Authorization"]
+    assert (
+        'cnonce="f2/wE4q74E6zIJEtWaHKaf5wv/H5QzzpXusqGemxURZJ"'
+        in request.headers["Authorization"]
+    )
+    assert "qop=auth-int," in request.headers["Authorization"]
+    assert (
+        'opaque="FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS"'
+        in request.headers["Authorization"]
+    )
+    assert (
+        'response="8bdf6f15638e260831e905028de5450562816d093c9bfc5c13d3a46adcdde940"'
         in request.headers["Authorization"]
     )
 


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Adding support for "auth-int" (message integrity authentication) quality-of-protection implementation, as specified in [RFC-7616.](https://datatracker.ietf.org/doc/html/rfc7616). Additionally, updates unit tests to reflect support for the "auth-int" QoP.

## Note on "example" scenario from RFC-7616

I had to change the expected response hashes from the official ones stated in the [RFC-7616 Section 3.9.1](https://datatracker.ietf.org/doc/html/rfc7616#section-3.9.1) example since they don't provide an example where the client chooses to use "auth-int" QoP.

That being said, I was able to check the correctness of my implementation against `httpbin` using the `/digest-auth/auth-int/Mufasa/CircleofLife/[MD5|SHA-256]` endpoints to verify that a proper 200 status code is returned, meaning the httpbin server implementation of "auth-int" authentication agrees with the implementation added to this feature branch. Httpbin appears to support "http" requests to this endpoint, but doesn't properly support "https" requests (unexpected EoF encountered).

<details><summary>Integration test with HTTPBin</summary>
<p>

```py
from httpx import Client, DigestAuth, Request

if __name__ == "__main__":
    auth = DigestAuth(username="Mufasa", password="CircleofLife")
    # Note that I'm using locally-hosted HTTPBin over Docker since the official website is down today, Dec 14 2025.
    request = Request(
        "GET",
        # "http://httpbin.org/digest-auth/auth-int/Mufasa/CircleofLife/MD5",
        # "http://httpbin.org/digest-auth/auth-int/Mufasa/CircleofLife/SHA-256",
        # "http://0.0.0.0:80/digest-auth/auth-int/Mufasa/CircleofLife/MD5",
        "http://0.0.0.0:80/digest-auth/auth-int/Mufasa/CircleofLife/SHA-256",
    )

    with Client(auth=auth) as client:
        response = client.send(request)
        print(response.headers.raw)
        print(response.content)
        print(response.status_code) # We get a HTTP code 200 "OK"

```

</p>
</details> 

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.

## GH Actions test failures

GH Actions seem to be failing non-deterministically for the `test_proxies.py` module (no changes from this PR), particularly due to timeouts when talking to `example.com`. I encourage a project maintainer to try re-running the checks for this PR during their review to demonstrate the non-deterministic behavior (take note of which python versions fail each time, if any).

Is there a default timeout being used for the tests which we can make more permissive?