### PR TITLE
Implement support for specifying the httpcore Network Backend when creating default transports

### DIFF
--- a/docs/advanced/transports.md
+++ b/docs/advanced/transports.md
@@ -35,6 +35,18 @@ connecting via a Unix Domain Socket that is only available via this low-level AP
 {"ID": "...", "Containers": 4, "Images": 74, ...}
 ```
 
+Another advanced configuration is supplying a custom httpcore [Network Backend](https://www.encode.io/httpcore/network-backends/).
+
+```pycon
+>>> import httpx
+>>> import myk8s
+>>> # This custom network backend enables remote access to ports inside a Kubernetes Cluster using pod port forwarding.
+>>> backend = myk8s.NetworkBackend('cluster.local')
+>>> transport = httpx.HTTPTransport(network_backend=backend)
+>>> client = httpx.Client(transport=transport)
+>>> response = client.get("http://argocd-server.argocd.svc.cluster.local")
+```
+
 ## WSGI Transport
 
 You can configure an `httpx` client to call directly into a Python web application using the WSGI protocol.

--- a/docs/advanced/transports.md
+++ b/docs/advanced/transports.md
@@ -38,13 +38,14 @@ connecting via a Unix Domain Socket that is only available via this low-level AP
 Another advanced configuration is supplying a custom httpcore [Network Backend](https://www.encode.io/httpcore/network-backends/).
 
 ```pycon
+>>> import httpcore
 >>> import httpx
->>> import myk8s
->>> # This custom network backend enables remote access to ports inside a Kubernetes Cluster using pod port forwarding.
->>> backend = myk8s.NetworkBackend('cluster.local')
+>>> backend = httpcore.MockBackend([b"HTTP/1.1 200 OK\r\n\r\nHello, World!"])
 >>> transport = httpx.HTTPTransport(network_backend=backend)
 >>> client = httpx.Client(transport=transport)
