### PR TITLE
Add python-proxy-headers to third_party_packages.md

### DIFF
--- a/docs/third_party_packages.md
+++ b/docs/third_party_packages.md
@@ -64,7 +64,7 @@ Provides a [pytest](https://docs.pytest.org/en/latest/) fixture to mock HTTPX wi
 
 [GitHub](https://github.com/proxymesh/python-proxy-headers)
 
-Provides `urllib3_proxy_manager.ProxyHeaderManager` that extends `urllib3.ProxyManager` with support for proxy response headers.
+Provides `HTTPProxyTransport` and `AsyncHTTPProxyTransport` to be able to access proxy response headers.
 
 ### RESPX
 

--- a/docs/third_party_packages.md
+++ b/docs/third_party_packages.md
@@ -60,6 +60,12 @@ WebSocket support for HTTPX.
 
 Provides a [pytest](https://docs.pytest.org/en/latest/) fixture to mock HTTPX within test cases.
 
+### python-proxy-headers
+
+[GitHub](https://github.com/proxymesh/python-proxy-headers)
+
+Provides `urllib3_proxy_manager.ProxyHeaderManager` that extends `urllib3.ProxyManager` with support for proxy response headers.
+
 ### RESPX
 
 [GitHub](https://github.com/lundberg/respx) - [Documentation](https://lundberg.github.io/respx/)


### PR DESCRIPTION
For `HTTPProxyTransport` & `AsyncHTTPProxyTransport`

<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Add `python-proxy-headers` extension to `third_party_packages.md`

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've updated the documentation accordingly.
