### PR TITLE
Fix MockTransport not setting elapsed property

### DIFF
--- a/httpx/_transports/mock.py
+++ b/httpx/_transports/mock.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 import typing
 
 from .._models import Request, Response
@@ -24,6 +25,7 @@ class MockTransport(AsyncBaseTransport, BaseTransport):
         response = self.handler(request)
         if not isinstance(response, Response):  # pragma: no cover
             raise TypeError("Cannot use an async handler in a sync Client")
+        response.elapsed = datetime.timedelta()
         return response
 
     async def handle_async_request(
@@ -40,4 +42,5 @@ class MockTransport(AsyncBaseTransport, BaseTransport):
         if not isinstance(response, Response):
             response = await response
 
+        response.elapsed = datetime.timedelta()
         return response

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -467,6 +467,7 @@ def test_mock_transport_elapsed():
 
     Regression test for https://github.com/encode/httpx/issues/3712
     """
+
     def handler(request):
         return httpx.Response(200, json={"text": "Hello, world!"})
 
@@ -486,6 +487,7 @@ async def test_async_mock_transport_elapsed():
 
     Regression test for https://github.com/encode/httpx/issues/3712
     """
+
     def handler(request):
         return httpx.Response(200, json={"text": "Hello, world!"})
 

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -460,3 +460,40 @@ def test_client_decode_text_using_explicit_encoding():
         assert response.reason_phrase == "OK"
         assert response.encoding == "ISO-8859-1"
         assert response.text == text
+
+
+def test_mock_transport_elapsed():
+    """Test that MockTransport sets the elapsed property.
+
+    Regression test for https://github.com/encode/httpx/issues/3712
+    """
+    def handler(request):
+        return httpx.Response(200, json={"text": "Hello, world!"})
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport) as client:
+        response = client.get("http://www.example.com")
+        assert response.status_code == 200
+        # MockTransport should set elapsed to timedelta(0)
+        assert response.elapsed == timedelta(0)
+        # Accessing elapsed should not raise RuntimeError
+        assert isinstance(response.elapsed, timedelta)
+
+
+@pytest.mark.anyio
+async def test_async_mock_transport_elapsed():
+    """Test that MockTransport sets the elapsed property for async requests.
+
+    Regression test for https://github.com/encode/httpx/issues/3712
+    """
+    def handler(request):
+        return httpx.Response(200, json={"text": "Hello, world!"})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        response = await client.get("http://www.example.com")
+        assert response.status_code == 200
+        # MockTransport should set elapsed to timedelta(0)
+        assert response.elapsed == timedelta(0)
+        # Accessing elapsed should not raise RuntimeError
+        assert isinstance(response.elapsed, timedelta)


### PR DESCRIPTION
## Summary
Fixes MockTransport to automatically set `response.elapsed` to `timedelta(0)` for both sync and async requests, eliminating boilerplate and matching real transport behavior.

## Problem
Previously, accessing `response.elapsed` on MockTransport responses would raise `RuntimeError`:
```python
RuntimeError: '.elapsed' may only be accessed after the response has been read or closed.
```

Users had to add boilerplate in every handler:
```python
def handler(request):
    resp = httpx.Response(200, json={"text": "Hello, world!"})
    resp.elapsed = timedelta(0)  # Boilerplate needed
    return resp
```

## Solution
MockTransport now automatically sets `response.elapsed = timedelta(0)` after calling the handler, in both `handle_request()` and `handle_async_request()`.

## Test Plan
**Before fix:**
```python
def handler(request):
    return httpx.Response(200, json={"text": "Hello, world!"})

transport = httpx.MockTransport(handler)
client = httpx.Client(transport=transport)
response = client.get("https://example.com")
print(response.elapsed)  # RuntimeError
```

**After fix:**
```python
def handler(request):
    return httpx.Response(200, json={"text": "Hello, world!"})

transport = httpx.MockTransport(handler)
client = httpx.Client(transport=transport)
response = client.get("https://example.com")
print(response.elapsed)  # 0:00:00 ✓
```

**Tests:**
- Added `test_mock_transport_elapsed()` for sync clients
- Added `test_async_mock_transport_elapsed()` for async clients
- Both tests verify `elapsed == timedelta(0)` and type correctness

## Related
Fixes #3712