### PR TITLE
perf: remove redundant .lower() calls in Headers

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -260,7 +260,7 @@ class Headers(typing.MutableMapping[str, str]):
         values = [
             item_value.decode(self.encoding)
             for _, item_key, item_value in self._list
-            if item_key.lower() == get_header_key
+            if item_key == get_header_key
         ]
 
         if not split_commas:
@@ -334,7 +334,7 @@ class Headers(typing.MutableMapping[str, str]):
         pop_indexes = [
             idx
             for idx, (_, item_key, _) in enumerate(self._list)
-            if item_key.lower() == del_key
+            if item_key == del_key
         ]
 
         if not pop_indexes:


### PR DESCRIPTION
\`Headers._list\` stores tuples as \`(raw_key, lowercase_key, value)\`.

In \`get_list()\` and \`__delitem__()\`, calling \`.lower()\` on \`item_key\` is redundant since it's already lowercase.

```python
# Before
if item_key.lower() == get_header_key

# After  
if item_key == get_header_key
```

## Benchmark

```python
# 10 headers, 100k iterations
_list = [(key, key.lower(), b'value') for key in headers]
get_header_key = b'x-header-5'

# Original
[v for _, k, v in _list if k.lower() == get_header_key]  # 0.0647s

# Fixed
[v for _, k, v in _list if k == get_header_key]          # 0.0437s
```

**Result: 32.5% faster (1.48x speedup)**