### PR TITLE
Use weakref for bound stream _response.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [UNRELEASED]
 
+### Fixed
+
+* Avoid creating references cycles from `BoundSyncStream` and `BoundAsyncStream` to the response object.  This allows memory to be freed by reference counting, which happens quickly, rather than waiting for the cyclic GC to run.
+
 ### Removed
 
 * Drop support for Python 3.8

--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -183,7 +183,6 @@ class BoundAsyncStream(AsyncByteStream):
         elapsed = time.perf_counter() - self._start
         response = self._response()
         if response is not None:
-            assert 0
             response.elapsed = datetime.timedelta(seconds=elapsed)
         await self._stream.aclose()
 


### PR DESCRIPTION
# Summary

This avoids creating reference cycles that can result in significant extra memory usage.  The cyclic GC should clean up the cycles but avoiding them is better. 

The Python 3.14.2 release makes the cyclic GC less aggressive about freeing reference cycles and so the cycles created from the `_response` attribute can result is significant memory use (80 MB vs 420 MB).  With this change, my example script goes to using 36 MB.  See this [CPython bug](https://github.com/python/cpython/issues/142516#issuecomment-3672186460).


# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.

This change is pretty small so I didn't add a test case for it.  The `_response` attribute doesn't appear to be used from outside the `Bound*` classes.  Should be no documentation update needed.