### PR TITLE
Fix `unquote` IndexError on empty string input

### DIFF
--- a/httpx/_utils.py
+++ b/httpx/_utils.py
@@ -89,7 +89,9 @@ def to_bytes_or_str(value: str, match_type_of: typing.AnyStr) -> typing.AnyStr:
 
 
 def unquote(value: str) -> str:
-    return value[1:-1] if value[0] == value[-1] == '"' else value
+    if len(value) >= 2 and value[0] == value[-1] == '"':
+        return value[1:-1]
+    return value
 
 
 def peek_filelike_length(stream: typing.Any) -> int | None:


### PR DESCRIPTION
`unquote('')` in `_utils.py` raises `IndexError` because it accesses `value[0]` without checking string length first.

This can occur when parsing digest auth `WWW-Authenticate` headers containing parameters with empty unquoted values (e.g. `realm=` instead of `realm=""`).