### PR TITLE
Improve SSL error message with helpful hints (#3713)

### DIFF
--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -115,6 +115,8 @@ def map_httpcore_exceptions() -> typing.Iterator[None]:
             raise
 
         message = str(exc)
+        if "WRONG_VERSION_NUMBER" in message or "RECORD_LAYER_FAILURE" in message:
+            message += " (Hint: HTTPS to HTTP server, or stale connection pool)"
         raise mapped_exc(message) from exc
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -61,3 +61,26 @@ def test_request_attribute() -> None:
     request = httpx.Request("GET", "https://www.example.com")
     exc = httpx.ReadTimeout("Read operation timed out", request=request)
     assert exc.request == request
+
+
+def test_ssl_error_message_enhancement() -> None:
+    """
+    SSL handshake failures should include helpful hints about possible causes.
+    Regression test for: https://github.com/encode/httpx/issues/3713
+    """
+    from httpx._transports.default import map_httpcore_exceptions
+
+    ssl_error_messages = [
+        "[SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:1000)",
+        "[SSL: RECORD_LAYER_FAILURE] record layer failure (_ssl.c:1081)",
+    ]
+
+    for original_message in ssl_error_messages:
+        with pytest.raises(httpx.ConnectError) as exc_info:
+            with map_httpcore_exceptions():
+                raise httpcore.ConnectError(original_message)
+
+        enhanced_message = str(exc_info.value)
+        assert original_message in enhanced_message
+        assert "Hint:" in enhanced_message
+        assert "stale connection pool" in enhanced_message


### PR DESCRIPTION
# Improve SSL error message with helpful hints

Relates to #3713

## Summary

When encountering `[SSL: WRONG_VERSION_NUMBER]` or `[SSL: RECORD_LAYER_FAILURE]` errors, the error message now includes a helpful hint about possible causes.

## Changes

**`httpx/_transports/default.py`:**
Enhanced `map_httpcore_exceptions` to detect SSL handshake failures and append guidance.

**Before:**
```
ConnectError: [SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:1000)
```

**After:**
```
ConnectError: [SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:1000) (Hint: HTTPS to HTTP server, or stale connection pool)
```

The commited hint is a small message, but we could add a more detailed message, such as:

```
               " (Possible causes: 1) Connecting via HTTPS to an HTTP server, "
               "2) A pooled connection was closed by the server - "
               "try setting `limits=httpx.Limits(keepalive_expiry=2)` or retrying)"
```

## Context

Users experiencing intermittent SSL errors in long-running containers (like the ECS scenario in #3713) face cryptic OpenSSL messages. The root cause is typically stale connections being reused after the server silently closed them. This hint points users in the right direction.

## Tests

Added `test_ssl_error_message_enhancement` in `tests/test_exceptions.py`.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
