### PR TITLE
Fix: Prevent query parameter corruption in base_url

### DIFF
--- a/httpx/_client.py
+++ b/httpx/_client.py
@@ -232,9 +232,19 @@ class BaseClient:
         return self._trust_env
 
     def _enforce_trailing_slash(self, url: URL) -> URL:
-        if url.raw_path.endswith(b"/"):
-            return url
-        return url.copy_with(raw_path=url.raw_path + b"/")
+        # Split raw_path into path and query to avoid corrupting query parameters
+        raw_path = url.raw_path
+        if b"?" in raw_path:
+            # URL has query parameters - only check/add slash to path portion
+            path, query = raw_path.split(b"?", 1)
+            if path.endswith(b"/"):
+                return url
+            return url.copy_with(raw_path=path + b"/?" + query)
+        else:
+            # No query parameters - check/add slash to entire raw_path
+            if raw_path.endswith(b"/"):
+                return url
+            return url.copy_with(raw_path=raw_path + b"/")
 
     def _get_proxy_map(
         self, proxy: ProxyTypes | None, allow_env_proxies: bool

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -460,3 +460,36 @@ def test_client_decode_text_using_explicit_encoding():
         assert response.reason_phrase == "OK"
         assert response.encoding == "ISO-8859-1"
         assert response.text == text
+
+
+def test_base_url_with_query_params():
+    """
+    Test that base_url with query parameters doesn't corrupt the query values.
+
+    Regression test for issue #3614.
+    """
+    client = httpx.Client(base_url="https://example.com/api?data=1")
+
+    # Query parameter should not be corrupted with trailing slash
+    assert client.base_url.query == b"data=1"
+    assert str(client.base_url) == "https://example.com/api/?data=1"
+
+
+def test_base_url_with_trailing_slash_and_query():
+    """
+    Test that base_url with existing trailing slash and query params works correctly.
+    """
+    client = httpx.Client(base_url="https://example.com/api/?key=value")
+
+    assert client.base_url.query == b"key=value"
+    assert str(client.base_url) == "https://example.com/api/?key=value"
+
+
+def test_base_url_with_multiple_query_params():
+    """
+    Test that base_url with multiple query parameters works correctly.
+    """
+    client = httpx.Client(base_url="https://example.com/api?a=1&b=2&c=3")
+
+    assert client.base_url.query == b"a=1&b=2&c=3"
+    assert str(client.base_url) == "https://example.com/api/?a=1&b=2&c=3"


### PR DESCRIPTION
## Summary

Fixes #3614

When a `base_url` contains query parameters, the trailing slash enforcement was corrupting the query parameter values by appending the slash to the query string instead of just the path.

## Problem

```python
client = httpx.Client(base_url="https://api.com/get?data=1")
print(client.base_url.query)  
# Before: b'data=1/' ❌ (corrupted!)
# After:  b'data=1'  ✅ (correct)
```

The `_enforce_trailing_slash()` method was appending `/` to the entire `raw_path`, which includes both the path and query string. For a URL like `/get?data=1`, this became `/get?data=1/`, corrupting the query parameter value.

## Solution

Modified `_enforce_trailing_slash()` in `_client.py` to:
1. Split `raw_path` into path and query components (using `?` as delimiter)
2. Add trailing slash only to the path portion
3. Recombine path and query

## Examples

**base_url with query parameters:**
```python
client = httpx.Client(base_url="https://api.com/get?data=1")
# Before: https://api.com/get?data=1/  (corrupted)
# After:  https://api.com/get/?data=1  (correct)
```

**base_url with trailing slash and query:**
```python
client = httpx.Client(base_url="https://api.com/get/?key=value")
# Result: https://api.com/get/?key=value  (no double slash)
```

**base_url without query (unchanged behavior):**
```python
client = httpx.Client(base_url="https://api.com/get")
# Result: https://api.com/get/  (trailing slash added as before)
```

## Testing
- ✅ Manual testing with various base_url configurations
- ✅ Added regression tests in `tests/client/test_client.py`
- ✅ Verified backward compatibility with existing behavior