### PR TITLE
Merge params with existing URL query parameters instead of replacing

### DIFF
--- a/httpx/_models.py
+++ b/httpx/_models.py
@@ -396,7 +396,7 @@ class Request:
         extensions: RequestExtensions | None = None,
     ) -> None:
         self.method = method.upper()
-        self.url = URL(url) if params is None else URL(url, params=params)
+        self.url = URL(url) if params is None else URL(url).copy_merge_params(params)
         self.headers = Headers(headers)
         self.extensions = {} if extensions is None else dict(extensions)
 

--- a/tests/models/test_requests.py
+++ b/tests/models/test_requests.py
@@ -232,10 +232,18 @@ def test_request_params():
     request = httpx.Request("GET", "http://example.com", params={})
     assert str(request.url) == "http://example.com"
 
+    # Params are merged with existing URL query parameters, not replaced.
     request = httpx.Request(
         "GET", "http://example.com?c=3", params={"a": "1", "b": "2"}
     )
-    assert str(request.url) == "http://example.com?a=1&b=2"
+    assert str(request.url) == "http://example.com?c=3&a=1&b=2"
 
+    # Empty params preserves existing URL query parameters.
     request = httpx.Request("GET", "http://example.com?a=1", params={})
-    assert str(request.url) == "http://example.com"
+    assert str(request.url) == "http://example.com?a=1"
+
+    # Params with overlapping keys override existing URL query parameters.
+    request = httpx.Request(
+        "GET", "http://example.com?a=1&b=2", params={"b": "3", "c": "4"}
+    )
+    assert str(request.url) == "http://example.com?a=1&b=3&c=4"


### PR DESCRIPTION
## Summary

- Fixes #3621: When a URL already contains query parameters (e.g. `https://example.com/path?page=1&s=list`) and the `params` argument is also provided, the existing query parameters were silently dropped and replaced by only the new `params`. This was inconsistent with the `requests` library and surprised users.
- Changed `Request.__init__` to use `URL(url).copy_merge_params(params)` instead of `URL(url, params=params)`, so existing URL query parameters are preserved and merged with the new ones.
- Updated `test_request_params` to reflect the new merge behavior and added an additional test case for overlapping keys.

### Before (broken)
```python
request = httpx.Request("GET", "https://example.com?page=1&s=list", params={"pid": 0})
print(request.url)
# https://example.com?pid=0   <-- page and s are lost!
```

### After (fixed)
```python
request = httpx.Request("GET", "https://example.com?page=1&s=list", params={"pid": 0})
print(request.url)
# https://example.com?page=1&s=list&pid=0   <-- all params preserved
```

## Test plan

- [x] Existing `test_request_params` updated and passes
- [x] New test case for overlapping parameter keys added
- [x] All 173 model and client tests pass
- [x] Verified the exact reproduction case from the issue works correctly