### PR TITLE
Percent-encode pipe character in URL paths

### DIFF
--- a/httpx/_urlparse.py
+++ b/httpx/_urlparse.py
@@ -51,12 +51,15 @@ QUERY_SAFE = "".join(
 )
 
 # The path percent-encode set is the query percent-encode set
-# and U+003F (?), U+0060 (`), U+007B ({), and U+007D (}).
+# and U+003F (?), U+0060 (`), U+007B ({), U+007C (|), and U+007D (}).
+# We include U+007C (|) in the encode set to align with RFC 3986 and
+# Python's stdlib, since | is not a valid pchar and can cause servers
+# to issue redirects or reject requests when left unencoded.
 PATH_SAFE = "".join(
     [
         chr(i)
         for i in range(0x20, 0x7F)
-        if i not in (0x20, 0x22, 0x23, 0x3C, 0x3E) + (0x3F, 0x60, 0x7B, 0x7D)
+        if i not in (0x20, 0x22, 0x23, 0x3C, 0x3E) + (0x3F, 0x60, 0x7B, 0x7C, 0x7D)
     ]
 )
 

--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -140,6 +140,13 @@ def test_path_query_fragment(url, raw_path, path, query, fragment):
     assert url.fragment == fragment
 
 
+def test_url_pipe_encoding_in_path():
+    # The pipe character should be percent-encoded in paths per RFC 3986.
+    url = httpx.URL("https://example.com/path|segment")
+    assert url.raw_path == b"/path%7Csegment"
+    assert url.path == "/path|segment"
+
+
 def test_url_query_encoding():
     url = httpx.URL("https://www.example.com/?a=b c&d=e/f")
     assert url.raw_path == b"/?a=b%20c&d=e/f"

--- a/tests/models/test_whatwg.py
+++ b/tests/models/test_whatwg.py
@@ -27,6 +27,12 @@ def test_urlparse(test_case):
         # Anyone know what's going on here?
         return
 
+    # We percent-encode "|" in paths (unlike WHATWG), to align with RFC 3986
+    # and Python's stdlib. The pipe character is not a valid pchar and some
+    # servers reject or redirect URLs containing an unencoded "|".
+    if "|" in test_case.get("pathname", ""):
+        return
+
     p = urlparse(test_case["href"])
 
     # Test cases include the protocol with the trailing ":"


### PR DESCRIPTION
Fixes #3565.

The `|` character wasn't being percent-encoded in path segments, even though it's not a valid `pchar` per RFC 3986. Some servers reject or redirect URLs that contain an unencoded pipe — which is what the original reporter ran into (getting a 301 redirect when switching from `requests` to `httpx`).

This removes `|` (U+007C) from the `PATH_SAFE` set so it gets encoded as `%7C`, matching the behavior of Python's `urllib.parse.quote` and the `requests` library.

The WHATWG URL spec technically allows `|` unencoded in paths, so I've skipped the 3 WHATWG conformance test cases that expect an unencoded pipe in the pathname. Added a regression test covering both `raw_path` and `path` properties.