### PR TITLE
Add module-level docstring to public HTTPX API

### DIFF
--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -1,3 +1,10 @@
+"""
+HTTPX is a fully featured HTTP client for Python.
+
+This module exposes the public HTTPX API, including the Client and AsyncClient
+classes, request functions, transports, exceptions, and related utilities.
+"""
+
 from .__version__ import __description__, __title__, __version__
 from ._api import *
 from ._auth import *


### PR DESCRIPTION
This PR adds a module-level docstring to `httpx/__init__.py`.

The goal is to improve IDE autocompletion and inline documentation when exploring
the public HTTPX API. No functional behavior is changed.

# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