->>> response = client.get("http://argocd-server.argocd.svc.cluster.local")
+>>> response = client.get("http://network-backend")
+>>> reposne.text
+'Hello, World!'
 ```
 
 ## WSGI Transport

--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -6,6 +6,7 @@ The following additional keyword arguments are currently supported by httpcore..
 * uds: str
 * local_address: str
 * retries: int
+* network_backend: httpcore.NetworkBackend
 
 Example usages...
 
@@ -22,6 +23,13 @@ client = httpx.Client(transport=transport)
 # Using advanced httpcore configuration, with unix domain sockets.
 transport = httpx.HTTPTransport(uds="socket.uds")
 client = httpx.Client(transport=transport)
+
+# Using advanced httpcore configuration, with custom network backend.
+import myk8s
+backend = myk8s.NetworkBackend('cluster.local')
+transport = httpx.HTTPTransport(network_backend=backend)
+client = httpx.Client(transport=transport)
+response = client.get("http://argocd-server.argocd.svc.cluster.local")
 """
 
 from __future__ import annotations
@@ -32,6 +40,8 @@ from types import TracebackType
 
 if typing.TYPE_CHECKING:
     import ssl  # pragma: no cover
+
+    import httpcore  # pragma: no cover
 
     import httpx  # pragma: no cover
 
@@ -146,6 +156,7 @@ class HTTPTransport(BaseTransport):
         local_address: str | None = None,
         retries: int = 0,
         socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
+        network_backend: httpcore.NetworkBackend | None = None,
     ) -> None:
         import httpcore
 
@@ -164,6 +175,7 @@ class HTTPTransport(BaseTransport):
                 local_address=local_address,
                 retries=retries,
                 socket_options=socket_options,
+                network_backend=network_backend,
             )
         elif proxy.url.scheme in ("http", "https"):
             self._pool = httpcore.HTTPProxy(
@@ -183,6 +195,7 @@ class HTTPTransport(BaseTransport):
                 http1=http1,
                 http2=http2,
                 socket_options=socket_options,
+                network_backend=network_backend,
             )
         elif proxy.url.scheme in ("socks5", "socks5h"):
             try:
@@ -207,6 +220,7 @@ class HTTPTransport(BaseTransport):
                 keepalive_expiry=limits.keepalive_expiry,
                 http1=http1,
                 http2=http2,
+                network_backend=network_backend,
             )
         else:  # pragma: no cover
             raise ValueError(
@@ -290,6 +304,7 @@ class AsyncHTTPTransport(AsyncBaseTransport):
         local_address: str | None = None,
         retries: int = 0,
         socket_options: typing.Iterable[SOCKET_OPTION] | None = None,
+        network_backend: httpcore.AsyncNetworkBackend | None = None,
     ) -> None:
         import httpcore
 
@@ -308,6 +323,7 @@ class AsyncHTTPTransport(AsyncBaseTransport):
                 local_address=local_address,
                 retries=retries,
                 socket_options=socket_options,
+                network_backend=network_backend,
             )
         elif proxy.url.scheme in ("http", "https"):
             self._pool = httpcore.AsyncHTTPProxy(
@@ -327,6 +343,7 @@ class AsyncHTTPTransport(AsyncBaseTransport):
                 http1=http1,
                 http2=http2,
                 socket_options=socket_options,
+                network_backend=network_backend,
             )
         elif proxy.url.scheme in ("socks5", "socks5h"):
             try:
@@ -351,6 +368,7 @@ class AsyncHTTPTransport(AsyncBaseTransport):
                 keepalive_expiry=limits.keepalive_expiry,
                 http1=http1,
                 http2=http2,
+                network_backend=network_backend,
             )
         else:  # pragma: no cover
             raise ValueError(

--- a/httpx/_transports/default.py
+++ b/httpx/_transports/default.py
@@ -25,11 +25,12 @@ transport = httpx.HTTPTransport(uds="socket.uds")
 client = httpx.Client(transport=transport)
 
 # Using advanced httpcore configuration, with custom network backend.
-import myk8s
-backend = myk8s.NetworkBackend('cluster.local')
+import httpcore
+backend = backend = httpcore.MockBackend([b"HTTP/1.1 200 OK\r\n\r\nHello, World!"])
 transport = httpx.HTTPTransport(network_backend=backend)
 client = httpx.Client(transport=transport)
-response = client.get("http://argocd-server.argocd.svc.cluster.local")
+response = client.get("http://network-backend")
+content = response.text
 """
 
 from __future__ import annotations

--- a/tests/client/test_network_backend.py
+++ b/tests/client/test_network_backend.py
@@ -1,0 +1,97 @@
+import typing
+
+import httpcore
+import pytest
+
+import httpx
+
+
+def test_network_backend():
+    class Backend(httpcore.NetworkBackend):
+        def connect_tcp(
+            self,
+            host: str,
+            port: int,
+            timeout: typing.Optional[float] = None,
+            local_address: typing.Optional[str] = None,
+            socket_options: typing.Optional[
+                typing.Iterable[httpcore.SOCKET_OPTION]
+            ] = None,
+        ) -> httpcore.NetworkStream:
+            return Stream()
+
+    class Stream(httpcore.NetworkStream):
+        body = b"\r\n".join(
+            [
+                b"HTTP/1.1 200 OK",
+                b"",
+                b"From Backend!",
+            ]
+        )
+
+        def read(self, max_bytes: int, timeout: typing.Optional[float] = None) -> bytes:
+            body = self.body
+            if body:
+                self.body = b""
+            return body
+
+        def write(self, buffer: bytes, timeout: typing.Optional[float] = None) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+    backend = Backend()
+    transport = httpx.HTTPTransport(network_backend=backend)
+    with httpx.Client(transport=transport) as client:
+        response = client.get("http://www.example.org")
+    assert response.status_code == 200
+    assert response.text == "From Backend!"
+
+
+@pytest.mark.anyio
+async def test_async_network_backend():
+    class AsyncBackend(httpcore.AsyncNetworkBackend):
+        async def connect_tcp(
+            self,
+            host: str,
+            port: int,
+            timeout: typing.Optional[float] = None,
+            local_address: typing.Optional[str] = None,
+            socket_options: typing.Optional[
+                typing.Iterable[httpcore.SOCKET_OPTION]
+            ] = None,
+        ) -> httpcore.AsyncNetworkStream:
+            return AsyncStream()
+
+    class AsyncStream(httpcore.AsyncNetworkStream):
+        body = b"\r\n".join(
+            [
+                b"HTTP/1.1 200 OK",
+                b"",
+                b"From Async Backend!",
+            ]
+        )
+
+        async def read(
+            self, max_bytes: int, timeout: typing.Optional[float] = None
+        ) -> bytes:
+            body = self.body
+            if body:
+                self.body = b""
+            return body
+
+        async def write(
+            self, buffer: bytes, timeout: typing.Optional[float] = None
+        ) -> None:
+            pass
+
+        async def aclose(self) -> None:
+            pass
+
+    backend = AsyncBackend()
+    transport = httpx.AsyncHTTPTransport(network_backend=backend)
+    async with httpx.AsyncClient(transport=transport) as client:
+        response = await client.get("http://www.example.org")
+    assert response.status_code == 200
+    assert response.text == "From Async Backend!"


### PR DESCRIPTION
# Summary

This enables specifying the httpcore Network Backend when creating the default transports as discussed here: https://github.com/encode/httpx/discussions/3180

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.