### PR TITLE
Add real async iterator for ByteStreams

### DIFF
--- a/httpx/_content.py
+++ b/httpx/_content.py
@@ -35,8 +35,25 @@ class ByteStream(AsyncByteStream, SyncByteStream):
     def __iter__(self) -> Iterator[bytes]:
         yield self._stream
 
-    async def __aiter__(self) -> AsyncIterator[bytes]:
-        yield self._stream
+    def __aiter__(self) -> AsyncIterator[bytes]:
+        return _ByteStreamAsyncIterator(self._stream)
+
+
+class _ByteStreamAsyncIterator:
+    __slots__ = ("_stream",)
+
+    def __init__(self, stream: bytes) -> None:
+        self._stream: bytes | None = stream
+
+    def __aiter__(self) -> _ByteStreamAsyncIterator:
+        return self
+
+    async def __anext__(self) -> bytes:
+        stream = self._stream
+        if stream is None:
+            raise StopAsyncIteration
+        self._stream = None  # Consumed.
+        return stream
 
 
 class IteratorByteStream(SyncByteStream):

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -32,6 +32,10 @@ async def test_bytes_content():
     sync_content = b"".join(list(request.stream))
     async_content = b"".join([part async for part in request.stream])
 
+    # The async iterator returned by __aiter__ is itself an async iterator.
+    async_iterator = request.stream.__aiter__()
+    assert async_iterator.__aiter__() is async_iterator
+
     assert request.headers == {"Host": "www.example.com", "Content-Length": "13"}
     assert sync_content == b"Hello, world!"
     assert async_content == b"Hello, world!"


### PR DESCRIPTION
# Summary

Previously, `__aiter__` was implemented as a generator function, and as such could get garbage collected when not completely exhausted in a way that has (recent versions of) `trio` complaining:

```
$ uv pip list | grep io
[... snip ...]
Package                    Version
anyio                      4.12.1
trio                       0.31.0
[... snip ...]
$ uv run pytest tests/ -k test_write_timeout[trio]
[... snip ...]
E ResourceWarning: Async generator 'httpx._content.ByteStream.__aiter__' was garbage collected before it had been exhausted. Surround its use in 'async with aclosing(...):' to ensure that it gets cleaned up as soon as you're done using it.

The above exception was the direct cause of the following exception:

E pytest.PytestUnraisableExceptionWarning: Exception ignored in: <async_generator object ByteStream.__aiter__ at 0x1075593c0>
[... snip ...]
```

Using a real, if trivial, object to do this causes less complaints.

Fixes #3686
Closes #3700 (fix for the same issue)

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
  - Retained pristine test coverage to check that the iterator does indeed adhere to the iterator protocol by returning itself when iterated upon. 
- [ ] I've updated the documentation accordingly.
  - No documentation changes required.