### PR TITLE
Quiesce warnings from `grep` in sync-version

### DIFF
--- a/scripts/sync-version
+++ b/scripts/sync-version
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-SEMVER_REGEX="([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?"
+SEMVER_REGEX="([0-9]+)\.([0-9]+)\.([0-9]+)(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\+[0-9A-Za-z-]+)?"
 CHANGELOG_VERSION=$(grep -o -E $SEMVER_REGEX CHANGELOG.md | sed -n 2p)
 VERSION=$(grep -o -E $SEMVER_REGEX httpx/__version__.py | head -1)
 echo "CHANGELOG_VERSION: $CHANGELOG_VERSION"


### PR DESCRIPTION
# Summary

`(?:...)` non-capturing groups are a PCRE thing, not a grep ERE thing.

As we can see in e.g. GitHub Actions runs, `sync-version` as of current main throws six (count 'em!) warnings when run. (Looks like [this warning was added into GNU tools some 4 years ago.](https://github.com/coreutils/gnulib/commit/88d3598a277061b855c778103c1f5a114ea0afd7))

```
Run scripts/check
+ ./scripts/sync-version
grep: warning: ? at start of expression
grep: warning: ? at start of expression
grep: warning: ? at start of expression
grep: warning: ? at start of expression
grep: warning: ? at start of expression
grep: warning: ? at start of expression
CHANGELOG_VERSION: 0.28.1
VERSION: 0.28.1
```

This removes the `?:`, so no more warnings, still the same grep power.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
  - No tests required.
- [ ] I've updated the documentation accordingly.
  - No documentation updates required.