### PR TITLE
Adapt test_response_decode_text_using_autodetect for chardet 6.0

### DIFF
--- a/tests/models/test_responses.py
+++ b/tests/models/test_responses.py
@@ -1011,7 +1011,10 @@ def test_response_decode_text_using_autodetect():
 
     assert response.status_code == 200
     assert response.reason_phrase == "OK"
-    assert response.encoding == "ISO-8859-1"
+    # The encoded byte string is consistent with either ISO-8859-1 or
+    # WINDOWS-1252. Versions <6.0 of chardet claim the former, while chardet
+    # 6.0 detects the latter.
+    assert response.encoding in ("ISO-8859-1", "WINDOWS-1252")
     assert response.text == text
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

See https://github.com/encode/httpx/discussions/3772. Version 6.0.0 of `chardet` detects this byte string as `WINDOWS-1252`, while previous versions detected `ISO-8859-1`. Since both are plausible (the encoded byte string decodes to the same Unicode string under either encoding), this PR adjusts the test to accept either claim.
<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change. **No new test required, as this fixes a test regression.**
- [x] I've updated the documentation accordingly. **No documentation changes required.**
