### PR TITLE
IteratorByteStream: split large iterator chunks into 64 KB pieces

### DIFF
--- a/httpx/_content.py
+++ b/httpx/_content.py
@@ -59,10 +59,14 @@ class IteratorByteStream(SyncByteStream):
                 yield chunk
                 chunk = self._stream.read(self.CHUNK_SIZE)
         else:
-            # Otherwise iterate.
+            # Otherwise iterate, splitting large chunks.
             for part in self._stream:
-                yield part
-
+                # Split large chunks into CHUNK_SIZE pieces
+                offset = 0
+                while offset < len(part):
+                    chunk_size = min(self.CHUNK_SIZE, len(part) - offset)
+                    yield part[offset : offset + chunk_size]
+                    offset += chunk_size
 
 class AsyncIteratorByteStream(AsyncByteStream):
     CHUNK_SIZE = 65_536

--- a/httpx/_content.py
+++ b/httpx/_content.py
@@ -68,6 +68,7 @@ class IteratorByteStream(SyncByteStream):
                     yield part[offset : offset + chunk_size]
                     offset += chunk_size
 
+
 class AsyncIteratorByteStream(AsyncByteStream):
     CHUNK_SIZE = 65_536
 

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -516,3 +516,28 @@ def test_allow_nan_false():
         ValueError, match="Out of range float values are not JSON compliant"
     ):
         httpx.Response(200, json=data_with_inf)
+
+
+@pytest.mark.anyio
+async def test_iterator_content_splits_large_chunks():
+    # Generator yielding a single large chunk (100 KB)
+    large_chunk = b"a" * 102_400  # 100 KB
+
+    def gen() -> typing.Iterator[bytes]:
+        yield large_chunk
+
+    # Pass generator to Request (internally uses IteratorByteStream)
+    request = httpx.Request(method, url, content=gen())
+
+    # Cast to Iterable[bytes] to make mypy happy
+    sync_stream: typing.Iterable[bytes] = request.stream  # type: ignore
+
+    # Collect chunks
+    chunks = list(sync_stream)
+
+    # Each chunk must be <= 64 KB
+    for chunk in chunks:
+        assert len(chunk) <= 64 * 1024
+
+    # Total content matches original
+    assert b"".join(chunks) == large_chunk


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Split large iterator chunks in `IteratorByteStream` into 64KB pieces to prevent memory spikes when sending large content streams.  
This ensures that very large generator chunks are safely split into manageable sizes internally without changing the public API.  
A test was added in `tests/test_content.py` to verify that large chunks are split correctly.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.(No Public docs changes were needed.)

Closes #3660